### PR TITLE
refactor(web-serial-rxjs): send キュー内部化で SerialSession.send$ を実働化 (#203)

### DIFF
--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -1,25 +1,14 @@
-import { Observable, Subject, defer, throwError } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { hasWebSerialSupport } from '../browser/browser-detection';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import { buildRequestOptions } from '../filters/build-request-options';
 import { DEFAULT_SERIAL_CLIENT_OPTIONS } from '../types/options';
 import { createReadPump, type ReadPump } from './read-pump';
+import { createSendQueue } from './send-queue';
 import type { SerialSession } from './serial-session';
 import type { SerialSessionOptions } from './serial-session-options';
 import { SessionStateMachine } from './session-state-machine';
-
-const SEND_NOT_IMPLEMENTED_MESSAGE =
-  'SerialSession.send$ is not implemented yet. Tracked by https://github.com/gurezo/web-serial-rxjs/issues/203';
-
-function sendNotImplemented$(): Observable<never> {
-  return defer(() =>
-    throwError(
-      () =>
-        new SerialError(SerialErrorCode.UNKNOWN, SEND_NOT_IMPLEMENTED_MESSAGE),
-    ),
-  );
-}
 
 function toError(error: unknown, code: SerialErrorCode, fallback: string): SerialError {
   if (error instanceof SerialError) {
@@ -32,10 +21,9 @@ function toError(error: unknown, code: SerialErrorCode, fallback: string): Seria
 /**
  * Create a v2 {@link SerialSession}.
  *
- * This release wires the internal read pump (#202) into the session so that
- * `connect$`, `disconnect$`, and `receive$` operate end-to-end. `send$`
- * remains deferred to the follow-up send-queue sub-issue (#203) and fails
- * with a `SerialError` carrying `SerialErrorCode.UNKNOWN` until then.
+ * This release wires the internal read pump (#202) and the internal send
+ * queue (#203) into the session so that `connect$`, `disconnect$`,
+ * `receive$`, and `send$` all operate end-to-end.
  *
  * Key behaviors:
  *
@@ -50,8 +38,14 @@ function toError(error: unknown, code: SerialErrorCode, fallback: string): Seria
  *   **not** subscription-lazy - the pump is started by `connect$` and
  *   decoded text is multicast to all subscribers; late subscribers see only
  *   new data.
- * - `errors$` multiplexes errors surfaced by `connect$` / `disconnect$` and
- *   the read pump; those errors also drive `state$` to `'error'`.
+ * - `send$` enqueues each payload on an internal FIFO queue so concurrent
+ *   subscribers are written to the port in call order. String payloads are
+ *   UTF-8 encoded through a shared `TextEncoder`.
+ * - `errors$` multiplexes errors surfaced by `connect$` / `disconnect$`,
+ *   the read pump, and `send$`. Connect / read failures also drive
+ *   `state$` to `'error'`; write failures do not mutate `state$` because
+ *   a real connection loss will be detected by the read pump on the next
+ *   tick anyway.
  *
  * @param options - Session options. Only `filters` is consulted by
  *   `connect$` today (forwarded to `navigator.serial.requestPort`); the
@@ -60,6 +54,7 @@ function toError(error: unknown, code: SerialErrorCode, fallback: string): Seria
  *
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/202 | Issue #202}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/203 | Issue #203}
  */
 export function createSerialSession(
   options?: SerialSessionOptions,
@@ -74,6 +69,8 @@ export function createSerialSession(
   const machine = new SessionStateMachine(supported ? 'idle' : 'unsupported');
   const errorsSubject = new Subject<SerialError>();
   const receiveSubject = new Subject<string>();
+  const sendQueue = createSendQueue();
+  const textEncoder = new TextEncoder();
 
   const errors$ = errorsSubject.asObservable();
   const receive$ = receiveSubject.asObservable();
@@ -105,10 +102,33 @@ export function createSerialSession(
   const emitPumpError = (error: SerialError): void => {
     errorsSubject.next(error);
     machine.toError();
+    sendQueue.clear();
     // Fire and forget - we can't await inside a sync callback.
     void teardownPump().then(() => closePortSafely(activePort)).then(() => {
       activePort = null;
     });
+  };
+
+  const writeToPort = async (payload: Uint8Array): Promise<void> => {
+    const port = activePort;
+    if (machine.current !== 'connected' || !port || !port.writable) {
+      throw new SerialError(
+        SerialErrorCode.PORT_NOT_OPEN,
+        'Cannot send data while session is not connected',
+      );
+    }
+    const writer = port.writable.getWriter();
+    try {
+      await writer.write(payload);
+    } finally {
+      try {
+        writer.releaseLock();
+      } catch {
+        // releaseLock throws when the stream is already errored; the real
+        // failure is surfaced through the write() rejection above so we
+        // intentionally swallow this secondary error.
+      }
+    }
   };
 
   return {
@@ -190,6 +210,7 @@ export function createSerialSession(
             onError: (pumpError) => emitPumpError(pumpError),
           });
           activePump.start();
+          sendQueue.clear();
           machine.toConnected();
           subscriber.next();
           subscriber.complete();
@@ -223,6 +244,7 @@ export function createSerialSession(
         }
 
         machine.toDisconnecting();
+        sendQueue.clear();
         const portToClose = activePort;
 
         const run = async (): Promise<void> => {
@@ -263,8 +285,21 @@ export function createSerialSession(
         void run();
       });
     },
-    send$(_data: string | Uint8Array): Observable<void> {
-      return sendNotImplemented$();
+    send$(data: string | Uint8Array): Observable<void> {
+      return sendQueue.enqueue(async () => {
+        const payload =
+          typeof data === 'string' ? textEncoder.encode(data) : data;
+        try {
+          await writeToPort(payload);
+        } catch (error) {
+          const serialError =
+            error instanceof SerialError
+              ? error
+              : toError(error, SerialErrorCode.WRITE_FAILED, 'Failed to write data');
+          errorsSubject.next(serialError);
+          throw serialError;
+        }
+      });
     },
     state$: machine.state$,
     errors$,

--- a/packages/web-serial-rxjs/src/session/send-queue.ts
+++ b/packages/web-serial-rxjs/src/session/send-queue.ts
@@ -1,0 +1,100 @@
+import { Observable, defer } from 'rxjs';
+
+/**
+ * A single enqueued unit of work. Operations are awaited sequentially so
+ * that `send$` guarantees call order even when the caller fires multiple
+ * observables concurrently.
+ *
+ * @internal
+ */
+export type SendQueueOperation<T> = () => Promise<T>;
+
+/**
+ * Internal helper returned by {@link createSendQueue}.
+ *
+ * The queue is intentionally not an RxJS operator because Issue #199 calls
+ * out explicitly that `send$` must not be re-implemented with `mergeMap`
+ * (or any other concurrency-altering operator). A chained `Promise<void>`
+ * is the simplest way to guarantee strict FIFO ordering while still
+ * surfacing per-operation completion back to the caller.
+ *
+ * @internal
+ */
+export interface SendQueue {
+  /**
+   * Schedule an operation to run after all previously enqueued operations
+   * have settled (resolved or rejected). The returned Observable completes
+   * with the operation's resolved value, or errors with its rejection.
+   *
+   * Subscribing is what actually schedules the work - the queue is driven
+   * by `defer`, so late/never-subscribed Observables never enqueue.
+   */
+  enqueue<T>(operation: SendQueueOperation<T>): Observable<T>;
+  /**
+   * Reset the internal promise chain. Existing in-flight operations keep
+   * running because we do not cancel native promises, but no newly
+   * enqueued work will wait for them. Use this when the session is torn
+   * down so a fresh `connect$` starts with a clean chain.
+   */
+  clear(): void;
+}
+
+/**
+ * Create an internal send queue that serialises `send$` writes.
+ *
+ * Ordering model:
+ *
+ * - Each `enqueue` call appends its operation to a single `Promise<void>`
+ *   chain.
+ * - A failure in one operation does not poison the chain - the next
+ *   operation still runs (the chain is advanced with a `.then(() => {},
+ *   () => {})` safety tail).
+ * - Unsubscribing before the operation resolves suppresses `next` /
+ *   `complete` / `error` for that subscriber; the underlying promise is
+ *   still awaited so later operations continue to respect call order.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/203 | Issue #203}
+ */
+export function createSendQueue(): SendQueue {
+  let chain: Promise<void> = Promise.resolve();
+
+  return {
+    enqueue<T>(operation: SendQueueOperation<T>): Observable<T> {
+      return defer(
+        () =>
+          new Observable<T>((subscriber) => {
+            let cancelled = false;
+
+            const run = async (): Promise<void> => {
+              try {
+                const value = await operation();
+                if (!cancelled) {
+                  subscriber.next(value);
+                  subscriber.complete();
+                }
+              } catch (error) {
+                if (!cancelled) {
+                  subscriber.error(error);
+                }
+              }
+            };
+
+            const scheduled = chain.then(run, run);
+            chain = scheduled.then(
+              () => undefined,
+              () => undefined,
+            );
+
+            return () => {
+              cancelled = true;
+            };
+          }),
+      );
+    },
+    clear(): void {
+      chain = Promise.resolve();
+    },
+  };
+}

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -28,6 +28,7 @@ import type { SerialSessionState } from './serial-session-state';
  *
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/203 | Issue #203}
  */
 export interface SerialSession {
   /**
@@ -90,12 +91,25 @@ export interface SerialSession {
   /**
    * Enqueue data for ordered transmission.
    *
-   * Writes are serialized internally so that concurrent `send$` calls are
-   * delivered to the port in call order. The returned Observable completes
-   * once the enqueued payload has been flushed.
+   * Writes are serialized internally through a FIFO send queue so that
+   * concurrent `send$` calls are delivered to the port in **call order**,
+   * regardless of how quickly each subscriber runs. String payloads are
+   * UTF-8 encoded via a shared `TextEncoder`; `Uint8Array` payloads are
+   * passed through unchanged. Write failures are normalized into
+   * {@link SerialError} with {@link SerialErrorCode.WRITE_FAILED} and
+   * multiplexed on {@link SerialSession.errors$} in addition to being
+   * surfaced to the subscriber, so a single subscription is enough to
+   * observe every I/O error. Calling `send$` while the session is not in
+   * `'connected'` state fails fast with
+   * {@link SerialErrorCode.PORT_NOT_OPEN}.
+   *
+   * The returned Observable completes once the enqueued payload has been
+   * flushed to the underlying writer.
    *
    * @param data - Text (UTF-8 encoded) or raw bytes to send.
    * @returns An Observable that completes when the payload is written.
+   *
+   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/203 | Issue #203}
    */
   send$(data: string | Uint8Array): Observable<void>;
 }

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -36,12 +36,31 @@ const makeStream = (): StreamHandle => {
 const makeMockPort = (
   stream: ReadableStream<Uint8Array>,
   close: ReturnType<typeof vi.fn> = vi.fn().mockResolvedValue(undefined),
+  writable: WritableStream<Uint8Array> | null = null,
 ): MockPort => ({
   readable: stream,
-  writable: null,
+  writable,
   open: vi.fn().mockResolvedValue(undefined),
   close,
 });
+
+type WritableHarness = {
+  stream: WritableStream<Uint8Array>;
+  writes: Uint8Array[];
+};
+
+const makeRecordingWritable = (
+  onChunk?: (chunk: Uint8Array) => Promise<void> | void,
+): WritableHarness => {
+  const writes: Uint8Array[] = [];
+  const stream = new WritableStream<Uint8Array>({
+    async write(chunk) {
+      writes.push(chunk);
+      await onChunk?.(chunk);
+    },
+  });
+  return { stream, writes };
+};
 
 const installNavigator = (port: MockPort): void => {
   Object.defineProperty(globalThis, 'navigator', {
@@ -340,6 +359,98 @@ describe('createSerialSession', () => {
         name: 'SerialError',
         code: SerialErrorCode.PORT_NOT_OPEN,
       });
+    });
+
+    it('encodes string payloads as UTF-8 and writes them through the port writer', async () => {
+      const { stream } = makeStream();
+      const { stream: writable, writes } = makeRecordingWritable();
+      const port = makeMockPort(stream, undefined, writable);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      await firstValueFrom(session.send$('ping\r\n'));
+
+      expect(writes).toHaveLength(1);
+      expect(new TextDecoder().decode(writes[0])).toBe('ping\r\n');
+    });
+
+    it('passes raw Uint8Array payloads straight through to the writer', async () => {
+      const { stream } = makeStream();
+      const { stream: writable, writes } = makeRecordingWritable();
+      const port = makeMockPort(stream, undefined, writable);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const payload = new Uint8Array([0x01, 0x02, 0x03]);
+      await firstValueFrom(session.send$(payload));
+
+      expect(writes).toHaveLength(1);
+      expect(Array.from(writes[0])).toEqual([0x01, 0x02, 0x03]);
+    });
+
+    it('guarantees FIFO order for concurrently subscribed send$ calls', async () => {
+      const { stream } = makeStream();
+      let releaseFirst!: () => void;
+      const firstPending = new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      let chunkIndex = 0;
+      const { stream: writable, writes } = makeRecordingWritable(async () => {
+        if (chunkIndex === 0) {
+          chunkIndex += 1;
+          await firstPending;
+        }
+      });
+      const port = makeMockPort(stream, undefined, writable);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const first = firstValueFrom(session.send$('a'));
+      const second = firstValueFrom(session.send$('b'));
+      const third = firstValueFrom(session.send$('c'));
+
+      await flushMicrotasks();
+      expect(writes.map((buf) => new TextDecoder().decode(buf))).toEqual(['a']);
+
+      releaseFirst();
+      await Promise.all([first, second, third]);
+
+      expect(writes.map((buf) => new TextDecoder().decode(buf))).toEqual([
+        'a',
+        'b',
+        'c',
+      ]);
+    });
+
+    it('maps writer failures to WRITE_FAILED and emits them on errors$', async () => {
+      const { stream } = makeStream();
+      const writable = new WritableStream<Uint8Array>({
+        write() {
+          return Promise.reject(new Error('write rejected'));
+        },
+      });
+      const port = makeMockPort(stream, undefined, writable);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const errorsPromise = firstValueFrom(session.errors$);
+
+      await expect(firstValueFrom(session.send$('x'))).rejects.toMatchObject({
+        name: 'SerialError',
+        code: SerialErrorCode.WRITE_FAILED,
+      });
+
+      const emitted = await errorsPromise;
+      expect(emitted).toBeInstanceOf(SerialError);
+      expect(emitted.code).toBe(SerialErrorCode.WRITE_FAILED);
     });
   });
 });

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -327,33 +327,19 @@ describe('createSerialSession', () => {
     });
   });
 
-  describe('send$ (not implemented)', () => {
-    const failsWithNotImplemented = async (
-      observable: ReturnType<SerialSession['send$']>,
-    ) => {
-      await expect(firstValueFrom(observable)).rejects.toMatchObject({
+  describe('send$', () => {
+    it('rejects with PORT_NOT_OPEN when called before connect$', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
+      (globalThis as any).navigator = { serial: {} };
+
+      const session = createSerialSession();
+
+      await expect(
+        firstValueFrom(session.send$('ping\r\n')),
+      ).rejects.toMatchObject({
         name: 'SerialError',
-        code: SerialErrorCode.UNKNOWN,
+        code: SerialErrorCode.PORT_NOT_OPEN,
       });
-    };
-
-    it('fails with SerialErrorCode.UNKNOWN for string payload', async () => {
-      const session = createSerialSession();
-
-      await failsWithNotImplemented(session.send$('ping\r\n'));
-    });
-
-    it('fails with SerialErrorCode.UNKNOWN for bytes payload and references #203', async () => {
-      const session = createSerialSession();
-
-      try {
-        await firstValueFrom(session.send$(new Uint8Array([0x41])));
-        expect.fail('Expected send$ to error');
-      } catch (error) {
-        expect(error).toBeInstanceOf(SerialError);
-        expect((error as SerialError).code).toBe(SerialErrorCode.UNKNOWN);
-        expect((error as SerialError).message).toContain('issues/203');
-      }
     });
   });
 });

--- a/packages/web-serial-rxjs/tests/session/send-queue.test.ts
+++ b/packages/web-serial-rxjs/tests/session/send-queue.test.ts
@@ -1,0 +1,129 @@
+import { firstValueFrom } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { createSendQueue } from '../../src/session/send-queue';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+const createDeferred = <T,>(): Deferred<T> => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe('createSendQueue', () => {
+  it('executes enqueued operations in FIFO order', async () => {
+    const queue = createSendQueue();
+    const order: number[] = [];
+    const first = createDeferred<void>();
+    const second = createDeferred<void>();
+
+    const firstRun = firstValueFrom(
+      queue.enqueue(async () => {
+        order.push(1);
+        await first.promise;
+        order.push(11);
+      }),
+    );
+    const secondRun = firstValueFrom(
+      queue.enqueue(async () => {
+        order.push(2);
+        await second.promise;
+        order.push(22);
+      }),
+    );
+
+    await Promise.resolve();
+    expect(order).toEqual([1]);
+
+    first.resolve();
+    await firstRun;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual([1, 11, 2]);
+
+    second.resolve();
+    await secondRun;
+    expect(order).toEqual([1, 11, 2, 22]);
+  });
+
+  it('continues executing subsequent operations after a failure', async () => {
+    const queue = createSendQueue();
+    const failure = new Error('boom');
+
+    const failing = firstValueFrom(
+      queue.enqueue(async () => {
+        throw failure;
+      }),
+    );
+    const succeeding = firstValueFrom(
+      queue.enqueue(async () => 'ok'),
+    );
+
+    await expect(failing).rejects.toBe(failure);
+    await expect(succeeding).resolves.toBe('ok');
+  });
+
+  it('suppresses next/complete when the subscriber unsubscribes before completion', async () => {
+    const queue = createSendQueue();
+    const gate = createDeferred<void>();
+    let runCount = 0;
+    let nextFired = false;
+    let completeFired = false;
+
+    const subscription = queue
+      .enqueue(async () => {
+        runCount += 1;
+        await gate.promise;
+        return 'value';
+      })
+      .subscribe({
+        next: () => {
+          nextFired = true;
+        },
+        complete: () => {
+          completeFired = true;
+        },
+      });
+
+    subscription.unsubscribe();
+    gate.resolve();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(runCount).toBe(1);
+    expect(nextFired).toBe(false);
+    expect(completeFired).toBe(false);
+  });
+
+  it('clear() starts a fresh chain so later enqueues do not wait for prior pending work', async () => {
+    const queue = createSendQueue();
+    const gate = createDeferred<void>();
+    let secondStartedAt: number | null = null;
+    let tick = 0;
+
+    queue.enqueue(async () => {
+      await gate.promise;
+    }).subscribe();
+
+    queue.clear();
+
+    const second = firstValueFrom(
+      queue.enqueue(async () => {
+        secondStartedAt = tick;
+        return 'second';
+      }),
+    );
+
+    tick = 1;
+    await second;
+    expect(secondStartedAt).toBe(1);
+
+    gate.resolve();
+  });
+});


### PR DESCRIPTION
## Summary
<!--
日本語: 何を・なぜ変更したかを1〜3行で書いてください
English: Briefly describe what you changed and why (1–3 lines)
-->
Issue #199 の v2 API 再設計の一部として、サブ課題 #203「send queue 内部化」を実装しました。スタブのままだった `SerialSession.send$` を内部 FIFO キュー経由の writer.write 実装に差し替え、apps 側が呼び出し順制御を持たずに並行 `send$` を扱えるようにします。

## Type of change
<!--
日本語: 該当するものにチェックを入れてください
English: Check the relevant items
-->
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
<!--
日本語: 関連する Issue があれば記載してください
English: Link related issues (use \"Fixes #123\" to auto-close)
-->
- Fixes #203
- Refs #199

## What changed?
<!--
日本語: 主な変更点を箇条書きで書いてください
English: List the main changes in bullet points
-->
- `packages/web-serial-rxjs/src/session/send-queue.ts` を新規追加し、`SerialClientImpl.enqueueOperation` と等価なシングルチェーン `Promise<void>` ベースの FIFO キューを session 配下に切り出し
- `createSerialSession` で `TextEncoder` と `createSendQueue` をセッションごとに保持し、`send$` を「未接続時は `PORT_NOT_OPEN`／失敗時は `WRITE_FAILED` を `errors$` に多重化」する実装に差し替え
- `connect$` 成功時・`disconnect$` 開始時・read pump エラー時に `sendQueue.clear()` を呼び、再接続後に古い enqueue が走らないよう制御
- `SEND_NOT_IMPLEMENTED` スタブおよび旧「not implemented」テストを撤去
- `SerialSession.send$` の JSDoc を FIFO 保証・UTF-8 エンコード・エラー経路の仕様に合わせて更新

## API / Compatibility
<!--
日本語: 公開 API や互換性への影響があれば明記してください
English: Describe any impact on public APIs or compatibility
-->
- [ ] Public API changes (export / function signature / behavior)
  - Details: `SerialSession.send$` のシグネチャは不変ですが、挙動が「常に `SerialErrorCode.UNKNOWN` で失敗する」から「実際に writer.write を行い、失敗時のみ `WRITE_FAILED` を流す」に変わります。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
<!--
日本語: 動作確認の手順を具体的に書いてください
English: Describe how reviewers can test this change
-->
1. `pnpm nx test web-serial-rxjs` が全て green（142 tests）を確認
2. Chromium 系ブラウザ（Chrome/Edge/Opera）で `createSerialSession()` を使い、`connect$().subscribe()` → `send$('hello\r\n').subscribe()` の順で端末にデータが届くことを確認
3. 連続して `send$('a')` / `send$('b')` / `send$('c')` を subscribe し、呼び出し順で writer に渡ることを確認（新規テストで自動検証済み）
4. ケーブル抜去／writer 側の失敗で `errors$` に `SerialErrorCode.WRITE_FAILED` が流れることを確認

## Environment (if relevant)
<!--
日本語: バグ修正・挙動変更の場合は記載してください
English: Required for bug fixes or behavior changes
-->
- Browser: Chrome / Edge / Opera（Web Serial API 対応環境）
- OS: macOS / Windows / Linux いずれか
- web-serial-rxjs version (for verification): 0.2.0 (本 PR 適用後のビルド)
- RxJS version: ^7.8.0

## Checklist
<!--
日本語: PR 作成前の確認事項です
English: Please confirm before submitting
-->
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)