### PR TITLE
ci(workspace): add GitHub Release creation to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,10 @@ jobs:
 
       - name: Publish to npm (OIDC Trusted Publishing)
         run: npm publish ./packages/web-serial-rxjs --access public --provenance
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
npm公開時にGitHub Releaseとリリースノートを自動生成する機能を追加しました。PR #90でOIDC認証に戻した際に削除されていたGitHub Release作成ステップを復元します。

## Type of change
- [x] Chore (build/test/ci)

## Related issues
- Fixes #66
- Fixes #84 

## What changed?
- `.github/workflows/release.yml` にGitHub Release作成ステップを追加
- `softprops/action-gh-release@v1` アクションを使用してリリースを作成
- `generate_release_notes: true` オプションを設定してリリースノートの自動生成を有効化
- OIDC Trusted Publishingを使用したnpm公開の後に実行されるように設定

## API / Compatibility
- [x] This change is backward compatible
- [ ] Public API changes (export / function signature / behavior)
- [ ] This change introduces a breaking change

## How to test
1. 新しいタグ（例: `v0.1.3`）を作成してプッシュ
2. GitHub Actionsのワークフローが正常に実行されることを確認
3. npmへの公開が成功することを確認（OIDC Trusted Publishing）
4. GitHub Releasesページで新しいリリースが作成され、リリースノートが自動生成されることを確認

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) - N/A
- [ ] I updated docs/README if needed - N/A
- [ ] I added/updated types and kept exports consistent - N/A
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A