### PR TITLE
chore(web-serial-rxjs): bump version to 0.1.19

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
日本語: `@gurezo/web-serial-rxjs` の npm パッケージバージョンを `0.1.18` から `0.1.19` に更新します。

## Type of change
- [x] Chore (build/test/ci)
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Breaking change

## Related issues
- Fixes #162

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `0.1.18` -> `0.1.19` に更新

## API / Compatibility
- [x] This change is backward compatible
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `npx nx run-many --target=build, lint, test --all`

## Environment (if relevant)
- OS: macOS

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

