### PR TITLE
chore(web-serial-rxjs): bump package version to v0.1.20

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bump npm package version of `@gurezo/web-serial-rxjs` from `v0.1.19` to `v0.1.20` for the next release.
No functional code behavior was changed.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #170

## What changed?
- Updated `packages/web-serial-rxjs/package.json` version from `0.1.19` to `0.1.20`
- Confirmed no additional lockfile change was required

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. Check `packages/web-serial-rxjs/package.json` has `"version": "0.1.20"`
2. Run `pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs` (optional release check)
3. Confirm no runtime/API behavior changes in consumers

## Environment (if relevant)
- Browser: N/A
- OS: macOS
- web-serial-rxjs version (for verification): 0.1.20
- RxJS version: unchanged

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)