### PR TITLE
chore(web-serial-rxjs): prepare release v0.1.17

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
#145 対応のタグ作成のため、`@gurezo/web-serial-rxjs` のバージョンを 0.1.16 から 0.1.17 に更新します。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #147

## What changed?
- packages/web-serial-rxjs/package.json の version を 0.1.17 に変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. ビルド: `pnpm exec nx build web-serial-rxjs`
2. テスト: `pnpm test`（存在する場合）

## Environment (if relevant)
- N/A（バージョン番号のみの変更）

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
