### PR TITLE
fix(workspace): configure npm authentication token for setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
CIのnpmパブリッシュ時にOTPエラーが発生していた問題を修正しました。setup-nodeアクションにNODE_AUTH_TOKEN環境変数を追加し、npm認証トークンが適切に設定されるようにしました。

Fixed npm publish OTP error in CI by adding NODE_AUTH_TOKEN environment variable to setup-node action, ensuring npm authentication token is properly configured.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes the error from: https://github.com/gurezo/web-serial-rxjs/actions/runs/20873501506/job/59979270814
- Fixes #84 

## What changed?
- Added NODE_AUTH_TOKEN environment variable to setup-node action in release.yml workflow
- This ensures the npm authentication token is properly configured in .npmrc for pnpm publish command

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. Tag a new release (e.g., v0.1.3)
2. Verify the release workflow runs successfully
3. Confirm npm publish completes without OTP error
4. Check that the package is published to npm registry

## Environment (if relevant)
- CI/CD: GitHub Actions
- npm registry: registry.npmjs.org

## Checklist
- [ ] I ran tests locally (if available)
- [x] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)