### PR TITLE
feat: update version to 0.1.0

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

ライブラリのバージョンを `0.0.1` から `0.1.0` に更新しました。Issue #53 の提案に基づき、初回リリースとして適切なバージョン番号に変更しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #53

## What changed?

- `packages/web-serial-rxjs/package.json` の `version` フィールドを `0.0.1` から `0.1.0` に更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `packages/web-serial-rxjs/package.json` を確認し、`version` が `0.1.0` になっていることを確認
2. ビルドが正常に完了することを確認（`pnpm build`）
3. パッケージのバージョンが正しく反映されていることを確認

## Environment (if relevant)

- Browser: N/A (バージョン変更のみ)
- OS: N/A
- web-serial-rxjs version (for verification): 0.1.0
- RxJS version: N/A

## Checklist

- [x] I ran tests locally (if available)
- [x] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)
