### PR TITLE
refactor(web-serial-rxjs): SerialSession interface と createSerialSession を追加 (#200)

### DIFF
--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -55,6 +55,14 @@ export type {
   SerialSupport,
 } from './client';
 
+// v2 SerialSession API (additive, stabilizing under #199)
+export { createSerialSession } from './session';
+export type {
+  SerialSession,
+  SerialSessionOptions,
+  SerialSessionState,
+} from './session';
+
 // Advanced API
 export { createShellClient } from './shell';
 export type { ShellClient, ShellClientOptions, ShellExecResult } from './shell';

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -1,0 +1,77 @@
+import {
+  BehaviorSubject,
+  Observable,
+  Subject,
+  defer,
+  throwError,
+} from 'rxjs';
+import { hasWebSerialSupport } from '../browser/browser-detection';
+import { SerialError } from '../errors/serial-error';
+import { SerialErrorCode } from '../errors/serial-error-code';
+import type { SerialSession } from './serial-session';
+import type { SerialSessionOptions } from './serial-session-options';
+import type { SerialSessionState } from './serial-session-state';
+
+const NOT_IMPLEMENTED_MESSAGE =
+  'SerialSession runtime is not implemented yet. Tracked by the remaining sub-issues of https://github.com/gurezo/web-serial-rxjs/issues/199';
+
+function notImplemented$(): Observable<never> {
+  return defer(() =>
+    throwError(
+      () =>
+        new SerialError(SerialErrorCode.UNKNOWN, NOT_IMPLEMENTED_MESSAGE),
+    ),
+  );
+}
+
+/**
+ * Create a v2 {@link SerialSession}.
+ *
+ * This initial release establishes a stable public shape for the session
+ * API. The runtime (read pump, send queue, error pipeline, state
+ * transitions) is implemented in the remaining sub-issues of #199.
+ *
+ * Current behavior:
+ *
+ * - `isBrowserSupported()` returns whether `navigator.serial` is available.
+ * - `state$` replays `'idle'` on subscribe.
+ * - `errors$` is an open stream with no default emissions.
+ * - `receive$` is an open stream with no default emissions.
+ * - `connect$()`, `disconnect$()`, and `send$()` fail with a `SerialError`
+ *   carrying `SerialErrorCode.UNKNOWN` until the runtime lands.
+ *
+ * @param _options - Session options. Currently unused; retained so the
+ *   public signature stays stable when the runtime is implemented.
+ * @returns A {@link SerialSession} instance.
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ */
+export function createSerialSession(
+  _options?: SerialSessionOptions,
+): SerialSession {
+  const stateSubject = new BehaviorSubject<SerialSessionState>('idle');
+  const errorsSubject = new Subject<SerialError>();
+  const receiveSubject = new Subject<string | Uint8Array>();
+
+  const state$ = stateSubject.asObservable();
+  const errors$ = errorsSubject.asObservable();
+  const receive$ = receiveSubject.asObservable();
+
+  return {
+    isBrowserSupported(): boolean {
+      return hasWebSerialSupport();
+    },
+    connect$(): Observable<void> {
+      return notImplemented$();
+    },
+    disconnect$(): Observable<void> {
+      return notImplemented$();
+    },
+    send$(_data: string | Uint8Array): Observable<void> {
+      return notImplemented$();
+    },
+    state$,
+    errors$,
+    receive$,
+  };
+}

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -1,0 +1,4 @@
+export { createSerialSession } from './create-serial-session';
+export type { SerialSession } from './serial-session';
+export type { SerialSessionOptions } from './serial-session-options';
+export type { SerialSessionState } from './serial-session-state';

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -1,0 +1,14 @@
+import type { SerialClientOptions } from '../types/options';
+
+/**
+ * Options for creating a {@link SerialSession} via {@link createSerialSession}.
+ *
+ * For the v2 API these options mirror the v1 {@link SerialClientOptions}
+ * surface (baud rate, data bits, stop bits, parity, buffer size, flow
+ * control, and filters). A dedicated interface is kept so the v2 options
+ * surface can diverge in later sub-issues of #199 without touching v1.
+ *
+ * @see {@link SerialClientOptions}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ */
+export type SerialSessionOptions = SerialClientOptions;

--- a/packages/web-serial-rxjs/src/session/serial-session-state.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-state.ts
@@ -1,0 +1,27 @@
+/**
+ * Reactive lifecycle state for a {@link SerialSession}.
+ *
+ * This is the v2 API counterpart of the legacy `SerialState` used by
+ * `SerialClient`. It is expressed as a flat string union so that consumers
+ * (Angular, Vue, React, etc.) can drive their UI from `state$` directly
+ * without unwrapping discriminator fields.
+ *
+ * Lifecycle transitions:
+ *
+ * ```
+ * idle -> connecting -> connected -> disconnecting -> idle
+ *                                \-> error
+ * (any)  -> unsupported   (when Web Serial API is unavailable)
+ * (any)  -> error         (when an unrecoverable failure occurs)
+ * ```
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ */
+export type SerialSessionState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'disconnecting'
+  | 'unsupported'
+  | 'error';

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -1,0 +1,99 @@
+import type { Observable } from 'rxjs';
+import type { SerialError } from '../errors/serial-error';
+import type { SerialSessionState } from './serial-session-state';
+
+/**
+ * v2 public API for interacting with the Web Serial API through a
+ * minimal, session-oriented surface.
+ *
+ * The session is intentionally slim so that apps (Angular, Vue, React, etc.)
+ * can drive their UI purely from `state$` + `receive$` + `errors$` and never
+ * have to rebuild BehaviorSubjects, manage a read loop, or serialize writes
+ * themselves.
+ *
+ * All imperative Web Serial work (open / read loop / write / close) is
+ * encapsulated by the implementation. Only Observables are exposed.
+ *
+ * @example
+ * ```typescript
+ * const session = createSerialSession({ baudRate: 115200 });
+ *
+ * session.state$.subscribe((state) => console.log('state:', state));
+ * session.receive$.subscribe((chunk) => console.log('rx:', chunk));
+ * session.errors$.subscribe((error) => console.error('err:', error));
+ *
+ * session.connect$().subscribe();
+ * session.send$('hello\r\n').subscribe();
+ * ```
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ */
+export interface SerialSession {
+  /**
+   * Synchronous feature detection for the Web Serial API.
+   *
+   * Never throws; intended for UI branching before calling `connect$`.
+   *
+   * @returns `true` when `navigator.serial` is available.
+   */
+  isBrowserSupported(): boolean;
+
+  /**
+   * Open a serial port and start the internal read pump.
+   *
+   * Returns an Observable that completes when the port is fully opened and
+   * the read pump is running. Subscribing to `receive$` before calling
+   * `connect$` is safe: emissions simply start after the pump is active.
+   *
+   * @returns An Observable that completes on successful connection.
+   */
+  connect$(): Observable<void>;
+
+  /**
+   * Close the active serial port and stop the internal read pump.
+   *
+   * Safe to call when already disconnected.
+   *
+   * @returns An Observable that completes when the port is fully closed.
+   */
+  disconnect$(): Observable<void>;
+
+  /**
+   * Reactive session lifecycle state.
+   *
+   * Replays the current state on subscribe. UIs should drive entirely from
+   * this stream instead of reconstructing their own BehaviorSubject.
+   */
+  readonly state$: Observable<SerialSessionState>;
+
+  /**
+   * Primary error channel.
+   *
+   * All {@link SerialError} instances produced by the session (connect /
+   * read / write / close) are multiplexed here. This is the main channel,
+   * not a supplementary one.
+   */
+  readonly errors$: Observable<SerialError>;
+
+  /**
+   * Incoming data from the serial port.
+   *
+   * The stream is driven by the read pump started by `connect$`. It is
+   * **not** subscription-lazy: emissions happen regardless of whether a
+   * consumer is currently subscribed, so late subscribers see only new data.
+   */
+  readonly receive$: Observable<string | Uint8Array>;
+
+  /**
+   * Enqueue data for ordered transmission.
+   *
+   * Writes are serialized internally so that concurrent `send$` calls are
+   * delivered to the port in call order. The returned Observable completes
+   * once the enqueued payload has been flushed.
+   *
+   * @param data - Text (UTF-8 encoded) or raw bytes to send.
+   * @returns An Observable that completes when the payload is written.
+   */
+  send$(data: string | Uint8Array): Observable<void>;
+}

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -1,0 +1,132 @@
+import { firstValueFrom, lastValueFrom, take, toArray } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { createSerialSession } from '../../src/session/create-serial-session';
+import type { SerialSession } from '../../src/session/serial-session';
+import type { SerialSessionState } from '../../src/session/serial-session-state';
+
+describe('createSerialSession (skeleton)', () => {
+  const originalNavigator = global.navigator;
+
+  beforeEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Reset navigator for isolation
+    delete (global as any).navigator;
+  });
+
+  afterEach(() => {
+    global.navigator = originalNavigator;
+  });
+
+  it('returns an object that satisfies the SerialSession contract', () => {
+    const session: SerialSession = createSerialSession();
+
+    expect(typeof session.isBrowserSupported).toBe('function');
+    expect(typeof session.connect$).toBe('function');
+    expect(typeof session.disconnect$).toBe('function');
+    expect(typeof session.send$).toBe('function');
+    expect(session.state$).toBeDefined();
+    expect(session.errors$).toBeDefined();
+    expect(session.receive$).toBeDefined();
+  });
+
+  it('accepts SerialSessionOptions without throwing', () => {
+    expect(() =>
+      createSerialSession({ baudRate: 115200, bufferSize: 1024 }),
+    ).not.toThrow();
+  });
+
+  describe('isBrowserSupported', () => {
+    it('returns true when navigator.serial is present', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
+      (global as any).navigator = { serial: {} };
+
+      const session = createSerialSession();
+
+      expect(session.isBrowserSupported()).toBe(true);
+    });
+
+    it('returns false when navigator.serial is missing', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
+      (global as any).navigator = {};
+
+      const session = createSerialSession();
+
+      expect(session.isBrowserSupported()).toBe(false);
+    });
+
+    it('returns false when navigator is undefined', () => {
+      const session = createSerialSession();
+
+      expect(session.isBrowserSupported()).toBe(false);
+    });
+  });
+
+  describe('state$', () => {
+    it('replays the current idle state on subscribe', async () => {
+      const session = createSerialSession();
+
+      const state = await firstValueFrom(session.state$);
+
+      expect(state).toBe<SerialSessionState>('idle');
+    });
+
+    it('only emits idle in the skeleton implementation', async () => {
+      const session = createSerialSession();
+
+      const states = await lastValueFrom(
+        session.state$.pipe(take(1), toArray()),
+      );
+
+      expect(states).toEqual<SerialSessionState[]>(['idle']);
+    });
+  });
+
+  describe('not-yet-implemented runtime methods', () => {
+    const failsWithNotImplemented = async (
+      observable: ReturnType<SerialSession['connect$']>,
+    ) => {
+      await expect(firstValueFrom(observable)).rejects.toMatchObject({
+        name: 'SerialError',
+        code: SerialErrorCode.UNKNOWN,
+      });
+    };
+
+    it('connect$ fails with SerialErrorCode.UNKNOWN', async () => {
+      const session = createSerialSession();
+
+      await failsWithNotImplemented(session.connect$());
+    });
+
+    it('disconnect$ fails with SerialErrorCode.UNKNOWN', async () => {
+      const session = createSerialSession();
+
+      await failsWithNotImplemented(session.disconnect$());
+    });
+
+    it('send$ fails with SerialErrorCode.UNKNOWN for string payload', async () => {
+      const session = createSerialSession();
+
+      await failsWithNotImplemented(session.send$('ping\r\n'));
+    });
+
+    it('send$ fails with SerialErrorCode.UNKNOWN for bytes payload', async () => {
+      const session = createSerialSession();
+
+      await failsWithNotImplemented(session.send$(new Uint8Array([0x41])));
+    });
+
+    it('error is a SerialError instance', async () => {
+      const session = createSerialSession();
+
+      try {
+        await firstValueFrom(session.connect$());
+        expect.fail('Expected connect$ to error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(SerialError);
+        expect((error as SerialError).code).toBe(SerialErrorCode.UNKNOWN);
+        expect((error as SerialError).message).toContain('issues/199');
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary
<!--
日本語: 何を・なぜ変更したかを1〜3行で書いてください
English: Briefly describe what you changed and why (1–3 lines)
-->
- Issue #199（v2 API 再設計）の基盤となる `SerialSession` interface / `SerialSessionState` / `SerialSessionOptions` / `createSerialSession` を追加し、`packages/web-serial-rxjs/src/index.ts` から公開しました。
- 既存の v1 API（`SerialClient` / `createSerialClient` など）はそのまま維持する **additive な変更** です。read pump / send queue / state 遷移 / errors パイプラインといったランタイム実装は #199 の後続サブ Issue で段階的に導入します。

## Type of change
<!--
日本語: 該当するものにチェックを入れてください
English: Check the relevant items
-->
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
<!--
日本語: 関連する Issue があれば記載してください
English: Link related issues (use "Fixes #123" to auto-close)
-->
- Fixes #200
- Refs #199

## What changed?
<!--
日本語: 主な変更点を箇条書きで書いてください
English: List the main changes in bullet points
-->
- `packages/web-serial-rxjs/src/session/` を新設し、以下の 5 ファイルを追加しました。
  - `serial-session-state.ts`: `SerialSessionState`（`idle` / `connecting` / `connected` / `disconnecting` / `unsupported` / `error`）
  - `serial-session-options.ts`: `SerialSessionOptions`（v1 の `SerialClientOptions` を alias）
  - `serial-session.ts`: `SerialSession` interface（`isBrowserSupported` / `connect$` / `disconnect$` / `state$` / `errors$` / `receive$` / `send$`）
  - `create-serial-session.ts`: `createSerialSession` ファクトリ（型を安定させるためのスケルトン実装）
  - `index.ts`: バレル export
- `packages/web-serial-rxjs/src/index.ts` から v2 API を追加で export。
- `packages/web-serial-rxjs/tests/session/create-serial-session.test.ts` でシェイプ・`isBrowserSupported`・`state$` の `idle` 返却・未実装メソッドの失敗挙動を検証。

### スケルトンの現状挙動
- `isBrowserSupported()` は `hasWebSerialSupport()` を実装済み。
- `state$` は `'idle'` を replay します。
- `errors$` / `receive$` は空の Subject を公開します。
- `connect$()` / `disconnect$()` / `send$()` は `SerialErrorCode.UNKNOWN` で即時エラーを返し、メッセージで #199 の追跡先を案内します。

## API / Compatibility
<!--
日本語: 公開 API や互換性への影響があれば明記してください
English: Describe any impact on public APIs or compatibility
-->
- [x] Public API changes (export / function signature / behavior)
  - Details: v2 API として `createSerialSession` / `SerialSession` / `SerialSessionOptions` / `SerialSessionState` を **追加**。v1 API（`createSerialClient` 等）のシグネチャ・エクスポートは変更ありません。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: 本 PR では発生しません。#199 に沿った v1 削除は後続サブ Issue で計画します。

## How to test
<!--
日本語: 動作確認の手順を具体的に書いてください
English: Describe how reviewers can test this change
-->
1. `pnpm install`
2. `pnpm nx run web-serial-rxjs:test` で 110 テストすべてがパスすることを確認（新規スケルトンテスト 12 件を含む）
3. `pnpm --filter @gurezo/web-serial-rxjs run build` を実行
4. `packages/web-serial-rxjs/dist/index.d.ts` に `createSerialSession` / `SerialSession` / `SerialSessionOptions` / `SerialSessionState` が export されていることを確認
5. `packages/web-serial-rxjs/dist/session/` 配下に v2 API の `.d.ts` が生成されていることを確認
6. `pnpm nx run web-serial-rxjs:lint` がエラーなし（warning のみ）であることを確認

## Environment (if relevant)
<!--
日本語: バグ修正・挙動変更の場合は記載してください
English: Required for bug fixes or behavior changes
-->
- Browser: 本 PR はランタイム挙動を伴わないため検証不要
- OS: macOS
- web-serial-rxjs version (for verification): 0.2.0 (branch HEAD)
- RxJS version: ^7.8.0

## Checklist
<!--
日本語: PR 作成前の確認事項です
English: Please confirm before submitting
-->
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API) — 本 PR は型定義とスケルトンのみのため該当せず
- [ ] I updated docs/README if needed — 公開 API の README 反映は後続サブ Issue（ランタイム実装時）でまとめて対応
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.) — 未実装メソッドは `SerialError(SerialErrorCode.UNKNOWN)` で明示的に失敗させています

Made with [Cursor](https://cursor.com)