### PR TITLE
ci(workspace): configure npm trusted publishing with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,15 +19,25 @@ jobs:
         with:
           version: 10
 
+      # 重要：registry-url を渡さない（token用npmrcを作らせない）
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org/"
+
+      # registry は自分で設定（tokenは設定しない）
+      - name: Configure npm registry (no token)
+        shell: bash
+        run: |
+          npm config set registry "https://registry.npmjs.org/"
+          npm config get registry
+          # 念のため token が設定されていたら消す
+          npm config delete //registry.npmjs.org/:_authToken || true
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
 
+      # OIDC publish（token env は渡さない）
       - name: Publish to npm (Trusted Publishing / OIDC)
         run: npm publish ./packages/web-serial-rxjs --access public --provenance
 


### PR DESCRIPTION
## Summary
日本語: GitHub Actionsのリリースワークフローをnpm Trusted Publishing（OIDC）対応に更新しました。トークンベースの認証を廃止し、より安全で検証可能な公開方法に移行します。
English: Updated GitHub Actions release workflow to use npm Trusted Publishing (OIDC). Removed token-based authentication in favor of a more secure and verifiable publishing method.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #66
- Fixes #84

## What changed?
- `setup-node@v4`アクションから`registry-url`パラメータを削除し、トークンベースの認証を無効化
- npm registryを手動で設定するステップを追加（トークンは設定しない）
- npm公開時にOIDC（OpenID Connect）を使用するTrusted Publishingを有効化
- 変更内容を説明するコメントを追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. GitHub上でこのPRをマージする
2. 新しいGit tag（例: `v1.0.0`）を作成してプッシュする
3. GitHub Actionsのリリースワークフローが正常に実行されることを確認
4. npmパッケージが正常に公開され、provenance情報が付与されていることを確認

## Environment (if relevant)
- CI/CD: GitHub Actions
- Node.js: 22
- Package Manager: pnpm

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) - N/A (CI変更のため)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent - N/A (CI変更のため)
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A (CI変更のため)