### PR TITLE
ci(workspace): clear NODE_AUTH_TOKEN for OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
           echo "npm registry=$(npm config get registry)"
 
       - name: Publish to npm (OIDC Trusted Publishing)
+        env:
+          NODE_AUTH_TOKEN: ""
         run: npm publish ./packages/web-serial-rxjs --access public --provenance
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary

OIDC Trusted Publishingを使用する際に、不要な`NODE_AUTH_TOKEN`環境変数を空文字に設定して明示的に無効化するように変更しました。これにより、OIDC認証が正しく動作するようになります。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

<!--
日本語: 関連する Issue があれば記載してください
English: Link related issues (use "Fixes #123" to auto-close)
-->

- Fixes #66
- Fixes #84

## What changed?

- `.github/workflows/release.yml`の`Publish to npm (OIDC Trusted Publishing)`ステップに`NODE_AUTH_TOKEN: ""`環境変数を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. リリースワークフローが実行されることを確認
2. OIDC Trusted Publishingが正しく動作することを確認
3. npmへの公開が成功することを確認

## Environment (if relevant)

- N/A (CI workflow change)

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
