### PR TITLE
chore: bump version to 0.1.2 for release notes CI test

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
リリースノート作成CIの動作確認のため、バージョンを0.1.1から0.1.2に更新しました。

## Type of change
- [x] Chore (build/test/ci)

## Related issues
- Fixes #81

## What changed?
- packages/web-serial-rxjs/package.jsonのバージョンを0.1.1から0.1.2に更新

## API / Compatibility
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. このPRをマージ後、v0.1.2タグを作成してプッシュ
2. GitHub Actionsのリリースワークフローが実行されることを確認
3. リリースノートが自動生成されることを確認

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)