### PR TITLE
chore: bump version to 0.1.6

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
バージョンを0.1.5から0.1.6に更新しました。
Updated version from 0.1.5 to 0.1.6.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #109

## What changed?
- Updated `packages/web-serial-rxjs/package.json` version from 0.1.5 to 0.1.6

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. Confirm that the version in `packages/web-serial-rxjs/package.json` is 0.1.6
2. Verify package builds successfully

## Environment (if relevant)
- Browser: N/A
- OS: N/A
- web-serial-rxjs version (for verification): 0.1.6
- RxJS version: N/A

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
