### PR TITLE
fix(workspace): update release workflow for pnpm 10 and npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,22 +10,23 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write  # ★ Trusted Publishing(OIDC)に必須
+      id-token: write   # ★ OIDC必須
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
+        # ★ env: NODE_AUTH_TOKEN は不要なので削除
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
 
       - name: Get pnpm store directory
         shell: bash
@@ -71,21 +72,16 @@ jobs:
           fi
           echo "Version validation passed"
 
-      # ★★★ ここが肝：Trusted Publishing(OIDC)で publish（トークン不要）
-      - name: Publish to npm (Trusted Publishing / OIDC)
+      # ★★★ ここが肝：pnpm publish をやめて npm publish にする（OIDC）
+      - name: Publish to npm (OIDC Trusted Publishing)
         id: publish-npm
         continue-on-error: true
         shell: bash
         run: |
-          # Nx の出力先に合わせて調整してください
-          PKG_DIR="dist/packages/web-serial-rxjs"
-
-          if [ ! -f "$PKG_DIR/package.json" ]; then
-            echo "::error::package.json not found in $PKG_DIR. Please confirm Nx output path."
-            exit 1
-          fi
-
-          npm publish "$PKG_DIR" --access public || echo "::warning::npm publish failed, but continuing with release creation"
+          # workspace の package を publish
+          # ここは packages/web-serial-rxjs のままでOK（ログを見る限りこの構造）
+          npm publish ./packages/web-serial-rxjs --access public --provenance || \
+            echo "::warning::npm publish failed, but continuing with release creation"
 
       - name: Create GitHub Release
         if: always()


### PR DESCRIPTION
## Summary
リリースワークフローをpnpm 10に対応し、npm publishの設定を改善しました。OIDC Trusted Publishingを使用してより安全にパッケージを公開できるように変更しました。

Release workflow updated for pnpm 10 compatibility and improved npm publish configuration. Changes enable safer package publishing using OIDC Trusted Publishing.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #84

## What changed?
- Update pnpm version from 9 to 10
- Reorder setup steps (Node.js setup before pnpm setup for better compatibility)
- Change npm publish path from `dist/packages/web-serial-rxjs` to `./packages/web-serial-rxjs`
- Add `--provenance` flag for OIDC Trusted Publishing support
- Update comments for clarity

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. タグをプッシュしてリリースワークフローが実行されることを確認
2. npmへの公開が正常に完了することを確認
3. OIDC Trusted Publishingが機能することを確認（--provenanceフラグが付与されていること）

1. Push a tag and verify the release workflow executes
2. Confirm npm publishing completes successfully
3. Verify OIDC Trusted Publishing works (--provenance flag is applied)

## Environment (if relevant)
- Browser: N/A
- OS: GitHub Actions (ubuntu-latest)
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)