### PR TITLE
feat(web-serial-rxjs): Phase4 protocol（command$/transact$）を実装 (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ A TypeScript library that provides a reactive RxJS-based wrapper for the Web Ser
 ## Features
 
 - **RxJS-based reactive API**: Leverage the power of RxJS Observables for reactive serial port communication
-- **Text-friendly API**: Use `text$`/`lines$` and `writeText()` without manual encoding/decoding
-- **Shell utility layer**: Execute command/prompt workflows with `createShellClient()`
+- **Text-friendly API**: Use `text$`/`lines$`, `send$()`, and `writeText()` without manual encoding/decoding
+- **Built-in protocol API**: Execute request/response workflows with `command$()` and `transact$()`
+- **Shell utility layer**: `createShellClient()` remains available for shell-oriented helpers
 - **TypeScript support**: Full TypeScript type definitions included
 - **Browser detection**: Built-in browser support detection and error handling
 - **Error handling**: Comprehensive error handling with custom error classes and error codes

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -24,8 +24,9 @@ A TypeScript library that provides a reactive RxJS-based wrapper for the Web Ser
 ## Features
 
 - **RxJS-based reactive API**: Leverage the power of RxJS Observables for reactive serial port communication
-- **Text-friendly API**: Use `text$`/`lines$` and `writeText()` without manual encoding/decoding
-- **Shell utility layer**: Execute command/prompt workflows with `createShellClient()`
+- **Text-friendly API**: Use `text$`/`lines$`, `send$()`, and `writeText()` without manual encoding/decoding
+- **Built-in protocol API**: Execute request/response workflows with `command$()` and `transact$()`
+- **Shell utility layer**: `createShellClient()` remains available for shell-oriented helpers
 - **TypeScript support**: Full TypeScript type definitions included
 - **Browser detection**: Built-in browser support detection and error handling
 - **Error handling**: Comprehensive error handling with custom error classes and error codes

--- a/packages/web-serial-rxjs/src/client/index.ts
+++ b/packages/web-serial-rxjs/src/client/index.ts
@@ -1,6 +1,11 @@
 import { Observable } from 'rxjs';
 import { SerialError } from '../errors/serial-error';
 import { SerialClientOptions } from '../types/options';
+import type {
+  CommandResult,
+  SerialCommandOptions,
+  SerialRequest,
+} from './protocol';
 import { SerialClientImpl } from './serial-client';
 import { SerialState, SerialSupport } from './serial-state';
 
@@ -181,6 +186,23 @@ export interface SerialClient {
   send$(data: string | Uint8Array): Observable<void>;
 
   /**
+   * Execute a command and collect output until prompt.
+   *
+   * @param command - Command text to send
+   * @param options - Prompt matching and timeout options
+   * @returns An Observable that emits captured stdout
+   */
+  command$(command: string, options?: SerialCommandOptions): Observable<CommandResult>;
+
+  /**
+   * Execute a protocol transaction with custom response collector.
+   *
+   * @param request - Transaction request options
+   * @returns An Observable that emits collected value
+   */
+  transact$<T>(request: SerialRequest<T>): Observable<T>;
+
+  /**
    * Write a single chunk of data to the serial port.
    *
    * Writes a single Uint8Array chunk to the serial port immediately.
@@ -266,6 +288,11 @@ export interface SerialClient {
  * Browser support information for Web Serial API.
  */
 export type { SerialState, SerialSupport };
+export type {
+  CommandResult,
+  SerialCommandOptions,
+  SerialRequest,
+} from './protocol';
 
 /**
  * Create a new SerialClient instance for interacting with serial ports.

--- a/packages/web-serial-rxjs/src/client/protocol.ts
+++ b/packages/web-serial-rxjs/src/client/protocol.ts
@@ -1,0 +1,32 @@
+export interface SerialCommandOptions {
+  /**
+   * Prompt matcher used to detect command completion.
+   *
+   * @default '$ '
+   */
+  prompt?: string | RegExp;
+  /**
+   * Timeout in milliseconds while waiting for prompt.
+   *
+   * @default 10000
+   */
+  timeout?: number;
+  /**
+   * Line ending appended to command payload.
+   *
+   * @default '\r\n'
+   */
+  lineEnding?: string;
+}
+
+export interface CommandResult {
+  stdout: string;
+}
+
+export interface SerialRequest<T> {
+  payload: string | Uint8Array;
+  collect: (stdout: string) => T;
+  prompt?: string | RegExp;
+  timeout?: number;
+  lineEnding?: string;
+}

--- a/packages/web-serial-rxjs/src/client/serial-client.ts
+++ b/packages/web-serial-rxjs/src/client/serial-client.ts
@@ -1,16 +1,14 @@
 import {
   BehaviorSubject,
-  EMPTY,
   Observable,
   Subject,
-  catchError,
-  concatMap,
+  defaultIfEmpty,
   defer,
   distinctUntilChanged,
+  firstValueFrom,
   map,
   of,
   switchMap,
-  tap,
   throwError,
 } from 'rxjs';
 import {
@@ -21,11 +19,20 @@ import {
 import { SerialError, SerialErrorCode } from '../errors/serial-error';
 import { buildRequestOptions } from '../filters/build-request-options';
 import { readableToObservable } from '../io/readable-to-observable';
+import type {
+  CommandResult,
+  SerialCommandOptions,
+  SerialRequest,
+} from './protocol';
 import {
   DEFAULT_SERIAL_CLIENT_OPTIONS,
   SerialClientOptions,
 } from '../types/options';
 import type { SerialState, SerialSupport } from './serial-state';
+
+const DEFAULT_PROMPT = '$ ';
+const DEFAULT_PROTOCOL_TIMEOUT_MS = 10_000;
+const DEFAULT_PROTOCOL_LINE_ENDING = '\r\n';
 
 /**
  * Internal implementation of SerialClient interface.
@@ -56,25 +63,11 @@ export class SerialClientImpl {
   /** @internal */
   private readonly linesSubject$ = new Subject<string>();
   /** @internal */
-  private readonly outboundSubject$ = new Subject<{
-    payload: Uint8Array;
-    onComplete: () => void;
-    onError: (error: unknown) => void;
-  }>();
+  private readonly bufferTick$ = new Subject<void>();
   /** @internal */
-  private readonly outboundSubscription = this.outboundSubject$
-    .pipe(
-      concatMap((job) =>
-        this.write(job.payload).pipe(
-          tap({ complete: job.onComplete }),
-          catchError((error) => {
-            job.onError(error);
-            return EMPTY;
-          }),
-        ),
-      ),
-    )
-    .subscribe();
+  private operationQueue: Promise<void> = Promise.resolve();
+  /** @internal */
+  private readBuffer = '';
   /** @internal */
   private readonly stateSubject$: BehaviorSubject<SerialState>;
   /** @internal */
@@ -283,29 +276,35 @@ export class SerialClientImpl {
   }
 
   send$(data: string | Uint8Array): Observable<void> {
-    return new Observable<void>((subscriber) => {
-      if (!this.isOpen || !this.port || !this.port.writable) {
-        subscriber.error(
-          new SerialError(
-            SerialErrorCode.PORT_NOT_OPEN,
-            'Port is not open or writable stream is not available',
-          ),
-        );
-        return;
-      }
-
+    return this.enqueueOperation(async () => {
       const payload =
         typeof data === 'string' ? this.textEncoder.encode(data) : data;
-      this.outboundSubject$.next({
-        payload,
-        onComplete: () => {
-          subscriber.next();
-          subscriber.complete();
-        },
-        onError: (error) => {
-          subscriber.error(error);
-        },
-      });
+      await firstValueFrom(this.write(payload).pipe(defaultIfEmpty(undefined)));
+    });
+  }
+
+  command$(
+    command: string,
+    options?: SerialCommandOptions,
+  ): Observable<CommandResult> {
+    return this.enqueueOperation(async () => {
+      await this.sendCommandPayload(command, options?.lineEnding);
+      const stdout = await this.waitUntilPrompt(
+        options?.prompt ?? DEFAULT_PROMPT,
+        options?.timeout ?? DEFAULT_PROTOCOL_TIMEOUT_MS,
+      );
+      return { stdout };
+    });
+  }
+
+  transact$<T>(request: SerialRequest<T>): Observable<T> {
+    return this.enqueueOperation(async () => {
+      await this.sendRequestPayload(request.payload, request.lineEnding);
+      const stdout = await this.waitUntilPrompt(
+        request.prompt ?? DEFAULT_PROMPT,
+        request.timeout ?? DEFAULT_PROTOCOL_TIMEOUT_MS,
+      );
+      return request.collect(stdout);
     });
   }
 
@@ -521,6 +520,8 @@ export class SerialClientImpl {
     this.bytesSubject$.next(chunk);
     const decodedText = this.textDecoder.decode(chunk, { stream: true });
     this.textSubject$.next(decodedText);
+    this.readBuffer += decodedText;
+    this.bufferTick$.next();
 
     const merged = `${this.lineBuffer}${decodedText}`.replace(/\r\n/g, '\n');
     const parts = merged.split('\n');
@@ -533,5 +534,132 @@ export class SerialClientImpl {
   private resetReceiveState(): void {
     this.textDecoder = new TextDecoder();
     this.lineBuffer = '';
+    this.readBuffer = '';
+  }
+
+  private enqueueOperation<T>(operation: () => Promise<T>): Observable<T> {
+    return defer(
+      () =>
+        new Observable<T>((subscriber) => {
+          let cancelled = false;
+          const run = async (): Promise<void> => {
+            try {
+              const value = await operation();
+              if (!cancelled) {
+                subscriber.next(value);
+                subscriber.complete();
+              }
+            } catch (error) {
+              if (!cancelled) {
+                subscriber.error(error);
+              }
+            }
+          };
+
+          const scheduled = this.operationQueue.then(run, run);
+          this.operationQueue = scheduled.then(
+            () => undefined,
+            () => undefined,
+          );
+
+          return () => {
+            cancelled = true;
+          };
+        }),
+    );
+  }
+
+  private async sendCommandPayload(
+    command: string,
+    lineEnding = DEFAULT_PROTOCOL_LINE_ENDING,
+  ): Promise<void> {
+    await this.sendRequestPayload(command, lineEnding);
+  }
+
+  private async sendRequestPayload(
+    payload: string | Uint8Array,
+    lineEnding = DEFAULT_PROTOCOL_LINE_ENDING,
+  ): Promise<void> {
+    const normalized =
+      typeof payload === 'string'
+        ? this.textEncoder.encode(payload + lineEnding)
+        : payload;
+    await firstValueFrom(this.write(normalized).pipe(defaultIfEmpty(undefined)));
+  }
+
+  private waitUntilPrompt(
+    prompt: string | RegExp,
+    timeoutMs: number,
+  ): Promise<string> {
+    const immediate = this.tryConsumePrompt(prompt);
+    if (immediate !== null) {
+      return Promise.resolve(immediate);
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        subscription.unsubscribe();
+        reject(
+          new SerialError(
+            SerialErrorCode.OPERATION_TIMEOUT,
+            `Timed out waiting for prompt after ${timeoutMs}ms`,
+          ),
+        );
+      }, timeoutMs);
+
+      const complete = (value: string): void => {
+        clearTimeout(timer);
+        subscription.unsubscribe();
+        resolve(value);
+      };
+
+      const fail = (error: unknown): void => {
+        clearTimeout(timer);
+        subscription.unsubscribe();
+        reject(error);
+      };
+
+      const tryResolve = (): void => {
+        const output = this.tryConsumePrompt(prompt);
+        if (output !== null) {
+          complete(output);
+        }
+      };
+
+      const subscription = this.bufferTick$.subscribe({
+        next: () => tryResolve(),
+        error: (error) => fail(error),
+        complete: () => fail(new Error('Read stream completed before prompt was found')),
+      });
+    });
+  }
+
+  private tryConsumePrompt(prompt: string | RegExp): string | null {
+    if (typeof prompt === 'string') {
+      if (
+        this.readBuffer.length >= prompt.length &&
+        this.readBuffer.endsWith(prompt)
+      ) {
+        const body = this.readBuffer.slice(0, this.readBuffer.length - prompt.length);
+        this.readBuffer = '';
+        return body.trimEnd();
+      }
+      return null;
+    }
+
+    const regex = this.createAnchoredRegex(prompt);
+    const match = regex.exec(this.readBuffer);
+    if (!match || match.index == null) {
+      return null;
+    }
+
+    const body = this.readBuffer.slice(0, match.index);
+    this.readBuffer = '';
+    return body.trimEnd();
+  }
+
+  private createAnchoredRegex(source: RegExp): RegExp {
+    const flags = source.flags.replace(/g/g, '');
+    return new RegExp(`(?:${source.source})$`, flags);
   }
 }

--- a/packages/web-serial-rxjs/src/errors/serial-error-code.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error-code.ts
@@ -130,6 +130,14 @@ export enum SerialErrorCode {
   OPERATION_CANCELLED = 'OPERATION_CANCELLED',
 
   /**
+   * Operation timed out before completion.
+   *
+   * This error occurs when an operation waits for a condition (for example, prompt
+   * detection) and the timeout period elapses first.
+   */
+  OPERATION_TIMEOUT = 'OPERATION_TIMEOUT',
+
+  /**
    * Unknown error occurred.
    *
    * This error code is used for errors that don't fit into any other category.

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -47,7 +47,14 @@ export { createSerialClient } from './client';
 export { createShellClient } from './shell';
 
 // Type exports
-export type { SerialClient, SerialState, SerialSupport } from './client';
+export type {
+  CommandResult,
+  SerialClient,
+  SerialCommandOptions,
+  SerialRequest,
+  SerialState,
+  SerialSupport,
+} from './client';
 export type { ShellClient, ShellClientOptions, ShellExecResult } from './shell';
 
 // Error exports

--- a/packages/web-serial-rxjs/tests/client/serial-client.test.ts
+++ b/packages/web-serial-rxjs/tests/client/serial-client.test.ts
@@ -243,4 +243,136 @@ describe('serial-client', () => {
       code: 'BROWSER_NOT_SUPPORTED',
     });
   });
+
+  it('executes command$ and collects stdout until prompt', async () => {
+    const writes: string[] = [];
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const readable = new ReadableStream<Uint8Array>({
+      start(nextController) {
+        controller = nextController;
+      },
+    });
+    const writable = new WritableStream<Uint8Array>({
+      write(chunk) {
+        writes.push(new TextDecoder().decode(chunk));
+      },
+    });
+    const port = {
+      readable,
+      writable,
+      open: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SerialPort;
+    const client = createSerialClient();
+    await firstValueFrom(client.connect(port).pipe(defaultIfEmpty(undefined)));
+
+    const resultPromise = firstValueFrom(client.command$('status'));
+    if (!controller) {
+      throw new Error('Readable stream controller was not initialized');
+    }
+    controller.enqueue(new TextEncoder().encode('ok\n$ '));
+
+    await expect(resultPromise).resolves.toEqual({ stdout: 'ok' });
+    expect(writes[0]).toBe('status\r\n');
+  });
+
+  it('executes transact$ with custom collect function', async () => {
+    const writes: string[] = [];
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const readable = new ReadableStream<Uint8Array>({
+      start(nextController) {
+        controller = nextController;
+      },
+    });
+    const writable = new WritableStream<Uint8Array>({
+      write(chunk) {
+        writes.push(new TextDecoder().decode(chunk));
+      },
+    });
+    const port = {
+      readable,
+      writable,
+      open: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SerialPort;
+    const client = createSerialClient();
+    await firstValueFrom(client.connect(port).pipe(defaultIfEmpty(undefined)));
+
+    const resultPromise = firstValueFrom(
+      client.transact$({
+        payload: 'whoami',
+        prompt: '> ',
+        collect: (stdout) => stdout.split(':')[1],
+      }),
+    );
+    if (!controller) {
+      throw new Error('Readable stream controller was not initialized');
+    }
+    controller.enqueue(new TextEncoder().encode('user:root> '));
+
+    await expect(resultPromise).resolves.toBe('root');
+    expect(writes[0]).toBe('whoami\r\n');
+  });
+
+  it('returns timeout error when command$ prompt is not received', async () => {
+    const port = {
+      readable: new ReadableStream<Uint8Array>({}),
+      writable: new WritableStream<Uint8Array>({}),
+      open: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SerialPort;
+    const client = createSerialClient();
+    await firstValueFrom(client.connect(port).pipe(defaultIfEmpty(undefined)));
+
+    await expect(
+      firstValueFrom(client.command$('timeout', { timeout: 5 })),
+    ).rejects.toMatchObject({
+      name: 'SerialError',
+      code: 'OPERATION_TIMEOUT',
+    });
+  });
+
+  it('serializes command$ and send$ on a single queue', async () => {
+    const writes: string[] = [];
+    let promptSent = false;
+    let sendStartedBeforePrompt = false;
+    let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const readable = new ReadableStream<Uint8Array>({
+      start(nextController) {
+        controller = nextController;
+      },
+    });
+    const writable = new WritableStream<Uint8Array>({
+      write(chunk) {
+        const text = new TextDecoder().decode(chunk);
+        writes.push(text);
+        if (text === 'tail' && !promptSent) {
+          sendStartedBeforePrompt = true;
+        }
+      },
+    });
+    const port = {
+      readable,
+      writable,
+      open: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+    } as unknown as SerialPort;
+    const client = createSerialClient();
+    await firstValueFrom(client.connect(port).pipe(defaultIfEmpty(undefined)));
+
+    const commandPromise = firstValueFrom(client.command$('cmd'));
+    const sendPromise = firstValueFrom(client.send$('tail').pipe(defaultIfEmpty(undefined)));
+    if (!controller) {
+      throw new Error('Readable stream controller was not initialized');
+    }
+    setTimeout(() => {
+      promptSent = true;
+      controller.enqueue(new TextEncoder().encode('done$ '));
+    }, 20);
+
+    await Promise.all([commandPromise, sendPromise]);
+
+    expect(writes).toEqual(['cmd\r\n', 'tail']);
+    expect(sendStartedBeforePrompt).toBe(false);
+  });
 });

--- a/packages/web-serial-rxjs/tests/shell/create-shell-client.test.ts
+++ b/packages/web-serial-rxjs/tests/shell/create-shell-client.test.ts
@@ -16,6 +16,8 @@ function createMockClient(
     text$: readSubject.asObservable(),
     lines$: of(''),
     send$: vi.fn(),
+    command$: vi.fn(),
+    transact$: vi.fn(),
     write: vi.fn(),
     writeText: writeTextImpl,
     connected: true,


### PR DESCRIPTION
## Summary
Issue #190 の Phase4 として、通信手順（request/response）を `SerialClient` の標準 API に引き上げました。
`command$` / `transact$` を追加し、送信キュー統合・prompt 待機・timeout をライブラリ責務として実装しています。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #190
- Refs #186

## What changed?
- `SerialClient` に `command$` / `transact$` と関連型（`SerialCommandOptions` / `SerialRequest` / `CommandResult`）を追加
- `SerialClientImpl` に prompt 終端待機を伴う protocol 実装を追加し、`send$` と同一キューで直列化
- timeout 発生時に `SerialErrorCode.OPERATION_TIMEOUT` を返すようにエラーコードを追加
- `serial-client` / `shell` テストを拡張し、正常系・timeout・順序保証を検証
- README（root/package）に Phase4 protocol API の説明を反映

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `command$` / `transact$` および protocol 関連型を公開 API として追加
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm nx test web-serial-rxjs` を実行
2. `tests/client/serial-client.test.ts` の command$/transact$/timeout/queue 系テストが通ることを確認
3. `tests/shell/create-shell-client.test.ts` が既存互換のまま通ることを確認

## Environment (if relevant)
- Browser: N/A（unit test ベースで検証）
- OS: macOS
- web-serial-rxjs version (for verification): workspace HEAD
- RxJS version: ^7.8.2

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)