### PR TITLE
chore(web-serial-rxjs): bump package version to v0.1.21

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Issue #176 に対応し、npm パッケージ `@gurezo/web-serial-rxjs` のバージョンを `0.1.20` から `0.1.21` に更新しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #176

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `0.1.21` に更新
- リリース対象バージョンの差分を 1 コミットで管理

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `git checkout chore/release-0.1.21`
2. `cat packages/web-serial-rxjs/package.json | grep '"version"'` で `0.1.21` を確認
3. 必要に応じて `pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs` で公開前確認

## Environment (if relevant)
- Browser: N/A
- OS: macOS
- web-serial-rxjs version (for verification): 0.1.21
- RxJS version: ^7.8.0 (peerDependencies)

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)