### PR TITLE
ci(workspace): add GitHub Release auto-generation on npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -71,3 +73,12 @@ jobs:
         run: pnpm publish --filter @gurezo/web-serial-rxjs --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ steps.tag-version.outputs.VERSION }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
npm公開時にGitHub Releaseとリリースノートを自動生成する機能を追加しました。タグをプッシュしてnpm公開が完了した後、自動的にGitHub Releaseが作成されるようになります。

## Type of change
- [x] Chore (build/test/ci)

## Related issues
- Fixes #66

## What changed?
- `.github/workflows/release.yml`に`permissions`セクションを追加し、`contents: write`権限を付与
- npm公開後にGitHub Releaseを作成するステップを追加
- `softprops/action-gh-release@v1`アクションを使用してリリースを作成
- `generate_release_notes: true`オプションを設定してリリースノートの自動生成を有効化

## API / Compatibility
- [x] This change is backward compatible
- [ ] Public API changes (export / function signature / behavior)
- [ ] This change introduces a breaking change

## How to test
1. 新しいタグ（例: `v1.0.1`）を作成してプッシュ
2. GitHub Actionsのワークフローが正常に実行されることを確認
3. npmへの公開が成功することを確認
4. GitHub Releasesページで新しいリリースが作成され、リリースノートが自動生成されることを確認

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) - N/A
- [ ] I updated docs/README if needed - N/A
- [ ] I added/updated types and kept exports consistent - N/A
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A