### PR TITLE
fix(github-actions): fix deploy-docs workflow and update Node.js to v22

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/svelte": "^5.2.10",
     "@testing-library/user-event": "^14.6.1",
-    "@types/node": "20.19.9",
+    "@types/node": "22.19.3",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/w3c-web-serial": "^1.0.8",


### PR DESCRIPTION
## 概要

GitHub Actionsのdeploy-docsワークフローで発生していた依存関係インストールエラーを修正し、Node.jsのバージョンをv22.xに更新しました。

## 変更内容

### ワークフローの修正

- Node.jsのセットアップをpnpmの前に移動
- pnpmキャッシュの明示的な設定を追加
- setup-nodeアクションからcacheオプションを削除（競合回避）

### Node.jsバージョンの更新

- `@types/node`を20.19.9から22.19.3に更新
- GitHub Actionsワークフローの`node-version`を18から22に更新

## 関連Issue

[Issue #18](https://github.com/gurezo/web-serial-rxjs/issues/18) の対応の一部として、ドキュメントデプロイワークフローの修正を行いました。

## テスト

- [ ] GitHub Actionsでワークフローが正常に実行されることを確認
