### PR TITLE
fix(workspace): add npm authentication token to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,8 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
-        # ★ env: NODE_AUTH_TOKEN は不要なので削除
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCOUNT }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary

npm publish時の認証エラーを解決するため、GitHub ActionsのreleaseワークフローにNODE_AUTH_TOKEN環境変数を追加しました。

CIでnpm publish実行時に`ENEEDAUTH`エラーが発生していたため、`setup-node@v4`アクションに認証トークンを設定する環境変数を追加しました。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #84

## What changed?

- `.github/workflows/release.yml`の`Setup Node.js`ステップに`NODE_AUTH_TOKEN`環境変数を追加
- `secrets.NPM_ACCOUNT`から認証トークンを参照するように設定

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. リリースタグ（`v*`）をプッシュしてreleaseワークフローが実行されることを確認
2. npm publishが正常に完了することを確認
3. パッケージがnpmレジストリに公開されることを確認

## Environment (if relevant)

- CI環境でのみ影響する変更のため、ローカル環境への影響はありません

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
