### PR TITLE
ci: remove debug code and add zip attachment to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,19 @@ jobs:
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
 
+      # リリース添付用の zip を作る（パッケージ単位）
+      - name: Create release zip
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          ZIP_NAME="web-serial-rxjs-${VERSION}.zip"
+          cd packages/web-serial-rxjs
+          zip -r "../../${ZIP_NAME}" . \
+            -x "node_modules/*" \
+               ".git/*" \
+               ".DS_Store"
+
       # publish は token を使わず、OIDC のみで実施（設定を隔離）
       - name: Publish to npm (Trusted Publishing / OIDC)
         shell: bash
@@ -49,15 +62,8 @@ jobs:
           echo "registry=https://registry.npmjs.org/" > "${NPM_CONFIG_USERCONFIG}"
           echo "always-auth=false" >> "${NPM_CONFIG_USERCONFIG}"
 
-          echo "== DEBUG =="
-          echo "npm=$(npm -v)"
-          echo "ACTIONS_ID_TOKEN_REQUEST_URL=${ACTIONS_ID_TOKEN_REQUEST_URL:+SET}"
-          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN=${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+SET}"
-          echo "NODE_AUTH_TOKEN=${NODE_AUTH_TOKEN:+SET}"
-          echo "npm userconfig=$(npm config get userconfig)"
-          echo "npm registry=$(npm config get registry)"
-          echo "--- npmrc-ci ---"
-          cat "${NPM_CONFIG_USERCONFIG}"
+          npm config delete //registry.npmjs.org/:_authToken || true
+          npm config delete _authToken || true
 
           npm publish ./packages/web-serial-rxjs --access public --provenance
 
@@ -67,5 +73,7 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
           generate_release_notes: true
+          files: |
+            web-serial-rxjs-*.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

リリースワークフローからデバッグコードを削除し、GitHub Release に zip ファイルを添付する機能を追加しました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #105

## What changed?

- release.yml の Publish to npm ステップからデバッグ出力（52-60 行目）を削除
- リリース用 zip ファイル作成ステップを追加（ビルド後、npm 公開前に実行）
- GitHub Release 作成ステップに zip ファイル添付機能を追加
- パッケージバージョンを 0.1.3 から 0.1.4 に更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. リリースワークフローを実行（タグをプッシュ）
2. npm 公開が正常に完了することを確認（デバッグ出力なし）
3. GitHub Release に zip ファイルが添付されていることを確認

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)