### PR TITLE
ci(workspace): enforce OIDC-only authentication for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,20 +28,41 @@ jobs:
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
 
-      # ルートnpmrcは残す。認証系だけ消す
+      # 追加①: ビルド成果物の場所を確認（dist がリポジトリ直下に無い前提）
+      - name: Show build output
+        shell: bash
+        run: |
+          echo "== packages/web-serial-rxjs =="
+          ls -la packages/web-serial-rxjs
+          echo "== packages/web-serial-rxjs/dist =="
+          ls -la packages/web-serial-rxjs/dist || true
+
+      # 既存: token系npmrcを消してOIDC一本化（※ルート .npmrc は pnpm 用なので消さない方が安全）
       - name: Force OIDC only
+        shell: bash
         run: |
           rm -f ~/.npmrc
           rm -f packages/web-serial-rxjs/.npmrc
 
-      - name: Find built package.json
+      # 追加②: どこかから注入される NODE_AUTH_TOKEN を強制無効化し、
+      # setup-node が使う NPM_CONFIG_USERCONFIG を token無しで上書き
+      - name: Force OIDC only (hard)
+        shell: bash
         run: |
-          ls -la dist || true
-          find dist -maxdepth 5 -name package.json -print -exec node -p "require('./{}').name + '@' + require('./{}').version" \;
+          echo "Before unset: NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN:+SET}"
+          unset NODE_AUTH_TOKEN
+          echo "After unset: NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN:+SET}"
 
-      # ↑の出力を見てパスを確定させる。まずは典型パスで試す
+          echo "NPM_CONFIG_USERCONFIG=${NPM_CONFIG_USERCONFIG}"
+          # setup-node が指定している npmrc を token無しで上書き
+          echo "registry=https://registry.npmjs.org/" > "${NPM_CONFIG_USERCONFIG}"
+          echo "always-auth=false" >> "${NPM_CONFIG_USERCONFIG}"
+
+          echo "== Effective npmrc =="
+          cat "${NPM_CONFIG_USERCONFIG}"
+
       - name: Publish to npm (OIDC Trusted Publishing)
-        run: npm publish dist/packages/web-serial-rxjs --access public --provenance
+        run: npm publish ./packages/web-serial-rxjs --access public --provenance
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
リリースワークフローのnpm公開時にOIDC認証のみを使用するように強制する変更を追加しました。NODE_AUTH_TOKENを無効化し、npmrcを上書きしてトークンベースの認証を排除します。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #66
- Fixes #84

## What changed?
- ビルド成果物の場所を確認するステップを追加
- NODE_AUTH_TOKENを強制的に無効化するステップを追加
- setup-nodeが使用するnpmrcをトークン無しで上書きする処理を追加
- npm publishのパスを`./packages/web-serial-rxjs`に修正

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. リリースタグをプッシュしてCIワークフローが正常に実行されることを確認
2. npm公開がOIDC認証のみで成功することを確認
3. ビルド成果物の確認ステップが正しく動作することを確認

## Environment (if relevant)
- Browser: N/A (CI workflow)
- OS: Ubuntu (GitHub Actions)
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)