### PR TITLE
feat(web-serial-rxjs): update homepage URL to GitHub Pages

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",
@@ -39,7 +39,7 @@
   "bugs": {
     "url": "https://github.com/gurezo/web-serial-rxjs/issues"
   },
-  "homepage": "https://github.com/gurezo/web-serial-rxjs",
+  "homepage": "https://gurezo.github.io/web-serial-rxjs/",
   "keywords": [
     "rxjs",
     "serial",


### PR DESCRIPTION
## Summary
npmパッケージのホームページURLをリポジトリURLからGitHub PagesのドキュメントサイトURLに更新し、バージョンを0.1.7に上げました。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #112

## What changed?
- package.jsonのhomepageフィールドを`https://github.com/gurezo/web-serial-rxjs`から`https://gurezo.github.io/web-serial-rxjs/`に更新
- バージョンを0.1.6から0.1.7に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. package.jsonに新しいホームページURLが含まれていることを確認
2. バージョンが0.1.7に更新されていることを確認
3. ホームページURLが正しく解決されることを確認

## Environment (if relevant)
- Browser: N/A
- OS: N/A
- web-serial-rxjs version (for verification): 0.1.7
- RxJS version: N/A

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
