### PR TITLE
refactor(web-serial-rxjs): read pump を内部化し receive$ から受信できるようにする (#202)

### DIFF
--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -50,7 +50,7 @@ export function createSerialSession(
   const supported = hasWebSerialSupport();
   const machine = new SessionStateMachine(supported ? 'idle' : 'unsupported');
   const errorsSubject = new Subject<SerialError>();
-  const receiveSubject = new Subject<string | Uint8Array>();
+  const receiveSubject = new Subject<string>();
 
   const errors$ = errorsSubject.asObservable();
   const receive$ = receiveSubject.asObservable();

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -2,51 +2,74 @@ import { Observable, Subject, defer, throwError } from 'rxjs';
 import { hasWebSerialSupport } from '../browser/browser-detection';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
+import { buildRequestOptions } from '../filters/build-request-options';
+import { DEFAULT_SERIAL_CLIENT_OPTIONS } from '../types/options';
+import { createReadPump, type ReadPump } from './read-pump';
 import type { SerialSession } from './serial-session';
 import type { SerialSessionOptions } from './serial-session-options';
 import { SessionStateMachine } from './session-state-machine';
 
-const NOT_IMPLEMENTED_MESSAGE =
-  'SerialSession runtime is not implemented yet. Tracked by the remaining sub-issues of https://github.com/gurezo/web-serial-rxjs/issues/199';
+const SEND_NOT_IMPLEMENTED_MESSAGE =
+  'SerialSession.send$ is not implemented yet. Tracked by https://github.com/gurezo/web-serial-rxjs/issues/203';
 
-function notImplemented$(): Observable<never> {
+function sendNotImplemented$(): Observable<never> {
   return defer(() =>
     throwError(
       () =>
-        new SerialError(SerialErrorCode.UNKNOWN, NOT_IMPLEMENTED_MESSAGE),
+        new SerialError(SerialErrorCode.UNKNOWN, SEND_NOT_IMPLEMENTED_MESSAGE),
     ),
   );
+}
+
+function toError(error: unknown, code: SerialErrorCode, fallback: string): SerialError {
+  if (error instanceof SerialError) {
+    return error;
+  }
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return new SerialError(code, `${fallback}: ${cause.message}`, cause);
 }
 
 /**
  * Create a v2 {@link SerialSession}.
  *
- * This release wires the internal {@link SessionStateMachine} into the
- * session skeleton so that `state$` accurately reflects environment
- * support at construction time. The runtime (read pump, send queue,
- * error pipeline, connect/disconnect transitions) is implemented in the
- * remaining sub-issues of #199.
+ * This release wires the internal read pump (#202) into the session so that
+ * `connect$`, `disconnect$`, and `receive$` operate end-to-end. `send$`
+ * remains deferred to the follow-up send-queue sub-issue (#203) and fails
+ * with a `SerialError` carrying `SerialErrorCode.UNKNOWN` until then.
  *
- * Current behavior:
+ * Key behaviors:
  *
  * - `isBrowserSupported()` returns whether `navigator.serial` is available.
- * - `state$` replays `'unsupported'` when the Web Serial API is missing,
- *   otherwise `'idle'`.
- * - `errors$` is an open stream with no default emissions.
- * - `receive$` is an open stream with no default emissions.
- * - `connect$()`, `disconnect$()`, and `send$()` fail with a `SerialError`
- *   carrying `SerialErrorCode.UNKNOWN` until the runtime lands.
+ * - `state$` replays the current lifecycle state driven by
+ *   {@link SessionStateMachine}.
+ * - `connect$()` opens a user-selected port, starts the internal read pump,
+ *   and transitions `idle -> connecting -> connected`.
+ * - `disconnect$()` stops the read pump, closes the port, and transitions
+ *   `connected -> disconnecting -> idle`.
+ * - `receive$` emits UTF-8 decoded text chunks pushed by the pump. It is
+ *   **not** subscription-lazy - the pump is started by `connect$` and
+ *   decoded text is multicast to all subscribers; late subscribers see only
+ *   new data.
+ * - `errors$` multiplexes errors surfaced by `connect$` / `disconnect$` and
+ *   the read pump; those errors also drive `state$` to `'error'`.
  *
- * @param _options - Session options. Currently unused; retained so the
- *   public signature stays stable when the runtime is implemented.
+ * @param options - Session options. Only `filters` is consulted by
+ *   `connect$` today (forwarded to `navigator.serial.requestPort`); the
+ *   remaining fields are passed to `port.open` using defaults when omitted.
  * @returns A {@link SerialSession} instance.
  *
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
- * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/201 | Issue #201}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/202 | Issue #202}
  */
 export function createSerialSession(
-  _options?: SerialSessionOptions,
+  options?: SerialSessionOptions,
 ): SerialSession {
+  const resolvedOptions = {
+    ...DEFAULT_SERIAL_CLIENT_OPTIONS,
+    ...options,
+    filters: options?.filters,
+  };
+
   const supported = hasWebSerialSupport();
   const machine = new SessionStateMachine(supported ? 'idle' : 'unsupported');
   const errorsSubject = new Subject<SerialError>();
@@ -55,18 +78,193 @@ export function createSerialSession(
   const errors$ = errorsSubject.asObservable();
   const receive$ = receiveSubject.asObservable();
 
+  let activePort: SerialPort | null = null;
+  let activePump: ReadPump | null = null;
+
+  const teardownPump = async (): Promise<void> => {
+    const pump = activePump;
+    activePump = null;
+    if (pump) {
+      await pump.stop();
+    }
+  };
+
+  const closePortSafely = async (port: SerialPort | null): Promise<void> => {
+    if (!port) {
+      return;
+    }
+    try {
+      await port.close();
+    } catch {
+      // The read pump may already have errored the stream, which makes
+      // close() reject. We ignore it here because disconnect$ has a
+      // dedicated error path for close failures initiated by the user.
+    }
+  };
+
+  const emitPumpError = (error: SerialError): void => {
+    errorsSubject.next(error);
+    machine.toError();
+    // Fire and forget - we can't await inside a sync callback.
+    void teardownPump().then(() => closePortSafely(activePort)).then(() => {
+      activePort = null;
+    });
+  };
+
   return {
     isBrowserSupported(): boolean {
       return hasWebSerialSupport();
     },
     connect$(): Observable<void> {
-      return notImplemented$();
+      return new Observable<void>((subscriber) => {
+        if (!hasWebSerialSupport()) {
+          const error = new SerialError(
+            SerialErrorCode.BROWSER_NOT_SUPPORTED,
+            'Web Serial API is not supported in this environment',
+          );
+          errorsSubject.next(error);
+          subscriber.error(error);
+          return;
+        }
+
+        const current = machine.current;
+        if (current !== 'idle' && current !== 'error') {
+          const error = new SerialError(
+            SerialErrorCode.PORT_ALREADY_OPEN,
+            `Cannot connect while session state is '${current}'`,
+          );
+          errorsSubject.next(error);
+          subscriber.error(error);
+          return;
+        }
+
+        let cancelled = false;
+        machine.toConnecting();
+
+        const run = async (): Promise<void> => {
+          let selectedPort: SerialPort | null = null;
+          try {
+            selectedPort = await navigator.serial.requestPort(
+              buildRequestOptions(resolvedOptions),
+            );
+            await selectedPort.open({
+              baudRate: resolvedOptions.baudRate,
+              dataBits: resolvedOptions.dataBits,
+              stopBits: resolvedOptions.stopBits,
+              parity: resolvedOptions.parity,
+              bufferSize: resolvedOptions.bufferSize,
+              flowControl: resolvedOptions.flowControl,
+            });
+          } catch (error) {
+            if (selectedPort) {
+              await closePortSafely(selectedPort);
+            }
+            const serialError =
+              error instanceof DOMException && error.name === 'NotFoundError'
+                ? new SerialError(
+                    SerialErrorCode.OPERATION_CANCELLED,
+                    'Port selection was cancelled by the user',
+                    error,
+                  )
+                : toError(
+                    error,
+                    SerialErrorCode.PORT_OPEN_FAILED,
+                    'Failed to open port',
+                  );
+            errorsSubject.next(serialError);
+            machine.toError();
+            if (!cancelled) {
+              subscriber.error(serialError);
+            }
+            return;
+          }
+
+          if (cancelled) {
+            await closePortSafely(selectedPort);
+            return;
+          }
+
+          activePort = selectedPort;
+          activePump = createReadPump(selectedPort, {
+            onChunk: (text) => receiveSubject.next(text),
+            onError: (pumpError) => emitPumpError(pumpError),
+          });
+          activePump.start();
+          machine.toConnected();
+          subscriber.next();
+          subscriber.complete();
+        };
+
+        void run();
+
+        return () => {
+          cancelled = true;
+        };
+      });
     },
     disconnect$(): Observable<void> {
-      return notImplemented$();
+      return new Observable<void>((subscriber) => {
+        const current = machine.current;
+
+        if (current === 'idle' || current === 'unsupported') {
+          subscriber.next();
+          subscriber.complete();
+          return;
+        }
+
+        if (current !== 'connected' && current !== 'error') {
+          const error = new SerialError(
+            SerialErrorCode.PORT_NOT_OPEN,
+            `Cannot disconnect while session state is '${current}'`,
+          );
+          errorsSubject.next(error);
+          subscriber.error(error);
+          return;
+        }
+
+        machine.toDisconnecting();
+        const portToClose = activePort;
+
+        const run = async (): Promise<void> => {
+          try {
+            await teardownPump();
+            if (portToClose) {
+              try {
+                await portToClose.close();
+              } catch (error) {
+                const serialError = toError(
+                  error,
+                  SerialErrorCode.CONNECTION_LOST,
+                  'Failed to close port',
+                );
+                activePort = null;
+                errorsSubject.next(serialError);
+                machine.toError();
+                subscriber.error(serialError);
+                return;
+              }
+            }
+            activePort = null;
+            machine.toIdle();
+            subscriber.next();
+            subscriber.complete();
+          } catch (error) {
+            const serialError = toError(
+              error,
+              SerialErrorCode.UNKNOWN,
+              'Unexpected disconnect failure',
+            );
+            errorsSubject.next(serialError);
+            machine.toError();
+            subscriber.error(serialError);
+          }
+        };
+
+        void run();
+      });
     },
     send$(_data: string | Uint8Array): Observable<void> {
-      return notImplemented$();
+      return sendNotImplemented$();
     },
     state$: machine.state$,
     errors$,

--- a/packages/web-serial-rxjs/src/session/read-pump.ts
+++ b/packages/web-serial-rxjs/src/session/read-pump.ts
@@ -1,0 +1,179 @@
+import { SerialError } from '../errors/serial-error';
+import { SerialErrorCode } from '../errors/serial-error-code';
+
+/**
+ * Callback invoked for every decoded chunk the read pump produces.
+ *
+ * The text is decoded from the raw bytes using a shared `TextDecoder` with
+ * `{ stream: true }`, so multi-byte characters that straddle chunk
+ * boundaries are joined correctly before reaching the callback.
+ *
+ * @internal
+ */
+export type ReadPumpChunkHandler = (text: string) => void;
+
+/**
+ * Callback invoked when the read pump cannot continue.
+ *
+ * The provided error is always a {@link SerialError}; raw platform errors
+ * are normalized by the pump before they reach the caller so consumers only
+ * ever observe the library's error type.
+ *
+ * @internal
+ */
+export type ReadPumpErrorHandler = (error: SerialError) => void;
+
+/**
+ * Options accepted by {@link createReadPump}.
+ *
+ * @internal
+ */
+export interface ReadPumpOptions {
+  onChunk: ReadPumpChunkHandler;
+  onError: ReadPumpErrorHandler;
+}
+
+/**
+ * Handle returned by {@link createReadPump}.
+ *
+ * @internal
+ */
+export interface ReadPump {
+  /**
+   * Start reading from the associated `SerialPort.readable` stream.
+   *
+   * Subsequent calls are ignored while the pump is already running.
+   */
+  start(): void;
+  /**
+   * Stop the read loop and release the underlying reader lock.
+   *
+   * Safe to call multiple times or before `start()`.
+   */
+  stop(): Promise<void>;
+  /**
+   * `true` while the internal loop is actively reading.
+   */
+  readonly isRunning: boolean;
+}
+
+/**
+ * Create an internal read pump for a {@link SerialPort}.
+ *
+ * The pump is an implementation detail of the v2 `SerialSession` API: it
+ * owns a single `TextDecoder` (with `stream: true`), drives a
+ * `reader.read()` loop against `port.readable`, and forwards decoded text
+ * to the provided sink. It is **not** subscription-lazy - the `SerialSession`
+ * starts the pump as soon as `connect$` succeeds so that `receive$`
+ * subscribers never miss data because of subscription timing.
+ *
+ * Errors are normalized into {@link SerialError} with
+ * {@link SerialErrorCode.READ_FAILED} for read-side failures and
+ * {@link SerialErrorCode.CONNECTION_LOST} for missing readable streams, so
+ * the session can forward them to `errors$` without rewrapping.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/202 | Issue #202}
+ */
+export function createReadPump(
+  port: SerialPort,
+  { onChunk, onError }: ReadPumpOptions,
+): ReadPump {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let running = false;
+  let stopped = false;
+  const decoder = new TextDecoder(undefined, { fatal: false });
+
+  const normalizeError = (error: unknown, code: SerialErrorCode): SerialError => {
+    if (error instanceof SerialError) {
+      return error;
+    }
+    const cause = error instanceof Error ? error : new Error(String(error));
+    return new SerialError(code, `Read pump failed: ${cause.message}`, cause);
+  };
+
+  const releaseReader = (): void => {
+    if (!reader) {
+      return;
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // releaseLock may throw when the reader is already detached; ignore.
+    }
+    reader = null;
+  };
+
+  const pump = async (stream: ReadableStream<Uint8Array>): Promise<void> => {
+    reader = stream.getReader();
+    running = true;
+    try {
+      while (!stopped) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        if (value && value.byteLength > 0) {
+          const text = decoder.decode(value, { stream: true });
+          if (text.length > 0) {
+            onChunk(text);
+          }
+        }
+      }
+      if (!stopped) {
+        const tail = decoder.decode();
+        if (tail.length > 0) {
+          onChunk(tail);
+        }
+      }
+    } catch (error) {
+      if (!stopped) {
+        onError(normalizeError(error, SerialErrorCode.READ_FAILED));
+      }
+    } finally {
+      running = false;
+      releaseReader();
+    }
+  };
+
+  return {
+    start(): void {
+      if (running || stopped) {
+        return;
+      }
+      const stream = port.readable;
+      if (!stream) {
+        stopped = true;
+        onError(
+          new SerialError(
+            SerialErrorCode.CONNECTION_LOST,
+            'Read pump failed: port.readable is not available',
+          ),
+        );
+        return;
+      }
+      void pump(stream);
+    },
+    async stop(): Promise<void> {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      if (!reader) {
+        return;
+      }
+      try {
+        await reader.cancel();
+      } catch {
+        // Cancel can reject when the stream is already errored; ignore so
+        // the caller's disconnect flow is not derailed by a read failure.
+      } finally {
+        releaseReader();
+      }
+    },
+    get isRunning(): boolean {
+      return running;
+    },
+  };
+}

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -77,13 +77,15 @@ export interface SerialSession {
   readonly errors$: Observable<SerialError>;
 
   /**
-   * Incoming data from the serial port.
+   * Incoming data from the serial port as UTF-8 decoded text.
    *
-   * The stream is driven by the read pump started by `connect$`. It is
-   * **not** subscription-lazy: emissions happen regardless of whether a
-   * consumer is currently subscribed, so late subscribers see only new data.
+   * The stream is driven by the read pump started by `connect$` and is
+   * decoded internally with a streaming `TextDecoder`, so multi-byte
+   * characters split across chunks are joined correctly. It is **not**
+   * subscription-lazy: emissions happen regardless of whether a consumer
+   * is currently subscribed, so late subscribers see only new data.
    */
-  readonly receive$: Observable<string | Uint8Array>;
+  readonly receive$: Observable<string>;
 
   /**
    * Enqueue data for ordered transmission.

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -1,45 +1,121 @@
-import { firstValueFrom, lastValueFrom, take, toArray } from 'rxjs';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  firstValueFrom,
+  lastValueFrom,
+  take,
+  toArray,
+} from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialError } from '../../src/errors/serial-error';
 import { SerialErrorCode } from '../../src/errors/serial-error-code';
 import { createSerialSession } from '../../src/session/create-serial-session';
 import type { SerialSession } from '../../src/session/serial-session';
 import type { SerialSessionState } from '../../src/session/serial-session-state';
 
-describe('createSerialSession (skeleton)', () => {
-  const originalNavigator = global.navigator;
+type MockPort = {
+  readable: ReadableStream<Uint8Array> | null;
+  writable: WritableStream<Uint8Array> | null;
+  open: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+};
+
+type StreamHandle = {
+  stream: ReadableStream<Uint8Array>;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+};
+
+const makeStream = (): StreamHandle => {
+  let captured!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      captured = controller;
+    },
+  });
+  return { stream, controller: captured };
+};
+
+const makeMockPort = (
+  stream: ReadableStream<Uint8Array>,
+  close: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
+): MockPort => ({
+  readable: stream,
+  writable: null,
+  open: vi.fn().mockResolvedValue(undefined),
+  close,
+});
+
+const installNavigator = (port: MockPort): void => {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    writable: true,
+    value: {
+      serial: {
+        requestPort: vi.fn().mockResolvedValue(port),
+        getPorts: vi.fn().mockResolvedValue([]),
+      },
+    },
+  });
+};
+
+const installUnsupportedNavigator = (): void => {
+  Object.defineProperty(globalThis, 'navigator', {
+    configurable: true,
+    writable: true,
+    value: {},
+  });
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe('createSerialSession', () => {
+  const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+    globalThis,
+    'navigator',
+  );
 
   beforeEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Reset navigator for isolation
-    delete (global as any).navigator;
+    delete (globalThis as any).navigator;
   });
 
   afterEach(() => {
-    global.navigator = originalNavigator;
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(
+        globalThis,
+        'navigator',
+        originalNavigatorDescriptor,
+      );
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: cleanup mocked navigator
+    delete (globalThis as any).navigator;
   });
 
-  it('returns an object that satisfies the SerialSession contract', () => {
-    const session: SerialSession = createSerialSession();
+  describe('contract', () => {
+    it('returns an object that satisfies the SerialSession contract', () => {
+      const session: SerialSession = createSerialSession();
 
-    expect(typeof session.isBrowserSupported).toBe('function');
-    expect(typeof session.connect$).toBe('function');
-    expect(typeof session.disconnect$).toBe('function');
-    expect(typeof session.send$).toBe('function');
-    expect(session.state$).toBeDefined();
-    expect(session.errors$).toBeDefined();
-    expect(session.receive$).toBeDefined();
-  });
+      expect(typeof session.isBrowserSupported).toBe('function');
+      expect(typeof session.connect$).toBe('function');
+      expect(typeof session.disconnect$).toBe('function');
+      expect(typeof session.send$).toBe('function');
+      expect(session.state$).toBeDefined();
+      expect(session.errors$).toBeDefined();
+      expect(session.receive$).toBeDefined();
+    });
 
-  it('accepts SerialSessionOptions without throwing', () => {
-    expect(() =>
-      createSerialSession({ baudRate: 115200, bufferSize: 1024 }),
-    ).not.toThrow();
+    it('accepts SerialSessionOptions without throwing', () => {
+      expect(() =>
+        createSerialSession({ baudRate: 115200, bufferSize: 1024 }),
+      ).not.toThrow();
+    });
   });
 
   describe('isBrowserSupported', () => {
     it('returns true when navigator.serial is present', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
-      (global as any).navigator = { serial: {} };
+      (globalThis as any).navigator = { serial: {} };
 
       const session = createSerialSession();
 
@@ -47,8 +123,7 @@ describe('createSerialSession (skeleton)', () => {
     });
 
     it('returns false when navigator.serial is missing', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
-      (global as any).navigator = {};
+      installUnsupportedNavigator();
 
       const session = createSerialSession();
 
@@ -65,7 +140,7 @@ describe('createSerialSession (skeleton)', () => {
   describe('state$', () => {
     it('replays idle on subscribe when Web Serial API is available', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
-      (global as any).navigator = { serial: {} };
+      (globalThis as any).navigator = { serial: {} };
 
       const session = createSerialSession();
 
@@ -81,24 +156,180 @@ describe('createSerialSession (skeleton)', () => {
 
       expect(state).toBe<SerialSessionState>('unsupported');
     });
+  });
 
-    it('only emits the initial state in the skeleton implementation', async () => {
+  describe('connect$ and disconnect$', () => {
+    it('transitions idle -> connecting -> connected on successful connect', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession({ baudRate: 115200 });
+      const statesPromise = lastValueFrom(
+        session.state$.pipe(take(3), toArray()),
+      );
+
+      await firstValueFrom(session.connect$());
+
+      const states = await statesPromise;
+      expect(states).toEqual<SerialSessionState[]>([
+        'idle',
+        'connecting',
+        'connected',
+      ]);
+      expect(port.open).toHaveBeenCalledTimes(1);
+      expect(port.open).toHaveBeenCalledWith(
+        expect.objectContaining({ baudRate: 115200 }),
+      );
+    });
+
+    it('maps user-cancelled requestPort DOMException to OPERATION_CANCELLED and state -> error', async () => {
+      const requestPort = vi
+        .fn()
+        .mockRejectedValue(new DOMException('user cancel', 'NotFoundError'));
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        writable: true,
+        value: { serial: { requestPort, getPorts: vi.fn() } },
+      });
+
+      const session = createSerialSession();
+      const errorsPromise = firstValueFrom(session.errors$);
+
+      await expect(firstValueFrom(session.connect$())).rejects.toBeInstanceOf(
+        SerialError,
+      );
+
+      const emitted = await errorsPromise;
+      expect(emitted).toBeInstanceOf(SerialError);
+      expect(emitted.code).toBe(SerialErrorCode.OPERATION_CANCELLED);
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
+        'error',
+      );
+    });
+
+    it('maps generic port.open failure to PORT_OPEN_FAILED', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+      port.open.mockRejectedValueOnce(new Error('cannot open'));
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const errorsPromise = firstValueFrom(session.errors$);
+
+      await expect(firstValueFrom(session.connect$())).rejects.toMatchObject({
+        name: 'SerialError',
+        code: SerialErrorCode.PORT_OPEN_FAILED,
+      });
+
+      const emitted = await errorsPromise;
+      expect(emitted.code).toBe(SerialErrorCode.PORT_OPEN_FAILED);
+    });
+
+    it('rejects connect$ with BROWSER_NOT_SUPPORTED when navigator.serial is missing', async () => {
+      const session = createSerialSession();
+
+      await expect(
+        firstValueFrom(session.connect$()),
+      ).rejects.toMatchObject({
+        name: 'SerialError',
+        code: SerialErrorCode.BROWSER_NOT_SUPPORTED,
+      });
+    });
+
+    it('disconnect$ completes immediately when state is idle', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
-      (global as any).navigator = { serial: {} };
+      (globalThis as any).navigator = { serial: {} };
 
       const session = createSerialSession();
 
-      const states = await lastValueFrom(
-        session.state$.pipe(take(1), toArray()),
+      await expect(firstValueFrom(session.disconnect$())).resolves.toBeUndefined();
+    });
+
+    it('transitions connected -> disconnecting -> idle on disconnect$ and closes the port', async () => {
+      const { stream } = makeStream();
+      const close = vi.fn().mockResolvedValue(undefined);
+      const port = makeMockPort(stream, close);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const statesPromise = lastValueFrom(
+        session.state$.pipe(take(3), toArray()),
       );
 
-      expect(states).toEqual<SerialSessionState[]>(['idle']);
+      await firstValueFrom(session.disconnect$());
+
+      const states = await statesPromise;
+      expect(states).toEqual<SerialSessionState[]>([
+        'connected',
+        'disconnecting',
+        'idle',
+      ]);
+      expect(close).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('not-yet-implemented runtime methods', () => {
+  describe('receive$', () => {
+    it('emits decoded UTF-8 text chunks after connect$', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const receivedPromise = firstValueFrom(
+        session.receive$.pipe(take(1)),
+      );
+
+      await firstValueFrom(session.connect$());
+      controller.enqueue(new TextEncoder().encode('hello'));
+
+      await expect(receivedPromise).resolves.toBe('hello');
+    });
+
+    it('delivers subsequent chunks to late subscribers as strings', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      controller.enqueue(new TextEncoder().encode('early'));
+      await flushMicrotasks();
+
+      const lateArrival = firstValueFrom(session.receive$.pipe(take(1)));
+      controller.enqueue(new TextEncoder().encode('late'));
+
+      await expect(lateArrival).resolves.toBe('late');
+    });
+
+    it('routes pump errors to errors$ and moves state$ to error', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const errorPromise = firstValueFrom(session.errors$);
+      controller.error(new Error('device unplugged'));
+
+      const received = await errorPromise;
+      expect(received).toBeInstanceOf(SerialError);
+      expect(received.code).toBe(SerialErrorCode.READ_FAILED);
+
+      await flushMicrotasks();
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
+        'error',
+      );
+    });
+  });
+
+  describe('send$ (not implemented)', () => {
     const failsWithNotImplemented = async (
-      observable: ReturnType<SerialSession['connect$']>,
+      observable: ReturnType<SerialSession['send$']>,
     ) => {
       await expect(firstValueFrom(observable)).rejects.toMatchObject({
         name: 'SerialError',
@@ -106,40 +337,22 @@ describe('createSerialSession (skeleton)', () => {
       });
     };
 
-    it('connect$ fails with SerialErrorCode.UNKNOWN', async () => {
-      const session = createSerialSession();
-
-      await failsWithNotImplemented(session.connect$());
-    });
-
-    it('disconnect$ fails with SerialErrorCode.UNKNOWN', async () => {
-      const session = createSerialSession();
-
-      await failsWithNotImplemented(session.disconnect$());
-    });
-
-    it('send$ fails with SerialErrorCode.UNKNOWN for string payload', async () => {
+    it('fails with SerialErrorCode.UNKNOWN for string payload', async () => {
       const session = createSerialSession();
 
       await failsWithNotImplemented(session.send$('ping\r\n'));
     });
 
-    it('send$ fails with SerialErrorCode.UNKNOWN for bytes payload', async () => {
-      const session = createSerialSession();
-
-      await failsWithNotImplemented(session.send$(new Uint8Array([0x41])));
-    });
-
-    it('error is a SerialError instance', async () => {
+    it('fails with SerialErrorCode.UNKNOWN for bytes payload and references #203', async () => {
       const session = createSerialSession();
 
       try {
-        await firstValueFrom(session.connect$());
-        expect.fail('Expected connect$ to error');
+        await firstValueFrom(session.send$(new Uint8Array([0x41])));
+        expect.fail('Expected send$ to error');
       } catch (error) {
         expect(error).toBeInstanceOf(SerialError);
         expect((error as SerialError).code).toBe(SerialErrorCode.UNKNOWN);
-        expect((error as SerialError).message).toContain('issues/199');
+        expect((error as SerialError).message).toContain('issues/203');
       }
     });
   });

--- a/packages/web-serial-rxjs/tests/session/read-pump.test.ts
+++ b/packages/web-serial-rxjs/tests/session/read-pump.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { createReadPump } from '../../src/session/read-pump';
+
+type StreamHandle = {
+  stream: ReadableStream<Uint8Array>;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+};
+
+const makeStream = (): StreamHandle => {
+  let captured!: ReadableStreamDefaultController<Uint8Array>;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      captured = controller;
+    },
+  });
+  return { stream, controller: captured };
+};
+
+const makePort = (
+  overrides: Partial<SerialPort> & {
+    readable?: ReadableStream<Uint8Array> | null;
+  } = {},
+): SerialPort => {
+  const { readable = null, ...rest } = overrides;
+  return {
+    readable,
+    writable: null,
+    ...rest,
+  } as unknown as SerialPort;
+};
+
+const flushMicrotasks = async (): Promise<void> => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+describe('createReadPump', () => {
+  it('decodes enqueued chunks to strings and forwards them to onChunk', async () => {
+    const { stream, controller } = makeStream();
+    const port = makePort({ readable: stream });
+    const chunks: string[] = [];
+    const onError = vi.fn();
+
+    const pump = createReadPump(port, {
+      onChunk: (text) => chunks.push(text),
+      onError,
+    });
+    pump.start();
+
+    controller.enqueue(new TextEncoder().encode('hello'));
+    controller.enqueue(new TextEncoder().encode(' world'));
+    await flushMicrotasks();
+
+    expect(chunks).toEqual(['hello', ' world']);
+    expect(onError).not.toHaveBeenCalled();
+    expect(pump.isRunning).toBe(true);
+
+    await pump.stop();
+  });
+
+  it('joins multi-byte characters split across chunk boundaries', async () => {
+    const { stream, controller } = makeStream();
+    const port = makePort({ readable: stream });
+    const chunks: string[] = [];
+
+    const pump = createReadPump(port, {
+      onChunk: (text) => chunks.push(text),
+      onError: vi.fn(),
+    });
+    pump.start();
+
+    const encoded = new TextEncoder().encode('あ');
+    controller.enqueue(encoded.slice(0, 1));
+    await flushMicrotasks();
+    controller.enqueue(encoded.slice(1));
+    await flushMicrotasks();
+
+    expect(chunks.join('')).toBe('あ');
+
+    await pump.stop();
+  });
+
+  it('emits a READ_FAILED SerialError to onError when the stream errors', async () => {
+    const { stream, controller } = makeStream();
+    const port = makePort({ readable: stream });
+    const onError = vi.fn<(error: SerialError) => void>();
+
+    const pump = createReadPump(port, {
+      onChunk: vi.fn(),
+      onError,
+    });
+    pump.start();
+
+    controller.error(new Error('boom'));
+    await flushMicrotasks();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const received = onError.mock.calls[0][0];
+    expect(received).toBeInstanceOf(SerialError);
+    expect(received.code).toBe(SerialErrorCode.READ_FAILED);
+    expect(received.message).toContain('boom');
+    expect(pump.isRunning).toBe(false);
+  });
+
+  it('emits a CONNECTION_LOST SerialError when port.readable is null', () => {
+    const port = makePort({ readable: null });
+    const onError = vi.fn<(error: SerialError) => void>();
+
+    const pump = createReadPump(port, {
+      onChunk: vi.fn(),
+      onError,
+    });
+    pump.start();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    const received = onError.mock.calls[0][0];
+    expect(received).toBeInstanceOf(SerialError);
+    expect(received.code).toBe(SerialErrorCode.CONNECTION_LOST);
+    expect(pump.isRunning).toBe(false);
+  });
+
+  it('stop() cancels the reader and suppresses further onError emissions', async () => {
+    const { stream, controller } = makeStream();
+    const port = makePort({ readable: stream });
+    const onError = vi.fn();
+    const chunks: string[] = [];
+
+    const pump = createReadPump(port, {
+      onChunk: (text) => chunks.push(text),
+      onError,
+    });
+    pump.start();
+    controller.enqueue(new TextEncoder().encode('before-stop'));
+    await flushMicrotasks();
+
+    await pump.stop();
+
+    expect(pump.isRunning).toBe(false);
+    expect(() => controller.enqueue(new TextEncoder().encode('after-stop'))).toThrow();
+    expect(chunks).toEqual(['before-stop']);
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('start() is a no-op when the pump has already been stopped', async () => {
+    const { stream } = makeStream();
+    const port = makePort({ readable: stream });
+
+    const pump = createReadPump(port, {
+      onChunk: vi.fn(),
+      onError: vi.fn(),
+    });
+
+    await pump.stop();
+    pump.start();
+
+    expect(pump.isRunning).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #199（v2 API 再設計）のサブ issue である #202 に対応し、SerialSession の read pump を内部化して `receive$` のみで受信できるようにします。あわせて `connect$` / `disconnect$` を最小実装し、`receive$` の型を `Observable<string | Uint8Array>` → `Observable<string>` に絞りました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

補足: 内部化と型絞り込みが主目的のため Refactor にチェック。`connect$` / `disconnect$` / `receive$` が「未実装」→「稼働」になる面は機能追加の側面も含みます。

## Related issues

- Fixes #202
- Refs #199

## What changed?

- `SerialSession.receive$` の型を `Observable<string>` に絞り、TextDecoder 内部化により UTF-8 デコード済み文字列のみ emit することを型でも表明
- `packages/web-serial-rxjs/src/session/read-pump.ts` を新規追加
  - `createReadPump(port, { onChunk, onError })` で `reader.read()` ループと `TextDecoder({ stream: true })` を内部化
  - 読み取りエラーは `SerialError`（`READ_FAILED` / `CONNECTION_LOST`）に正規化して `onError` へ通知
  - `start()` / `stop()` / `isRunning` を提供し、`stop()` で reader を `cancel()` + `releaseLock()`
- `createSerialSession` の `connect$` / `disconnect$` を最小実装
  - `connect$`: `navigator.serial.requestPort` → `port.open` → pump 起動 → 状態 `idle → connecting → connected`
  - `disconnect$`: pump 停止 → `port.close` → 状態 `connected → disconnecting → idle`
  - 失敗時は `errors$` に `SerialError` を流し、状態を `error` に遷移
  - pump からの受信エラーも同様に `errors$` と `state$` に反映
- `send$` は引き続き未実装（`SerialErrorCode.UNKNOWN`）。参照先メッセージを #203 に更新
- テストを刷新
  - `tests/session/read-pump.test.ts` を新規追加（チャンク分割、マルチバイト境界、エラー、stop 挙動）
  - `tests/session/create-serial-session.test.ts` を現行挙動に合わせて全面更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details:
    - `SerialSession.receive$` の型を `Observable<string | Uint8Array>` → `Observable<string>` に絞り込み（union の狭め込み。TextDecoder 内部化で受信は UTF-8 文字列のみになるため型も一致させる）
    - `createSerialSession` の `connect$` / `disconnect$` / `receive$` が skeleton 実装の `notImplemented$` から実稼働に変わる（挙動の有効化）
- [x] This change is backward compatible
  - v1 の `createSerialClient` / `SerialClient` 公開 API には影響なし
  - v2 API はまだ安定化中（#199 のロールアウト中）の additive API であり、型の絞り込み・未実装から実装への移行は下位互換的変更
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm nx test web-serial-rxjs`
2. `pnpm nx lint web-serial-rxjs`
3. `pnpm nx build web-serial-rxjs`
4. Chromium 系ブラウザの実機確認（任意）:
   - `createSerialSession({ baudRate: 115200 })` → `session.connect$().subscribe()`
   - `session.receive$.subscribe(console.log)` に対して、接続後のデータが UTF-8 文字列として流れてくることを確認
   - デバイス抜去時に `session.errors$` に `SerialError`（`READ_FAILED`）が流れ、`session.state$` が `error` に遷移することを確認
   - `session.disconnect$().subscribe()` で `connected → disconnecting → idle` に遷移することを確認

## Environment (if relevant)

- Browser: Chrome / Edge / Opera（Web Serial API 対応の Chromium 系）
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): v2 系（#199 対応ブランチ）
- RxJS version: プロジェクトの pnpm-lock.yaml に準拠

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed（TSDoc を更新。ユーザー向け README/Docs 更新は #207 側スコープ）
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)

```mermaid
stateDiagram-v2
    [*] --> idle
    idle --> connecting: connect$
    connecting --> connected: port.open ok + pump start
    connecting --> error: open fail
    connected --> disconnecting: disconnect$
    connected --> error: read pump fail
    disconnecting --> idle: close ok
    disconnecting --> error: close fail
    error --> idle: reset
```
