### PR TITLE
fix: update pnpm version to 9 in GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
 
       - name: Get pnpm store directory
         shell: bash


### PR DESCRIPTION

## 原因
`pnpm-lock.yaml`の`lockfileVersion`が`9.0`なのに、ワークフローでpnpm 8を指定していたため、互換性がありませんでした。

## 修正内容
- GitHub Actionsワークフローでpnpmのバージョンを8から9に更新

これにより、`lockfileVersion: '9.0'`の`pnpm-lock.yaml`と互換性が保たれます。

## 関連
- https://github.com/gurezo/web-serial-rxjs/actions/runs/20487413674/job/58872544037