### PR TITLE
chore(web-serial-rxjs): パッケージバージョンを v0.2.0 に更新

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.1.21",
+  "version": "0.2.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Issue #182 への対応として、公開パッケージ `@gurezo/web-serial-rxjs` のバージョンを `0.1.21` から `0.2.0` に更新しました。
リリース準備を目的とした版数更新のみを行っています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #182

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `0.1.21` から `0.2.0` に更新
- ほかの実装コード・API・設定ファイルには変更なし

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/package.json` を開く
2. `version` が `0.2.0` になっていることを確認する
3. `git show --name-only` で変更対象が版数更新のみであることを確認する

## Environment (if relevant)
- Browser: N/A (version: N/A)
- OS: macOS
- web-serial-rxjs version (for verification): 0.2.0
- RxJS version: ^7.8.0

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)