### PR TITLE
fix: ensure release creation runs even if npm publish fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,15 @@ jobs:
           echo "Version validation passed"
 
       - name: Publish to npm
-        run: pnpm publish --filter @gurezo/web-serial-rxjs --access public --no-git-checks
+        id: publish-npm
+        continue-on-error: true
+        run: |
+          pnpm publish --filter @gurezo/web-serial-rxjs --access public --no-git-checks || echo "::warning::npm publish failed, but continuing with release creation"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        continue-on-error: true
 
       - name: Create GitHub Release
+        if: always()
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Summary
npm公開が失敗してもリリース作成ステップが確実に実行されるように、ワークフローを修正しました。

## Type of change
- [x] Bug fix

## Related issues
- Related to #81

## What changed?
- npm公開ステップに `continue-on-error: true` と警告メッセージを追加
- リリース作成ステップに `if: always()` を追加して、npm公開が失敗しても確実に実行されるように修正

## API / Compatibility
- [x] This change is backward compatible

## How to test
1. このPRをマージ後、タグを作成してプッシュ
2. npm公開が失敗してもリリース作成ステップが実行されることを確認
3. リリースノートが自動生成されることを確認