### PR TITLE
fix(workspace): ensure npm release includes README files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,25 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
+      - name: Verify npm package includes README files
+        shell: bash
+        run: |
+          set -euo pipefail
+          PACK_RESULT="$(npm pack --dry-run --json ./packages/web-serial-rxjs)"
+
+          node -e '
+            const result = JSON.parse(process.argv[1]);
+            const files = (result[0]?.files ?? []).map((file) => file.path);
+            const required = ["README.md", "README.ja.md"];
+            const missing = required.filter((path) => !files.includes(path));
+
+            if (missing.length > 0) {
+              console.error(`Missing files in npm pack output: ${missing.join(", ")}`);
+              process.exit(1);
+            }
+
+            console.log("Verified npm pack includes README files.");
+          ' "$PACK_RESULT"
 
       # リリース添付用の zip を作る（パッケージ単位）
       - name: Create release zip
@@ -65,7 +84,8 @@ jobs:
           npm config delete //registry.npmjs.org/:_authToken || true
           npm config delete _authToken || true
 
-          npm publish ./packages/web-serial-rxjs --access public --provenance
+          cd packages/web-serial-rxjs
+          npm publish --access public --provenance
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
Issue #174 の再発防止として、npm 公開前に README 同梱を検証し、公開コマンドの実行位置を明示しました。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #174

## What changed?
- release workflow に `npm pack --dry-run --json` を使った README 同梱チェックを追加
- `README.md` / `README.ja.md` が不足している場合は release を fail させる検証を追加
- `npm publish` を `packages/web-serial-rxjs` ディレクトリ内で実行するように変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx build web-serial-rxjs` を実行してビルドが成功することを確認
2. `npm pack --dry-run --json ./packages/web-serial-rxjs` を実行し、`README.md` と `README.ja.md` が `files` に含まれることを確認
3. `.github/workflows/release.yml` の `Verify npm package includes README files` ステップが存在することを確認

## Environment (if relevant)
- Browser: N/A (release workflow change)
- OS: macOS
- web-serial-rxjs version (for verification): 0.1.20 (pack dry-run)
- RxJS version: ^7.8.0 (peer dependency)

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)