### PR TITLE
chore(web-serial-rxjs): bump to v0.1.16

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
`@gurezo/web-serial-rxjs` のバージョンを 0.1.15 から 0.1.16 に更新しました。#141 対応タグ作成のため（Issue #142）。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #142

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `0.1.16` に変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm install` を実行
2. `pnpm run build`（または対象パッケージのビルド）が通ることを確認
3. `packages/web-serial-rxjs/package.json` の `version` が `0.1.16` であることを確認

## Environment (if relevant)
- バージョン表記のみの変更のため不要

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
