### PR TITLE
ci(release): isolate npm config for trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,27 +19,47 @@ jobs:
         with:
           version: 10
 
-      # 重要：registry-url を渡さない（token用npmrcを作らせない）
+      # ※ registry-url は付けない（setup-node に token 用 npmrc を作らせない）
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
-
-      # registry は自分で設定（tokenは設定しない）
-      - name: Configure npm registry (no token)
-        shell: bash
-        run: |
-          npm config set registry "https://registry.npmjs.org/"
-          npm config get registry
-          # 念のため token が設定されていたら消す
-          npm config delete //registry.npmjs.org/:_authToken || true
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
 
-      # OIDC publish（token env は渡さない）
-      - name: Publish to npm (Trusted Publishing / OIDC)
-        run: npm publish ./packages/web-serial-rxjs --access public --provenance
+      # --- ここからが肝：publish 時の npm 設定を完全隔離 ---
+      - name: Publish to npm (Trusted Publishing / OIDC) - isolated config
+        shell: bash
+        env:
+          # ★どこから注入されても publish では使わせない
+          NODE_AUTH_TOKEN: ""
+          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc-ci
+          # ★HOME配下の ~/.npmrc を読ませない（探索を潰す）
+          HOME: ${{ github.workspace }}/_home_ci
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${HOME}"
+
+          # token無しの npmrc を作る（registry だけ）
+          echo "registry=https://registry.npmjs.org/" > "${NPM_CONFIG_USERCONFIG}"
+          echo "always-auth=false" >> "${NPM_CONFIG_USERCONFIG}"
+
+          echo "== DEBUG (should be token-less) =="
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL=${ACTIONS_ID_TOKEN_REQUEST_URL:+SET}"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN=${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+SET}"
+          echo "NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN:+SET}"
+          echo "npm userconfig=$(npm config get userconfig)"
+          echo "npm registry=$(npm config get registry)"
+          echo "--- npmrc-ci ---"
+          cat "${NPM_CONFIG_USERCONFIG}"
+
+          # 念のため token が紛れた設定を消す（存在しても無視されるが保険）
+          npm config delete //registry.npmjs.org/:_authToken || true
+          npm config delete _authToken || true
+
+          npm publish ./packages/web-serial-rxjs --access public --provenance
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary

<!--
日本語: npm publish 時の設定を完全に隔離し、Trusted Publishing (OIDC) のみを使用するように変更しました
English: Isolated npm configuration during publish to ensure only Trusted Publishing (OIDC) is used, preventing fallback to token-based authentication
-->

## Type of change

<!--
日本語: 該当するものにチェックを入れてください
English: Check the relevant items
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

<!--
日本語: 関連する Issue があれば記載してください
English: Link related issues (use "Fixes #123" to auto-close)
-->

- Fixes #66
- Fixes #84

## What changed?

<!--
日本語: 主な変更点を箇条書きで書いてください
English: List the main changes in bullet points
-->

- npm publish ステップで npm 設定を完全に隔離
- NODE_AUTH_TOKEN を空文字列に設定し、トークンベースの認証を無効化
- 独立した NPM_CONFIG_USERCONFIG を使用し、トークンなしの npmrc を作成
- HOME 環境変数を隔離し、~/.npmrc の読み込みを防止
- デバッグ出力を追加してトークンレス環境を検証
- セーフティネットとして、トークン関連の設定を明示的に削除

## API / Compatibility

<!--
日本語: 公開 API や互換性への影響があれば明記してください
English: Describe any impact on public APIs or compatibility
-->

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

<!--
日本語: 動作確認の手順を具体的に書いてください
English: Describe how reviewers can test this change
-->

1. リリースタグ (v\*) をプッシュしてワークフローを実行
2. ワークフローのログで「DEBUG (should be token-less)」セクションを確認
3. NODE_AUTH_TOKEN が空であることを確認
4. npmrc-ci ファイルがトークンなしで作成されていることを確認
5. npm publish が OIDC (Trusted Publishing) で正常に実行されることを確認

## Environment (if relevant)

<!--
日本語: バグ修正・挙動変更の場合は記載してください
English: Required for bug fixes or behavior changes
-->

- Browser: N/A (CI/CD workflow change)
- OS: GitHub Actions (ubuntu-latest)
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist

<!--
日本語: PR 作成前の確認事項です
English: Please confirm before submitting
-->

- [x] I ran tests locally (if available)
- [x] I verified behavior on a Chromium-based browser (Web Serial API) - N/A (CI change)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent - N/A (CI change)
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.) - N/A (CI change)
