### PR TITLE
refactor: Promise を Observable に変更

### DIFF
--- a/packages/web-serial-rxjs/src/client/create-serial-client.ts
+++ b/packages/web-serial-rxjs/src/client/create-serial-client.ts
@@ -8,28 +8,28 @@ import { SerialClientImpl } from './serial-client-impl';
 export interface SerialClient {
   /**
    * Request a serial port from the user
-   * @returns Promise that resolves to the selected SerialPort
+   * @returns Observable that emits the selected SerialPort
    */
-  requestPort(): Promise<SerialPort>;
+  requestPort(): Observable<SerialPort>;
 
   /**
    * Get available serial ports
-   * @returns Promise that resolves to an array of available SerialPorts
+   * @returns Observable that emits an array of available SerialPorts
    */
-  getPorts(): Promise<SerialPort[]>;
+  getPorts(): Observable<SerialPort[]>;
 
   /**
    * Connect to a serial port
    * @param port Optional SerialPort to connect to. If not provided, will request one.
-   * @returns Promise that resolves when the port is opened
+   * @returns Observable that completes when the port is opened
    */
-  connect(port?: SerialPort): Promise<void>;
+  connect(port?: SerialPort): Observable<void>;
 
   /**
    * Disconnect from the serial port
-   * @returns Promise that resolves when the port is closed
+   * @returns Observable that completes when the port is closed
    */
-  disconnect(): Promise<void>;
+  disconnect(): Observable<void>;
 
   /**
    * Get an Observable that emits data read from the serial port
@@ -47,9 +47,9 @@ export interface SerialClient {
   /**
    * Write a single chunk of data to the serial port
    * @param data Data to write
-   * @returns Promise that resolves when the data is written
+   * @returns Observable that completes when the data is written
    */
-  write(data: Uint8Array): Promise<void>;
+  write(data: Uint8Array): Observable<void>;
 
   /**
    * Check if the port is currently open


### PR DESCRIPTION
## 概要

SerialClient インターフェースとその実装クラスにおいて、Promise を返すメソッドを Observable に変更しました。

## 変更内容

以下の5つのメソッドの戻り値の型を Promise から Observable に変更:

- `requestPort()`: `Promise<SerialPort>` → `Observable<SerialPort>`
- `getPorts()`: `Promise<SerialPort[]>` → `Observable<SerialPort[]>`
- `connect()`: `Promise<void>` → `Observable<void>`
- `disconnect()`: `Promise<void>` → `Observable<void>`
- `write()`: `Promise<void>` → `Observable<void>`

## 実装詳細

- RxJS の `defer()` を使用して Promise を Observable に変換
- `connect()` メソッド内で `requestPort()` を Observable チェーンで呼び出すように変更（`switchMap` を使用）
- すべてのメソッドが RxJS の Observable ベースの API に統一

## 影響

- **破壊的変更**: 既存の API を変更するため、破壊的変更となります
- ライブラリ全体が RxJS の Observable ベースの API となり、`pipe()` や `map()` などのオペレーターを直接使用できるようになりました

## テスト結果

- ✅ `npx nx build web-serial-rxjs`: 成功
- ✅ `npx nx lint web-serial-rxjs`: 成功（エラー0、警告は既存のもののみ）
- ✅ `npx nx test web-serial-rxjs`: 成功（84テストすべてパス）