### PR TITLE
fix(workspace): simplify npm publish auth to use OIDC only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,17 +23,17 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org/'
-          scope: '@gurezo'
-          always-auth: true
-
-      - name: Configure npm for OIDC
-        run: |
-          echo "@gurezo:registry=https://registry.npmjs.org/" >> .npmrc
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
+
+      # 念のため：token系npmrcを消してOIDC一本化
+      - name: Force OIDC only
+        run: |
+          rm -f .npmrc
+          rm -f ~/.npmrc
+          rm -f packages/web-serial-rxjs/.npmrc
 
       - name: Publish to npm (OIDC Trusted Publishing)
         run: npm publish ./packages/web-serial-rxjs --access public --provenance


### PR DESCRIPTION
## Summary
npm公開時の認証エラー（「Access token expired or revoked」）を解決するため、GitHub Actionsワークフローを修正してOIDC Trusted Publishingのみを使用するように変更しました。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- 関連: https://github.com/gurezo/web-serial-rxjs/actions/runs/20875616394/job/59984396417

## What changed?
- `setup-node`アクションから`scope`と`always-auth`設定を削除
- 既存の`.npmrc`ファイルを削除するステップを追加して、OIDC認証のみを使用するように強制
- npm公開認証をOIDC Trusted Publishingのみに依存するようにシンプル化

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. 新しいバージョンタグ（例：`v0.1.3`）をプッシュしてリリースワークフローをトリガーする
2. npm公開ステップが認証エラーなく正常に完了することを確認する
3. provenance付きでnpmレジストリにパッケージが公開されることを確認する

## Environment (if relevant)
- Browser: N/A（CIワークフローの変更のため）
- OS: N/A（CIワークフローの変更のため）
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) - N/A（CI変更のため）
- [ ] I updated docs/README if needed - N/A
- [ ] I added/updated types and kept exports consistent - N/A
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A
