### PR TITLE
chore(web-serial-rxjs): bump version to 0.1.15

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
パッケージ `@gurezo/web-serial-rxjs` のバージョンを 0.1.14 から 0.1.15 に上げました。リリース準備のためのバージョンバンプです。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #137

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `0.1.15` に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm install` で依存をインストール
2. `pnpm run build`（または該当パッケージのビルド）でビルドが通ることを確認
3. 必要に応じて既存テストを実行

## Environment (if relevant)
- バージョンバンプのみのため特になし

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)
