### PR TITLE
fix: continue release workflow even if npm publish fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,7 @@ jobs:
         run: pnpm publish --filter @gurezo/web-serial-rxjs --access public --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        continue-on-error: true
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
npm公開が失敗してもリリースノート生成のテストを継続できるように、npm公開ステップにcontinue-on-errorを追加しました。

## Type of change
- [x] Bug fix

## Related issues
- Related to #81
- Fixes #84 

## What changed?
- .github/workflows/release.ymlのnpm公開ステップにcontinue-on-error: trueを追加

## API / Compatibility
- [x] This change is backward compatible

## How to test
1. このPRをマージ後、修正されたワークフローで再度タグをプッシュ
2. npm公開が失敗してもリリースノートが生成されることを確認

## Checklist
- [x] I ran tests locally (if available)
- [x] I added/updated types and kept exports consistent