### PR TITLE
chore(web-serial-rxjs): bump to v0.1.13

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
v0.1.13 リリースのため、`@gurezo/web-serial-rxjs` のパッケージバージョンを 0.1.13 に更新しました。Issue #132 の img 幅変更については、リポジトリ内に `width="128"` の記述が存在しなかったため変更は行っていません。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #134
- Fixes #132（該当箇所なしのためコード変更なし）

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `0.1.12` から `0.1.13` に変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm nx run web-serial-rxjs:build` でビルドが成功することを確認
2. `pnpm nx run-many --target=lint --all` で lint が通ることを確認
3. パッケージの `version` が 0.1.13 であることを確認

## Environment (if relevant)
- 不要（バージョン番号のみの変更）

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
