### PR TITLE
ci(workspace): migrate to npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,10 +28,8 @@ jobs:
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
 
-      - name: Publish to npm
+      - name: Publish to npm (Trusted Publishing / OIDC)
         run: npm publish ./packages/web-serial-rxjs --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
<!--
日本語: npm公開ワークフローをTrusted Publishing / OIDCに移行しました。NODE_AUTH_TOKENの環境変数を削除し、セキュリティを向上させます。
English: Migrated npm publish workflow to use Trusted Publishing / OIDC. Removed NODE_AUTH_TOKEN environment variable to improve security.
-->

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #66
- Fixes #84

## What changed?
- Updated `.github/workflows/release.yml` to use npm Trusted Publishing / OIDC
- Removed `NODE_AUTH_TOKEN` environment variable from npm publish step
- Updated step name to indicate Trusted Publishing / OIDC usage

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. Verify the GitHub Actions workflow file syntax is correct
2. Create a test tag (e.g., `v0.0.0-test`) and verify the workflow runs correctly
3. Confirm npm publish step uses `--provenance` flag without requiring `NODE_AUTH_TOKEN`

## Environment (if relevant)
- N/A (CI workflow changes only)

## Checklist
- [x] I ran tests locally (if available)
- [x] I verified behavior on a Chromium-based browser (Web Serial API) - N/A for this change
- [ ] I updated docs/README if needed - N/A
- [x] I added/updated types and kept exports consistent - N/A
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A