### PR TITLE
docs(web-serial-rxjs): add project icon to package READMEs

### DIFF
--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -1,5 +1,9 @@
 # web-serial-rxjs
 
+<p align="center">
+  <img src="../../assets/icon/web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="128" />
+</p>
+
 Web Serial API を RxJS ベースのリアクティブなラッパーで提供する TypeScript ライブラリです。Web アプリケーションでシリアルポート通信を簡単に実現できます。
 
 ## 目次

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -1,5 +1,9 @@
 # web-serial-rxjs
 
+<p align="center">
+  <img src="../../assets/icon/web-serial-rxjs-icon.png" alt="web-serial-rxjs project icon" width="128" />
+</p>
+
 A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.
 
 ## Table of Contents


### PR DESCRIPTION
## Summary
packages/web-serial-rxjs の README.md と README.ja.md にプロジェクトアイコンを追加しました。ルートの README と同様の見た目に揃えるためです。Fixes #129

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #129

## What changed?
- packages/web-serial-rxjs/README.md のタイトル直下にアイコンブロックを追加
- packages/web-serial-rxjs/README.ja.md のタイトル直下にアイコンブロックを追加（alt は日本語）

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. GitHub 上で `packages/web-serial-rxjs/README.md` を開く
2. タイトル直下にプロジェクトアイコンが表示されることを確認する
3. 同様に `packages/web-serial-rxjs/README.ja.md` を開き、アイコン表示を確認する

## Environment (if relevant)
（ドキュメントのみの変更のため不要）

## Checklist
- [x] I ran tests locally (if available)
- [x] I updated docs/README if needed
- [x] N/A for types/exports (documentation only)
- [x] N/A for error handling (documentation only)

Made with [Cursor](https://cursor.com)