### PR TITLE
fix(workspace): add OIDC authentication configuration for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
           scope: '@gurezo'
+          always-auth: true
+
+      - name: Configure npm for OIDC
+        run: |
+          echo "@gurezo:registry=https://registry.npmjs.org/" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test


### PR DESCRIPTION
## Summary
日本語: npm パッケージ公開時の404エラーを解決するため、GitHub Actions の release ワークフローに OIDC 認証設定を追加しました。
English: Added OIDC authentication configuration to the release workflow to fix 404 errors when publishing npm packages.

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes the npm publish 404 error in release workflow
- Fixes #66
- Fixes #84 

## What changed?
- Added `always-auth: true` to `actions/setup-node@v4` configuration
- Added explicit `.npmrc` configuration step for OIDC Trusted Publishing
- Configured scoped registry for `@gurezo` package namespace

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. Create a new git tag (e.g., `v0.1.3`)
2. Push the tag to trigger the release workflow
3. Verify that the workflow successfully publishes to npm without 404 errors

## Environment (if relevant)
- CI/CD: GitHub Actions

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)