### PR TITLE
chore(web-serial-rxjs): add npm publish configuration

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,7 +1,9 @@
 {
   "name": "@gurezo/web-serial-rxjs",
   "version": "0.1.0",
-  "private": true,
+  "description": "A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.",
+  "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
+  "license": "MIT",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
@@ -24,5 +26,26 @@
   "dependencies": {},
   "peerDependencies": {
     "rxjs": "^7.8.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gurezo/web-serial-rxjs.git"
+  },
+  "bugs": {
+    "url": "https://github.com/gurezo/web-serial-rxjs/issues"
+  },
+  "homepage": "https://github.com/gurezo/web-serial-rxjs#readme",
+  "keywords": [
+    "rxjs",
+    "serial",
+    "web-serial",
+    "serial-port",
+    "reactive",
+    "observable",
+    "typescript",
+    "web-serial-api"
+  ],
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
## Summary

Add npm package publication configuration to enable publishing `@gurezo/web-serial-rxjs` to npm registry. 
This includes removing the private flag, adding publishConfig, and adding required metadata fields (description, license, repository, bugs, homepage, keywords, author).

npm パッケージ公開を可能にするため、`@gurezo/web-serial-rxjs` の package.json に公開設定を追加しました。
private フラグの削除、publishConfig の追加、および必要なメタデータフィールド（description、license、repository、bugs、homepage、keywords、author）を追加しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #62

## What changed?

- Remove `private: true` flag to enable package publishing
- Add `publishConfig.access: "public"` for scoped package publication
- Add `description` field with package description
- Add `license: "MIT"` field
- Add `author` field with maintainer information
- Add `repository` field pointing to GitHub repository
- Add `bugs` field pointing to GitHub issues page
- Add `homepage` field pointing to GitHub README
- Add `keywords` array with relevant package keywords (rxjs, serial, web-serial, serial-port, reactive, observable, typescript, web-serial-api)

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. Verify `package.json` contains all required fields for npm publishing
2. Run `npm pack` or `pnpm pack` in `packages/web-serial-rxjs` directory to verify package contents
3. Confirm that `publishConfig.access` is set to `"public"`
4. Verify that `private` field is removed (or not present)

## Environment (if relevant)

- Browser: N/A (package configuration only)
- OS: N/A
- web-serial-rxjs version (for verification): 0.1.0
- RxJS version: N/A

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) - N/A (no code changes)
- [ ] I updated docs/README if needed - N/A (package.json metadata only)
- [ ] I added/updated types and kept exports consistent - N/A (no code changes)
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A (no code changes)
