### PR TITLE
fix(web-serial-rxjs): use absolute URL for README icon so it displays on npm

### DIFF
--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -1,7 +1,7 @@
 # web-serial-rxjs
 
 <p align="center">
-  <img src="./web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
+  <img src="https://raw.githubusercontent.com/gurezo/web-serial-rxjs/main/packages/web-serial-rxjs/web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
 </p>
 
 Web Serial API を RxJS ベースのリアクティブなラッパーで提供する TypeScript ライブラリです。Web アプリケーションでシリアルポート通信を簡単に実現できます。

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -1,7 +1,7 @@
 # web-serial-rxjs
 
 <p align="center">
-  <img src="./web-serial-rxjs-icon.png" alt="web-serial-rxjs project icon" width="512" />
+  <img src="https://raw.githubusercontent.com/gurezo/web-serial-rxjs/main/packages/web-serial-rxjs/web-serial-rxjs-icon.png" alt="web-serial-rxjs project icon" width="512" />
 </p>
 
 A TypeScript library that provides a reactive RxJS-based wrapper for the Web Serial API, enabling easy serial port communication in web applications.


### PR DESCRIPTION
## Summary

npm パッケージページで README のアイコンが表示されない問題を修正しました。README.md と README.ja.md の画像参照を相対パスから GitHub raw の絶対 URL に変更し、npm 上でも正しく表示されるようにしました。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #141

## What changed?
- README.md のアイコン画像の `src` を絶対 URL（raw.githubusercontent.com）に変更
- README.ja.md のアイコン画像の `src` を同じ絶対 URL に変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. このブランチの README を GitHub で開き、アイコンが表示されることを確認する
2. マージ・リリース後、https://www.npmjs.com/package/@gurezo/web-serial-rxjs の README タブでアイコンが表示されることを確認する

## Environment (if relevant)
- ドキュメント（README）のみの変更のため、ブラウザ/OS の記載は不要です。

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) — N/A（README のみの変更）
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent — N/A
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.) — N/A
