### PR TITLE
refactor(web-serial-rxjs): SerialSession 内部 state machine を実装 (#201)

### DIFF
--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -1,16 +1,10 @@
-import {
-  BehaviorSubject,
-  Observable,
-  Subject,
-  defer,
-  throwError,
-} from 'rxjs';
+import { Observable, Subject, defer, throwError } from 'rxjs';
 import { hasWebSerialSupport } from '../browser/browser-detection';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import type { SerialSession } from './serial-session';
 import type { SerialSessionOptions } from './serial-session-options';
-import type { SerialSessionState } from './serial-session-state';
+import { SessionStateMachine } from './session-state-machine';
 
 const NOT_IMPLEMENTED_MESSAGE =
   'SerialSession runtime is not implemented yet. Tracked by the remaining sub-issues of https://github.com/gurezo/web-serial-rxjs/issues/199';
@@ -27,14 +21,17 @@ function notImplemented$(): Observable<never> {
 /**
  * Create a v2 {@link SerialSession}.
  *
- * This initial release establishes a stable public shape for the session
- * API. The runtime (read pump, send queue, error pipeline, state
- * transitions) is implemented in the remaining sub-issues of #199.
+ * This release wires the internal {@link SessionStateMachine} into the
+ * session skeleton so that `state$` accurately reflects environment
+ * support at construction time. The runtime (read pump, send queue,
+ * error pipeline, connect/disconnect transitions) is implemented in the
+ * remaining sub-issues of #199.
  *
  * Current behavior:
  *
  * - `isBrowserSupported()` returns whether `navigator.serial` is available.
- * - `state$` replays `'idle'` on subscribe.
+ * - `state$` replays `'unsupported'` when the Web Serial API is missing,
+ *   otherwise `'idle'`.
  * - `errors$` is an open stream with no default emissions.
  * - `receive$` is an open stream with no default emissions.
  * - `connect$()`, `disconnect$()`, and `send$()` fail with a `SerialError`
@@ -44,16 +41,17 @@ function notImplemented$(): Observable<never> {
  *   public signature stays stable when the runtime is implemented.
  * @returns A {@link SerialSession} instance.
  *
- * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/201 | Issue #201}
  */
 export function createSerialSession(
   _options?: SerialSessionOptions,
 ): SerialSession {
-  const stateSubject = new BehaviorSubject<SerialSessionState>('idle');
+  const supported = hasWebSerialSupport();
+  const machine = new SessionStateMachine(supported ? 'idle' : 'unsupported');
   const errorsSubject = new Subject<SerialError>();
   const receiveSubject = new Subject<string | Uint8Array>();
 
-  const state$ = stateSubject.asObservable();
   const errors$ = errorsSubject.asObservable();
   const receive$ = receiveSubject.asObservable();
 
@@ -70,7 +68,7 @@ export function createSerialSession(
     send$(_data: string | Uint8Array): Observable<void> {
       return notImplemented$();
     },
-    state$,
+    state$: machine.state$,
     errors$,
     receive$,
   };

--- a/packages/web-serial-rxjs/src/session/session-state-machine.ts
+++ b/packages/web-serial-rxjs/src/session/session-state-machine.ts
@@ -1,0 +1,121 @@
+import { BehaviorSubject, Observable } from 'rxjs';
+import type { SerialSessionState } from './serial-session-state';
+
+/**
+ * Allowed transitions for the internal SerialSession state machine.
+ *
+ * Keys are the source state, values are the set of states that the source
+ * is allowed to transition into. Transitions missing from this map are
+ * treated as invalid and silently rejected (with a `console.warn`) so that
+ * a logic bug in one sub-issue cannot corrupt `state$` for downstream
+ * consumers.
+ *
+ * Lifecycle model (matches {@link SerialSessionState}):
+ *
+ * ```
+ * idle -> connecting -> connected -> disconnecting -> idle
+ *                                                \-> error
+ * error -> idle            (reset / retry)
+ * unsupported              (terminal; entered only at construction time)
+ * ```
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/201 | Issue #201}
+ */
+const ALLOWED_TRANSITIONS: Readonly<
+  Record<SerialSessionState, readonly SerialSessionState[]>
+> = {
+  idle: ['connecting', 'error'],
+  connecting: ['connected', 'error', 'idle'],
+  connected: ['disconnecting', 'error'],
+  disconnecting: ['idle', 'error'],
+  error: ['idle', 'connecting'],
+  unsupported: [],
+};
+
+/**
+ * Internal state machine that backs {@link SerialSession.state$}.
+ *
+ * The machine is deliberately kept as an internal module (not exported
+ * from the package) because the public surface is only the Observable.
+ * Sub-issues of #199 (read pump / send queue / errors) drive transitions
+ * through the dedicated `to*` methods below instead of mutating a shared
+ * `BehaviorSubject` directly.
+ *
+ * Design notes:
+ *
+ * - Invalid transitions are silently rejected so that the `state$` stream
+ *   never emits a state that violates the lifecycle contract. A
+ *   `console.warn` is emitted in development builds to aid debugging.
+ * - `unsupported` is terminal: once entered (during construction when
+ *   `navigator.serial` is missing), the machine refuses every further
+ *   transition.
+ * - `state$` is derived from a {@link BehaviorSubject} so late subscribers
+ *   still receive the current state on subscription.
+ *
+ * @internal
+ */
+export class SessionStateMachine {
+  private readonly subject: BehaviorSubject<SerialSessionState>;
+
+  constructor(initial: SerialSessionState = 'idle') {
+    this.subject = new BehaviorSubject<SerialSessionState>(initial);
+  }
+
+  get current(): SerialSessionState {
+    return this.subject.getValue();
+  }
+
+  get state$(): Observable<SerialSessionState> {
+    return this.subject.asObservable();
+  }
+
+  toConnecting(): boolean {
+    return this.transition('connecting');
+  }
+
+  toConnected(): boolean {
+    return this.transition('connected');
+  }
+
+  toDisconnecting(): boolean {
+    return this.transition('disconnecting');
+  }
+
+  toIdle(): boolean {
+    return this.transition('idle');
+  }
+
+  toError(): boolean {
+    return this.transition('error');
+  }
+
+  toUnsupported(): boolean {
+    return this.transition('unsupported');
+  }
+
+  complete(): void {
+    this.subject.complete();
+  }
+
+  private transition(next: SerialSessionState): boolean {
+    const current = this.subject.getValue();
+
+    if (current === next) {
+      return false;
+    }
+
+    const allowed = ALLOWED_TRANSITIONS[current];
+    if (!allowed.includes(next)) {
+      if (typeof console !== 'undefined' && console.warn) {
+        console.warn(
+          `[web-serial-rxjs] Ignoring invalid SerialSession transition ${current} -> ${next}`,
+        );
+      }
+      return false;
+    }
+
+    this.subject.next(next);
+    return true;
+  }
+}

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -63,7 +63,10 @@ describe('createSerialSession (skeleton)', () => {
   });
 
   describe('state$', () => {
-    it('replays the current idle state on subscribe', async () => {
+    it('replays idle on subscribe when Web Serial API is available', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
+      (global as any).navigator = { serial: {} };
+
       const session = createSerialSession();
 
       const state = await firstValueFrom(session.state$);
@@ -71,7 +74,18 @@ describe('createSerialSession (skeleton)', () => {
       expect(state).toBe<SerialSessionState>('idle');
     });
 
-    it('only emits idle in the skeleton implementation', async () => {
+    it('replays unsupported when navigator.serial is missing', async () => {
+      const session = createSerialSession();
+
+      const state = await firstValueFrom(session.state$);
+
+      expect(state).toBe<SerialSessionState>('unsupported');
+    });
+
+    it('only emits the initial state in the skeleton implementation', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
+      (global as any).navigator = { serial: {} };
+
       const session = createSerialSession();
 
       const states = await lastValueFrom(

--- a/packages/web-serial-rxjs/tests/session/session-state-machine.test.ts
+++ b/packages/web-serial-rxjs/tests/session/session-state-machine.test.ts
@@ -1,0 +1,184 @@
+import { firstValueFrom, lastValueFrom, take, toArray } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SerialSessionState } from '../../src/session/serial-session-state';
+import { SessionStateMachine } from '../../src/session/session-state-machine';
+
+describe('SessionStateMachine', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('construction', () => {
+    it('starts in idle by default', () => {
+      const machine = new SessionStateMachine();
+
+      expect(machine.current).toBe<SerialSessionState>('idle');
+    });
+
+    it('honours an explicit initial state', () => {
+      const machine = new SessionStateMachine('unsupported');
+
+      expect(machine.current).toBe<SerialSessionState>('unsupported');
+    });
+  });
+
+  describe('state$', () => {
+    it('replays the current state on subscribe', async () => {
+      const machine = new SessionStateMachine();
+
+      const state = await firstValueFrom(machine.state$);
+
+      expect(state).toBe<SerialSessionState>('idle');
+    });
+
+    it('emits every valid transition in order', async () => {
+      const machine = new SessionStateMachine();
+
+      const collected = lastValueFrom(
+        machine.state$.pipe(take(5), toArray()),
+      );
+
+      machine.toConnecting();
+      machine.toConnected();
+      machine.toDisconnecting();
+      machine.toIdle();
+
+      await expect(collected).resolves.toEqual<SerialSessionState[]>([
+        'idle',
+        'connecting',
+        'connected',
+        'disconnecting',
+        'idle',
+      ]);
+    });
+  });
+
+  describe('happy path transitions', () => {
+    it('moves idle -> connecting -> connected -> disconnecting -> idle', () => {
+      const machine = new SessionStateMachine();
+
+      expect(machine.toConnecting()).toBe(true);
+      expect(machine.current).toBe<SerialSessionState>('connecting');
+
+      expect(machine.toConnected()).toBe(true);
+      expect(machine.current).toBe<SerialSessionState>('connected');
+
+      expect(machine.toDisconnecting()).toBe(true);
+      expect(machine.current).toBe<SerialSessionState>('disconnecting');
+
+      expect(machine.toIdle()).toBe(true);
+      expect(machine.current).toBe<SerialSessionState>('idle');
+    });
+  });
+
+  describe('error path', () => {
+    it('allows error from connecting, connected and disconnecting', () => {
+      const fromConnecting = new SessionStateMachine();
+      fromConnecting.toConnecting();
+      expect(fromConnecting.toError()).toBe(true);
+      expect(fromConnecting.current).toBe<SerialSessionState>('error');
+
+      const fromConnected = new SessionStateMachine();
+      fromConnected.toConnecting();
+      fromConnected.toConnected();
+      expect(fromConnected.toError()).toBe(true);
+      expect(fromConnected.current).toBe<SerialSessionState>('error');
+
+      const fromDisconnecting = new SessionStateMachine();
+      fromDisconnecting.toConnecting();
+      fromDisconnecting.toConnected();
+      fromDisconnecting.toDisconnecting();
+      expect(fromDisconnecting.toError()).toBe(true);
+      expect(fromDisconnecting.current).toBe<SerialSessionState>('error');
+    });
+
+    it('recovers from error back to idle and forward to connecting', () => {
+      const machine = new SessionStateMachine();
+      machine.toConnecting();
+      machine.toError();
+
+      expect(machine.toIdle()).toBe(true);
+      expect(machine.current).toBe<SerialSessionState>('idle');
+
+      machine.toConnecting();
+      machine.toError();
+      expect(machine.toConnecting()).toBe(true);
+      expect(machine.current).toBe<SerialSessionState>('connecting');
+    });
+  });
+
+  describe('invalid transitions', () => {
+    it('ignores idle -> connected and warns', () => {
+      const machine = new SessionStateMachine();
+
+      expect(machine.toConnected()).toBe(false);
+      expect(machine.current).toBe<SerialSessionState>('idle');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('ignores connected -> idle (must go through disconnecting)', () => {
+      const machine = new SessionStateMachine();
+      machine.toConnecting();
+      machine.toConnected();
+
+      expect(machine.toIdle()).toBe(false);
+      expect(machine.current).toBe<SerialSessionState>('connected');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns false and does not emit on same-state transition', async () => {
+      const machine = new SessionStateMachine();
+
+      expect(machine.toIdle()).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      const states = await lastValueFrom(
+        machine.state$.pipe(take(1), toArray()),
+      );
+      expect(states).toEqual<SerialSessionState[]>(['idle']);
+    });
+  });
+
+  describe('unsupported (terminal)', () => {
+    it('rejects every transition once entered via construction', () => {
+      const machine = new SessionStateMachine('unsupported');
+
+      expect(machine.toIdle()).toBe(false);
+      expect(machine.toConnecting()).toBe(false);
+      expect(machine.toConnected()).toBe(false);
+      expect(machine.toDisconnecting()).toBe(false);
+      expect(machine.toError()).toBe(false);
+      expect(machine.current).toBe<SerialSessionState>('unsupported');
+    });
+
+    it('cannot be entered from idle at runtime', () => {
+      const machine = new SessionStateMachine();
+
+      expect(machine.toUnsupported()).toBe(false);
+      expect(machine.current).toBe<SerialSessionState>('idle');
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('complete', () => {
+    it('completes the state$ stream', async () => {
+      const machine = new SessionStateMachine();
+
+      const collected = lastValueFrom(machine.state$.pipe(toArray()));
+
+      machine.toConnecting();
+      machine.complete();
+
+      await expect(collected).resolves.toEqual<SerialSessionState[]>([
+        'idle',
+        'connecting',
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Issue #199 の v2 API 再設計ロードマップの一環として、`SerialSession` の内部 state machine（`SessionStateMachine`）を追加し、`createSerialSession` の `state$` を駆動する唯一の情報源にしました。これにより、後続サブ Issue（#202〜#204）から安全に状態遷移を差し込める基盤が整います。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Refs #199
- Closes #201

## What changed?
- 新規 `packages/web-serial-rxjs/src/session/session-state-machine.ts` を追加し、`SerialSessionState` の許可される遷移を集中管理する `SessionStateMachine` クラスを実装（internal、公開 export はしない）。
- `state$` は `BehaviorSubject` を `asObservable()` で公開し、replay セマンティクスを保持。
- ハッピーパス `idle → connecting → connected → disconnecting → idle`、エラー分岐、`error → idle / connecting` の復帰経路を許可。`unsupported` は構築時のみ到達可能な terminal 状態として扱う。
- 不正な遷移は `console.warn` を出しつつサイレントに拒否（`state$` の契約を壊さないため）。
- `packages/web-serial-rxjs/src/session/create-serial-session.ts` を更新し、生成時に `hasWebSerialSupport()` が `false` であれば初期状態を `'unsupported'`、それ以外は `'idle'` に設定。
- `connect$ / disconnect$ / send$` は引き続き `notImplemented$()` を返しますが、machine の参照はクロージャで保持しているため、後続 Issue でそのまま遷移呼び出しを差し込めます。
- テスト追加: `packages/web-serial-rxjs/tests/session/session-state-machine.test.ts`（13 ケース）。
- テスト更新: `packages/web-serial-rxjs/tests/session/create-serial-session.test.ts` で `navigator.serial` 不在時に初期状態が `'unsupported'` になることを検証。

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: 公開 API（`SerialSession` インターフェース / `createSerialSession` シグネチャ / `SerialSessionOptions` / `SerialSessionState`）に変更はありません。`SessionStateMachine` は internal のため `src/index.ts` / `src/session/index.ts` からは export していません。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

振る舞い変更: `navigator.serial` が存在しない環境では `state$` の初期値がこれまでの `'idle'` から `'unsupported'` に変わります。Issue #199/#201 の仕様に沿った修正であり、apps 側の state 再構築ロジック削除（#205 以降）に向けた正しい挙動です。

## How to test
1. `pnpm install`
2. `pnpm nx run web-serial-rxjs:lint`
3. `pnpm nx run web-serial-rxjs:test`
4. 124 テスト全てがパスすることを確認（新規 13 テスト、更新 13 テストを含む）。

## Environment (if relevant)
- Browser: N/A（ユニットテストのみ、ブラウザ非依存）
- OS: macOS
- web-serial-rxjs version (for verification): main HEAD + 本 PR
- RxJS version: ワークスペース既定（`package.json` 参照）

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)

```mermaid
stateDiagram-v2
    [*] --> idle
    idle --> connecting: connect$()
    connecting --> connected: open成功
    connected --> disconnecting: disconnect$()
    disconnecting --> idle: close成功
    connecting --> error: open失敗
    connected --> error: read/write失敗
    disconnecting --> error: close失敗
    error --> idle: reset/再connect$
    [*] --> unsupported: navigator.serial 不在
    unsupported --> unsupported: no-op
```
