### PR TITLE
fix(workspace): release CI の npm 自己更新失敗を回避

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,9 @@ jobs:
         with:
           node-version: "22"
 
-      # ★ここが肝：Trusted Publishing(OIDC)に必要な npm 11.5.1+ に上げる
-      - name: Upgrade npm for Trusted Publishing
+      - name: Show bundled npm version
         shell: bash
-        run: |
-          npm -v
-          npm i -g npm@^11.5.1
-          npm -v
+        run: npm -v
 
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
@@ -85,7 +81,7 @@ jobs:
           npm config delete _authToken || true
 
           cd packages/web-serial-rxjs
-          npm publish --access public --provenance
+          pnpm dlx npm@11.5.1 publish --access public --provenance
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
Issue #184 の release CI 失敗に対応し、GitHub Actions 上で `npm i -g npm@^11.5.1` を実行しない構成へ変更しました。
Trusted Publishing で必要な npm 11.5.1 は、publish 実行時のみ `pnpm dlx` 経由で利用するようにしています。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #184

## What changed?
- `.github/workflows/release.yml` の「npm グローバル自己更新」ステップを削除
- 代わりに `Show bundled npm version` ステップでバンドル npm のバージョンのみ確認
- publish コマンドを `npm publish --access public --provenance` から `pnpm dlx npm@11.5.1 publish --access public --provenance` に変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `fix/release-npm11-publish` ブランチの `.github/workflows/release.yml` を確認する
2. `npm i -g npm@^11.5.1` が削除され、publish が `pnpm dlx npm@11.5.1 publish --access public --provenance` になっていることを確認する
3. リリースタグを push して `Release` workflow が npm 自己更新エラーで失敗しないことを確認する

## Environment (if relevant)
- Browser: N/A (version: N/A)
- OS: ubuntu-latest (GitHub Actions)
- web-serial-rxjs version (for verification): 0.2.0
- RxJS version: ^7.8.0

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)