### PR TITLE
feat(web-serial-rxjs): Phase1 state + support を実装 (#187)

### DIFF
--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -27,6 +27,12 @@ const client = createSerialClient({
 
 ### メソッド
 
+#### `support(): SerialSupport`
+
+Web Serial API のブラウザ対応状況を、例外を投げずに返します。
+
+**戻り値:** `SerialSupport` - ブラウザ種別と、未対応時の理由を含むサポート結果
+
 #### `requestPort(): Observable<SerialPort>`
 
 ユーザーからシリアルポートをリクエストします。ポート選択のためのブラウザダイアログを開きます。
@@ -84,6 +90,9 @@ Observable ストリームからシリアルポートにデータを書き込み
 ### プロパティ
 
 - `connected: boolean` - ポートが現在開いているかどうかを示す読み取り専用プロパティ
+- `connected$: Observable<boolean>` - リアクティブな接続状態ストリーム（接続中は `true`、切断中は `false`）
+- `state$: Observable<SerialState>` - 詳細なライフサイクル状態ストリーム（`idle` / `unsupported` / `connecting` / `connected` / `disconnecting` / `error`）
+- `errors$: Observable<SerialError>` - クライアント内部で集約されるエラーストリーム
 - `currentPort: SerialPort | null` - 現在の `SerialPort` インスタンス、または接続されていない場合は `null` の読み取り専用プロパティ
 
 ## `SerialClientOptions` インターフェース

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -27,6 +27,12 @@ The main interface for interacting with serial ports.
 
 ### Methods
 
+#### `support(): SerialSupport`
+
+Returns browser support information for Web Serial API without throwing.
+
+**Returns:** `SerialSupport` - Support result with browser type and reason when unsupported
+
 #### `requestPort(): Observable<SerialPort>`
 
 Requests a serial port from the user. Opens a browser dialog for port selection.
@@ -105,6 +111,8 @@ The text is encoded with `TextEncoder` internally.
 
 - `connected: boolean` - Read-only property indicating if the port is currently open
 - `connected$: Observable<boolean>` - Reactive connection state stream (`true` when connected, `false` when disconnected)
+- `state$: Observable<SerialState>` - Detailed lifecycle state stream (`idle`, `unsupported`, `connecting`, `connected`, `disconnecting`, `error`)
+- `errors$: Observable<SerialError>` - Aggregated error stream emitted by the client
 - `connectionEvents$: Observable<'connected' | 'disconnected'>` - Reactive lifecycle events for connect/disconnect
 - `currentPort: SerialPort | null` - Read-only property with the current `SerialPort` instance, or `null` if not connected
 

--- a/packages/web-serial-rxjs/src/client/index.ts
+++ b/packages/web-serial-rxjs/src/client/index.ts
@@ -1,6 +1,8 @@
 import { Observable } from 'rxjs';
+import { SerialError } from '../errors/serial-error';
 import { SerialClientOptions } from '../types/options';
 import { SerialClientImpl } from './serial-client';
+import { SerialState, SerialSupport } from './serial-state';
 
 /**
  * SerialClient interface for interacting with serial ports using RxJS Observables.
@@ -31,6 +33,15 @@ import { SerialClientImpl } from './serial-client';
  * ```
  */
 export interface SerialClient {
+  /**
+   * Get the browser support information for Web Serial API.
+   *
+   * This method never throws. Use it to branch UI behavior before calling connect.
+   *
+   * @returns Browser support information
+   */
+  support(): SerialSupport;
+
   /**
    * Request a serial port from the user.
    *
@@ -242,6 +253,20 @@ export interface SerialClient {
   readonly connected$: Observable<boolean>;
 
   /**
+   * Reactive serial state stream.
+   *
+   * Emits detailed connection lifecycle and error states.
+   */
+  readonly state$: Observable<SerialState>;
+
+  /**
+   * Reactive error stream.
+   *
+   * Emits all {@link SerialError} instances produced by this client.
+   */
+  readonly errors$: Observable<SerialError>;
+
+  /**
    * Reactive connection event stream.
    *
    * Emits `'connected'` on successful connection and `'disconnected'` on disconnection.
@@ -258,6 +283,11 @@ export interface SerialClient {
    */
   readonly currentPort: SerialPort | null;
 }
+
+/**
+ * Browser support information for Web Serial API.
+ */
+export type { SerialState, SerialSupport };
 
 /**
  * Create a new SerialClient instance for interacting with serial ports.

--- a/packages/web-serial-rxjs/src/client/serial-client.ts
+++ b/packages/web-serial-rxjs/src/client/serial-client.ts
@@ -3,11 +3,18 @@ import {
   Observable,
   Subject,
   defer,
+  distinctUntilChanged,
   map,
+  of,
   share,
   switchMap,
+  throwError,
 } from 'rxjs';
-import { checkBrowserSupport } from '../browser/browser-support';
+import {
+  BrowserType,
+  detectBrowserType,
+  hasWebSerialSupport,
+} from '../browser/browser-detection';
 import { SerialError, SerialErrorCode } from '../errors/serial-error';
 import { buildRequestOptions } from '../filters/build-request-options';
 import { subscribeToWritable } from '../io/observable-to-writable';
@@ -16,6 +23,7 @@ import {
   DEFAULT_SERIAL_CLIENT_OPTIONS,
   SerialClientOptions,
 } from '../types/options';
+import type { SerialState, SerialSupport } from './serial-state';
 
 /**
  * Internal implementation of SerialClient interface.
@@ -42,7 +50,9 @@ export class SerialClientImpl {
   /** @internal */
   private textDecoder = new TextDecoder();
   /** @internal */
-  private readonly connectedState$ = new BehaviorSubject<boolean>(false);
+  private readonly stateSubject$: BehaviorSubject<SerialState>;
+  /** @internal */
+  private readonly errorsSubject$ = new Subject<SerialError>();
   /** @internal */
   private readonly connectionEventsSubject$ = new Subject<
     'connected' | 'disconnected'
@@ -60,12 +70,12 @@ export class SerialClientImpl {
    * @internal
    */
   constructor(options?: SerialClientOptions) {
-    checkBrowserSupport();
     this.options = {
       ...DEFAULT_SERIAL_CLIENT_OPTIONS,
       ...options,
       filters: options?.filters,
     };
+    this.stateSubject$ = new BehaviorSubject<SerialState>(this.getInitialState());
   }
 
   /**
@@ -76,7 +86,13 @@ export class SerialClientImpl {
    */
   requestPort(): Observable<SerialPort> {
     return defer(() => {
-      checkBrowserSupport();
+      const support = this.support();
+      if (!support.supported) {
+        const error = this.createUnsupportedError(support);
+        this.setUnsupportedState(support);
+        this.errorsSubject$.next(error);
+        throw error;
+      }
 
       return navigator.serial
         .requestPort(buildRequestOptions(this.options))
@@ -105,7 +121,13 @@ export class SerialClientImpl {
    */
   getPorts(): Observable<SerialPort[]> {
     return defer(() => {
-      checkBrowserSupport();
+      const support = this.support();
+      if (!support.supported) {
+        const error = this.createUnsupportedError(support);
+        this.setUnsupportedState(support);
+        this.errorsSubject$.next(error);
+        throw error;
+      }
 
       return navigator.serial.getPorts().catch((error) => {
         throw new SerialError(
@@ -125,25 +147,26 @@ export class SerialClientImpl {
    * @internal
    */
   connect(port?: SerialPort): Observable<void> {
-    checkBrowserSupport();
-
-    if (this.isOpen) {
-      return new Observable<void>((subscriber) => {
-        subscriber.error(
-          new SerialError(
-            SerialErrorCode.PORT_ALREADY_OPEN,
-            'Port is already open',
-          ),
-        );
-      });
+    const support = this.support();
+    if (!support.supported) {
+      this.setUnsupportedState(support);
+      const error = this.createUnsupportedError(support);
+      this.errorsSubject$.next(error);
+      return throwError(() => error);
     }
 
-    const port$ = port
-      ? new Observable<SerialPort>((subscriber) => {
-          subscriber.next(port);
-          subscriber.complete();
-        })
-      : this.requestPort();
+    if (this.isOpen) {
+      const error = new SerialError(
+        SerialErrorCode.PORT_ALREADY_OPEN,
+        'Port is already open',
+      );
+      this.errorsSubject$.next(error);
+      this.stateSubject$.next({ kind: 'error', error });
+      return throwError(() => error);
+    }
+    this.stateSubject$.next({ kind: 'connecting' });
+
+    const port$ = port ? of(port) : this.requestPort();
 
     return port$.pipe(
       switchMap((selectedPort) => {
@@ -161,7 +184,7 @@ export class SerialClientImpl {
             })
             .then(() => {
               this.isOpen = true;
-              this.connectedState$.next(true);
+              this.stateSubject$.next({ kind: 'connected' });
               this.connectionEventsSubject$.next('connected');
             })
             .catch((error) => {
@@ -172,11 +195,14 @@ export class SerialClientImpl {
                 throw error;
               }
 
-              throw new SerialError(
+              const serialError = new SerialError(
                 SerialErrorCode.PORT_OPEN_FAILED,
                 `Failed to open port: ${error instanceof Error ? error.message : String(error)}`,
                 error instanceof Error ? error : new Error(String(error)),
               );
+              this.errorsSubject$.next(serialError);
+              this.stateSubject$.next({ kind: 'error', error: serialError });
+              throw serialError;
             });
         });
       }),
@@ -192,8 +218,10 @@ export class SerialClientImpl {
   disconnect(): Observable<void> {
     return defer(() => {
       if (!this.isOpen || !this.port) {
+        this.stateSubject$.next({ kind: 'idle' });
         return Promise.resolve();
       }
+      this.stateSubject$.next({ kind: 'disconnecting' });
 
       // Unsubscribe from read/write streams
       if (this.readSubscription) {
@@ -214,20 +242,21 @@ export class SerialClientImpl {
         .then(() => {
           this.port = null;
           this.isOpen = false;
-          this.connectedState$.next(false);
+          this.stateSubject$.next({ kind: 'idle' });
           this.connectionEventsSubject$.next('disconnected');
         })
         .catch((error) => {
           this.port = null;
           this.isOpen = false;
-          this.connectedState$.next(false);
-          this.connectionEventsSubject$.next('disconnected');
-
-          throw new SerialError(
+          const serialError = new SerialError(
             SerialErrorCode.CONNECTION_LOST,
             `Failed to close port: ${error instanceof Error ? error.message : String(error)}`,
             error instanceof Error ? error : new Error(String(error)),
           );
+          this.errorsSubject$.next(serialError);
+          this.stateSubject$.next({ kind: 'error', error: serialError });
+
+          throw serialError;
         });
     });
   }
@@ -394,7 +423,32 @@ export class SerialClientImpl {
    * @internal
    */
   get connected$(): Observable<boolean> {
-    return this.connectedState$.asObservable();
+    return this.stateSubject$
+      .asObservable()
+      .pipe(
+        map((state) => state.kind === 'connected'),
+        distinctUntilChanged(),
+      );
+  }
+
+  /**
+   * Get detailed serial lifecycle states.
+   *
+   * @returns Observable of serial state machine events
+   * @internal
+   */
+  get state$(): Observable<SerialState> {
+    return this.stateSubject$.asObservable();
+  }
+
+  /**
+   * Get serial error stream.
+   *
+   * @returns Observable of aggregated serial errors
+   * @internal
+   */
+  get errors$(): Observable<SerialError> {
+    return this.errorsSubject$.asObservable();
   }
 
   /**
@@ -415,5 +469,52 @@ export class SerialClientImpl {
    */
   get currentPort(): SerialPort | null {
     return this.port;
+  }
+
+  /**
+   * Check Web Serial support information.
+   *
+   * @returns Browser support data
+   * @internal
+   */
+  support(): SerialSupport {
+    const browser = detectBrowserType();
+    const supported = hasWebSerialSupport();
+    if (supported) {
+      return { supported: true, browser };
+    }
+
+    return {
+      supported: false,
+      browser,
+      reason: this.buildUnsupportedMessage(browser),
+    };
+  }
+
+  private getInitialState(): SerialState {
+    const support = this.support();
+    if (!support.supported) {
+      return { kind: 'unsupported', support };
+    }
+    return { kind: 'idle' };
+  }
+
+  private setUnsupportedState(support: SerialSupport): void {
+    this.stateSubject$.next({ kind: 'unsupported', support });
+  }
+
+  private createUnsupportedError(support: SerialSupport): SerialError {
+    return new SerialError(
+      SerialErrorCode.BROWSER_NOT_SUPPORTED,
+      support.supported
+        ? 'Web Serial API is supported'
+        : support.reason,
+    );
+  }
+
+  private buildUnsupportedMessage(browser: BrowserType): string {
+    const browserName =
+      browser === BrowserType.UNKNOWN ? 'your browser' : browser.toUpperCase();
+    return `Web Serial API is not supported in ${browserName}. Please use a Chromium-based browser (Chrome, Edge, or Opera).`;
   }
 }

--- a/packages/web-serial-rxjs/src/client/serial-state.ts
+++ b/packages/web-serial-rxjs/src/client/serial-state.ts
@@ -1,0 +1,27 @@
+import { BrowserType } from '../browser/browser-detection';
+import { SerialError } from '../errors/serial-error';
+
+/**
+ * Browser support information for Web Serial API.
+ */
+export type SerialSupport =
+  | {
+      supported: true;
+      browser: BrowserType;
+    }
+  | {
+      supported: false;
+      browser: BrowserType;
+      reason: string;
+    };
+
+/**
+ * Reactive state machine for serial client lifecycle.
+ */
+export type SerialState =
+  | { kind: 'idle' }
+  | { kind: 'unsupported'; support: SerialSupport }
+  | { kind: 'connecting' }
+  | { kind: 'connected' }
+  | { kind: 'disconnecting' }
+  | { kind: 'error'; error: SerialError };

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -47,7 +47,7 @@ export { createSerialClient } from './client';
 export { createShellClient } from './shell';
 
 // Type exports
-export type { SerialClient } from './client';
+export type { SerialClient, SerialState, SerialSupport } from './client';
 export type { ShellClient, ShellClientOptions, ShellExecResult } from './shell';
 
 // Error exports

--- a/packages/web-serial-rxjs/tests/client/serial-client.test.ts
+++ b/packages/web-serial-rxjs/tests/client/serial-client.test.ts
@@ -100,6 +100,7 @@ describe('serial-client', () => {
     } as unknown as SerialPort;
 
     const client = createSerialClient();
+    const serialStatesPromise = firstValueFrom(client.state$.pipe(take(4), toArray()));
     const statesPromise = firstValueFrom(client.connected$.pipe(take(3), toArray()));
     const eventsPromise = firstValueFrom(
       client.connectionEvents$.pipe(take(2), toArray()),
@@ -108,7 +109,42 @@ describe('serial-client', () => {
     await firstValueFrom(client.connect(port).pipe(defaultIfEmpty(undefined)));
     await firstValueFrom(client.disconnect().pipe(defaultIfEmpty(undefined)));
 
+    await expect(serialStatesPromise).resolves.toEqual([
+      { kind: 'idle' },
+      { kind: 'connecting' },
+      { kind: 'connected' },
+      { kind: 'disconnecting' },
+    ]);
     await expect(statesPromise).resolves.toEqual([false, true, false]);
     await expect(eventsPromise).resolves.toEqual(['connected', 'disconnected']);
+  });
+
+  it('emits unsupported state and errors in unsupported browsers', async () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      configurable: true,
+      writable: true,
+      value: {},
+    });
+
+    const client = createSerialClient();
+    const support = client.support();
+    expect(support.supported).toBe(false);
+
+    const statePromise = firstValueFrom(client.state$.pipe(take(1)));
+    await expect(statePromise).resolves.toMatchObject({
+      kind: 'unsupported',
+      support: { supported: false },
+    });
+
+    const errorsPromise = firstValueFrom(client.errors$.pipe(take(1)));
+    await expect(
+      firstValueFrom(client.connect().pipe(defaultIfEmpty(undefined))),
+    ).rejects.toMatchObject({
+      name: 'SerialError',
+      code: 'BROWSER_NOT_SUPPORTED',
+    });
+    await expect(errorsPromise).resolves.toMatchObject({
+      code: 'BROWSER_NOT_SUPPORTED',
+    });
   });
 });


### PR DESCRIPTION
## Summary
Issue #186 の設計方針に沿って、Issue #187（Phase1: state + support）を実装しました。
SerialClient に状態機械とブラウザ対応判定を統合し、利用側の状態管理責務を削減します。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #187
- Refs #186

## What changed?
- `SerialState` / `SerialSupport` を追加し、`SerialClient` に `support()` / `state$` / `errors$` を公開
- `SerialClientImpl` で `connecting` / `connected` / `disconnecting` / `unsupported` / `error` の状態遷移を実装
- 未対応ブラウザ時の状態反映と `errors$` へのエラー集約を追加
- `serial-client` テストを拡張し、状態遷移と unsupported エラーフローを検証
- API リファレンス（日英）に Phase1 追加 API を追記

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialClient` に `support()` / `state$` / `errors$` を追加。型 `SerialState` / `SerialSupport` を公開。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm nx test web-serial-rxjs` を実行する
2. `packages/web-serial-rxjs/tests/client/serial-client.test.ts` で `state$` / `errors$` のケースが通ることを確認する
3. unsupported 環境モックで `BROWSER_NOT_SUPPORTED` が `errors$` に流れることを確認する

## Environment (if relevant)
- Browser: N/A (unit test)
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: ^7.8.2

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)