### PR TITLE
chore: add publish script for @gurezo/web-serial-rxjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "docs:generate": "typedoc --options packages/web-serial-rxjs/typedoc.json",
     "docs:clean": "rm -rf docs",
     "docs": "pnpm run docs:clean && pnpm run docs:generate",
-    "publish:test": "pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs"
+    "publish:test": "pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs",
+    "publish": "pnpm publish --filter @gurezo/web-serial-rxjs"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
package.jsonに`publish`スクリプトを追加して、`@gurezo/web-serial-rxjs`パッケージをnpmに公開できるようにしました。GitHub Actionsワークフローでの自動公開の準備として実施します。

## Type of change
- [x] Chore (build/test/ci)

## Related issues
- Related to #64

## What changed?
- ルートの`package.json`に`publish`スクリプトを追加
  - `pnpm publish --filter @gurezo/web-serial-rxjs` を実行するスクリプト

## API / Compatibility
- [x] This change is backward compatible
- [ ] Public API changes (export / function signature / behavior)
- [ ] This change introduces a breaking change

## How to test
1. `pnpm run publish:test` を実行して、公開前のテストを確認
2. 実際の公開は後続のPRでGitHub Actionsワークフロー実装後に実施予定

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) - N/A (スクリプト追加のみ)
- [ ] I updated docs/README if needed - N/A
- [ ] I added/updated types and kept exports consistent - N/A
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A