### PR TITLE
refactor(web-serial-rxjs): errors$ にエラー経路を統合 (#204)

### DIFF
--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -4,26 +4,37 @@ import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import { buildRequestOptions } from '../filters/build-request-options';
 import { DEFAULT_SERIAL_CLIENT_OPTIONS } from '../types/options';
+import {
+  normalizeSerialError,
+  type NormalizeSerialErrorOptions,
+} from './normalize-serial-error';
 import { createReadPump, type ReadPump } from './read-pump';
 import { createSendQueue } from './send-queue';
 import type { SerialSession } from './serial-session';
 import type { SerialSessionOptions } from './serial-session-options';
 import { SessionStateMachine } from './session-state-machine';
 
-function toError(error: unknown, code: SerialErrorCode, fallback: string): SerialError {
-  if (error instanceof SerialError) {
-    return error;
-  }
-  const cause = error instanceof Error ? error : new Error(String(error));
-  return new SerialError(code, `${fallback}: ${cause.message}`, cause);
-}
+/**
+ * Internal error classification used by the single `reportError` entry
+ * point. `'fatal'` errors drive `state$` into `'error'` and tear down
+ * the live session (pump stop + port close); `'non-fatal'` errors are
+ * only multiplexed on `errors$` without mutating session state - this
+ * matches the Issue #199 design note that write failures must not
+ * implicitly disconnect the session.
+ *
+ * @internal
+ */
+type ReportErrorSeverity = 'fatal' | 'non-fatal';
 
 /**
  * Create a v2 {@link SerialSession}.
  *
  * This release wires the internal read pump (#202) and the internal send
  * queue (#203) into the session so that `connect$`, `disconnect$`,
- * `receive$`, and `send$` all operate end-to-end.
+ * `receive$`, and `send$` all operate end-to-end. Error handling is
+ * centralised through a single `reportError` helper (#204) so every
+ * failure path normalises through {@link normalizeSerialError} and emits
+ * on the one `errors$` channel.
  *
  * Key behaviors:
  *
@@ -41,11 +52,11 @@ function toError(error: unknown, code: SerialErrorCode, fallback: string): Seria
  * - `send$` enqueues each payload on an internal FIFO queue so concurrent
  *   subscribers are written to the port in call order. String payloads are
  *   UTF-8 encoded through a shared `TextEncoder`.
- * - `errors$` multiplexes errors surfaced by `connect$` / `disconnect$`,
- *   the read pump, and `send$`. Connect / read failures also drive
- *   `state$` to `'error'`; write failures do not mutate `state$` because
- *   a real connection loss will be detected by the read pump on the next
- *   tick anyway.
+ * - `errors$` multiplexes every {@link SerialError} produced by the
+ *   session. Connect / read / close failures are treated as fatal and
+ *   also drive `state$` to `'error'`; write failures are non-fatal and
+ *   do not mutate `state$` because a real connection loss will be
+ *   observed by the read pump on the next tick anyway.
  *
  * @param options - Session options. Only `filters` is consulted by
  *   `connect$` today (forwarded to `navigator.serial.requestPort`); the
@@ -55,6 +66,7 @@ function toError(error: unknown, code: SerialErrorCode, fallback: string): Seria
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/202 | Issue #202}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/203 | Issue #203}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/204 | Issue #204}
  */
 export function createSerialSession(
   options?: SerialSessionOptions,
@@ -99,14 +111,36 @@ export function createSerialSession(
     }
   };
 
-  const emitPumpError = (error: SerialError): void => {
-    errorsSubject.next(error);
-    machine.toError();
-    sendQueue.clear();
-    // Fire and forget - we can't await inside a sync callback.
-    void teardownPump().then(() => closePortSafely(activePort)).then(() => {
+  /**
+   * Single entry point for every error that should reach `errors$`.
+   *
+   * Responsibilities:
+   *
+   * 1. Normalise the input through {@link normalizeSerialError} so every
+   *    emission is a well-formed {@link SerialError}.
+   * 2. Multiplex the normalised error on `errors$`.
+   * 3. For fatal severities, drive `state$` to `'error'`, clear the send
+   *    queue so pending writes fail fast, and tear down the live pump +
+   *    port off the hot path.
+   *
+   * Returning the normalised error keeps call sites terse: they can hand
+   * the result straight to `subscriber.error(...)` without re-normalising.
+   */
+  const reportError = (
+    error: unknown,
+    severity: ReportErrorSeverity,
+    options: NormalizeSerialErrorOptions,
+  ): SerialError => {
+    const serialError = normalizeSerialError(error, options);
+    errorsSubject.next(serialError);
+    if (severity === 'fatal') {
+      machine.toError();
+      sendQueue.clear();
+      const portToClose = activePort;
       activePort = null;
-    });
+      void teardownPump().then(() => closePortSafely(portToClose));
+    }
+    return serialError;
   };
 
   const writeToPort = async (payload: Uint8Array): Promise<void> => {
@@ -138,22 +172,28 @@ export function createSerialSession(
     connect$(): Observable<void> {
       return new Observable<void>((subscriber) => {
         if (!hasWebSerialSupport()) {
-          const error = new SerialError(
-            SerialErrorCode.BROWSER_NOT_SUPPORTED,
-            'Web Serial API is not supported in this environment',
+          const error = reportError(
+            new SerialError(
+              SerialErrorCode.BROWSER_NOT_SUPPORTED,
+              'Web Serial API is not supported in this environment',
+            ),
+            'non-fatal',
+            { fallbackCode: SerialErrorCode.BROWSER_NOT_SUPPORTED },
           );
-          errorsSubject.next(error);
           subscriber.error(error);
           return;
         }
 
         const current = machine.current;
         if (current !== 'idle' && current !== 'error') {
-          const error = new SerialError(
-            SerialErrorCode.PORT_ALREADY_OPEN,
-            `Cannot connect while session state is '${current}'`,
+          const error = reportError(
+            new SerialError(
+              SerialErrorCode.PORT_ALREADY_OPEN,
+              `Cannot connect while session state is '${current}'`,
+            ),
+            'non-fatal',
+            { fallbackCode: SerialErrorCode.PORT_ALREADY_OPEN },
           );
-          errorsSubject.next(error);
           subscriber.error(error);
           return;
         }
@@ -179,20 +219,11 @@ export function createSerialSession(
             if (selectedPort) {
               await closePortSafely(selectedPort);
             }
-            const serialError =
-              error instanceof DOMException && error.name === 'NotFoundError'
-                ? new SerialError(
-                    SerialErrorCode.OPERATION_CANCELLED,
-                    'Port selection was cancelled by the user',
-                    error,
-                  )
-                : toError(
-                    error,
-                    SerialErrorCode.PORT_OPEN_FAILED,
-                    'Failed to open port',
-                  );
-            errorsSubject.next(serialError);
-            machine.toError();
+            activePort = null;
+            const serialError = reportError(error, 'fatal', {
+              fallbackCode: SerialErrorCode.PORT_OPEN_FAILED,
+              messagePrefix: 'Failed to open port',
+            });
             if (!cancelled) {
               subscriber.error(serialError);
             }
@@ -207,7 +238,11 @@ export function createSerialSession(
           activePort = selectedPort;
           activePump = createReadPump(selectedPort, {
             onChunk: (text) => receiveSubject.next(text),
-            onError: (pumpError) => emitPumpError(pumpError),
+            onError: (pumpError) =>
+              reportError(pumpError, 'fatal', {
+                fallbackCode: SerialErrorCode.READ_FAILED,
+                messagePrefix: 'Read pump failed',
+              }),
           });
           activePump.start();
           sendQueue.clear();
@@ -234,11 +269,14 @@ export function createSerialSession(
         }
 
         if (current !== 'connected' && current !== 'error') {
-          const error = new SerialError(
-            SerialErrorCode.PORT_NOT_OPEN,
-            `Cannot disconnect while session state is '${current}'`,
+          const error = reportError(
+            new SerialError(
+              SerialErrorCode.PORT_NOT_OPEN,
+              `Cannot disconnect while session state is '${current}'`,
+            ),
+            'non-fatal',
+            { fallbackCode: SerialErrorCode.PORT_NOT_OPEN },
           );
-          errorsSubject.next(error);
           subscriber.error(error);
           return;
         }
@@ -254,14 +292,11 @@ export function createSerialSession(
               try {
                 await portToClose.close();
               } catch (error) {
-                const serialError = toError(
-                  error,
-                  SerialErrorCode.CONNECTION_LOST,
-                  'Failed to close port',
-                );
                 activePort = null;
-                errorsSubject.next(serialError);
-                machine.toError();
+                const serialError = reportError(error, 'fatal', {
+                  fallbackCode: SerialErrorCode.CONNECTION_LOST,
+                  messagePrefix: 'Failed to close port',
+                });
                 subscriber.error(serialError);
                 return;
               }
@@ -271,13 +306,10 @@ export function createSerialSession(
             subscriber.next();
             subscriber.complete();
           } catch (error) {
-            const serialError = toError(
-              error,
-              SerialErrorCode.UNKNOWN,
-              'Unexpected disconnect failure',
-            );
-            errorsSubject.next(serialError);
-            machine.toError();
+            const serialError = reportError(error, 'fatal', {
+              fallbackCode: SerialErrorCode.UNKNOWN,
+              messagePrefix: 'Unexpected disconnect failure',
+            });
             subscriber.error(serialError);
           }
         };
@@ -292,12 +324,10 @@ export function createSerialSession(
         try {
           await writeToPort(payload);
         } catch (error) {
-          const serialError =
-            error instanceof SerialError
-              ? error
-              : toError(error, SerialErrorCode.WRITE_FAILED, 'Failed to write data');
-          errorsSubject.next(serialError);
-          throw serialError;
+          throw reportError(error, 'non-fatal', {
+            fallbackCode: SerialErrorCode.WRITE_FAILED,
+            messagePrefix: 'Failed to write data',
+          });
         }
       });
     },

--- a/packages/web-serial-rxjs/src/session/normalize-serial-error.ts
+++ b/packages/web-serial-rxjs/src/session/normalize-serial-error.ts
@@ -1,0 +1,97 @@
+import { SerialError } from '../errors/serial-error';
+import { SerialErrorCode } from '../errors/serial-error-code';
+
+/**
+ * Default human-readable prefix attached to normalized errors when the
+ * caller does not supply one. Kept short so downstream messages remain
+ * readable (e.g. `"Serial operation failed: <cause>"`).
+ *
+ * @internal
+ */
+const DEFAULT_MESSAGE_PREFIX = 'Serial operation failed';
+
+/**
+ * Options accepted by {@link normalizeSerialError}.
+ *
+ * @internal
+ */
+export interface NormalizeSerialErrorOptions {
+  /**
+   * Error code assigned when the input cannot be classified more
+   * specifically (for example a generic `Error` thrown from `port.open`).
+   *
+   * Most call sites in the session pipeline know which lifecycle phase
+   * they are in (connect / read / write / close) and therefore pick a
+   * phase-specific fallback such as {@link SerialErrorCode.PORT_OPEN_FAILED}
+   * or {@link SerialErrorCode.WRITE_FAILED}.
+   */
+  fallbackCode: SerialErrorCode;
+  /**
+   * Prefix used when the input has to be wrapped. Ignored when the input
+   * is already a {@link SerialError} so we never rewrite a well-formed
+   * message the caller has already chosen.
+   */
+  messagePrefix?: string;
+}
+
+const isDomExceptionWithName = (
+  error: unknown,
+  name: string,
+): error is DOMException =>
+  typeof DOMException !== 'undefined' &&
+  error instanceof DOMException &&
+  error.name === name;
+
+/**
+ * Normalize an arbitrary thrown value into a {@link SerialError}.
+ *
+ * This helper is the single entry point used by every v2 session
+ * component (session factory, read pump, send queue) to coerce raw
+ * platform errors into the library's error type. Centralising the
+ * mapping here satisfies Issue #204's completion criterion that
+ * "error handling lives in one place" and removes the duplicated
+ * `toError` / `normalizeError` helpers previously scattered across
+ * session modules.
+ *
+ * Mapping rules applied, in order:
+ *
+ * 1. `SerialError` instances pass through unchanged so a caller that has
+ *    already classified the failure (e.g. `PORT_NOT_OPEN` on a pre-open
+ *    `send$`) is not rewrapped.
+ * 2. `DOMException('NotFoundError')` is mapped to
+ *    {@link SerialErrorCode.OPERATION_CANCELLED}. Chromium raises this
+ *    when the user dismisses the `requestPort` dialog; it is a normal
+ *    control-flow event, not a hard failure.
+ * 3. Any other value is wrapped as a {@link SerialError} with
+ *    {@link NormalizeSerialErrorOptions.fallbackCode}, preserving the
+ *    original error as `originalError` for debugging.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/204 | Issue #204}
+ */
+export function normalizeSerialError(
+  error: unknown,
+  options: NormalizeSerialErrorOptions,
+): SerialError {
+  if (error instanceof SerialError) {
+    return error;
+  }
+
+  const prefix = options.messagePrefix ?? DEFAULT_MESSAGE_PREFIX;
+
+  if (isDomExceptionWithName(error, 'NotFoundError')) {
+    return new SerialError(
+      SerialErrorCode.OPERATION_CANCELLED,
+      'Port selection was cancelled by the user',
+      error,
+    );
+  }
+
+  const cause = error instanceof Error ? error : new Error(String(error));
+  return new SerialError(
+    options.fallbackCode,
+    `${prefix}: ${cause.message}`,
+    cause,
+  );
+}

--- a/packages/web-serial-rxjs/src/session/read-pump.ts
+++ b/packages/web-serial-rxjs/src/session/read-pump.ts
@@ -1,5 +1,6 @@
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
+import { normalizeSerialError } from './normalize-serial-error';
 
 /**
  * Callback invoked for every decoded chunk the read pump produces.
@@ -85,14 +86,6 @@ export function createReadPump(
   let stopped = false;
   const decoder = new TextDecoder(undefined, { fatal: false });
 
-  const normalizeError = (error: unknown, code: SerialErrorCode): SerialError => {
-    if (error instanceof SerialError) {
-      return error;
-    }
-    const cause = error instanceof Error ? error : new Error(String(error));
-    return new SerialError(code, `Read pump failed: ${cause.message}`, cause);
-  };
-
   const releaseReader = (): void => {
     if (!reader) {
       return;
@@ -129,7 +122,12 @@ export function createReadPump(
       }
     } catch (error) {
       if (!stopped) {
-        onError(normalizeError(error, SerialErrorCode.READ_FAILED));
+        onError(
+          normalizeSerialError(error, {
+            fallbackCode: SerialErrorCode.READ_FAILED,
+            messagePrefix: 'Read pump failed',
+          }),
+        );
       }
     } finally {
       running = false;

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -74,6 +74,20 @@ export interface SerialSession {
    * All {@link SerialError} instances produced by the session (connect /
    * read / write / close) are multiplexed here. This is the main channel,
    * not a supplementary one.
+   *
+   * Every emission is the exact same instance that is also surfaced to
+   * the relevant call-site subscriber (for example `connect$().subscribe`
+   * receives the same `SerialError` that `errors$` emits for that
+   * failure), so a single subscription is enough to observe the full
+   * error history without double-normalisation.
+   *
+   * Fatal failures (connect / read / close) additionally drive `state$`
+   * to `'error'` and tear down the live pump + port; non-fatal failures
+   * (currently only `send$` write failures) are multiplexed here without
+   * mutating `state$`, on the assumption that a real connection loss is
+   * detected by the read pump on the next tick.
+   *
+   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/204 | Issue #204}
    */
   readonly errors$: Observable<SerialError>;
 

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -453,4 +453,146 @@ describe('createSerialSession', () => {
       expect(emitted.code).toBe(SerialErrorCode.WRITE_FAILED);
     });
   });
+
+  describe('errors$ integration (#204)', () => {
+    it('emits the same SerialError instance on errors$ and to the connect$ subscriber', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+      port.open.mockRejectedValueOnce(new Error('cannot open'));
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const emissions: SerialError[] = [];
+      const subscription = session.errors$.subscribe((error) => {
+        emissions.push(error);
+      });
+
+      try {
+        const rejection = await firstValueFrom(session.connect$()).catch(
+          (error: unknown) => error as SerialError,
+        );
+
+        expect(rejection).toBeInstanceOf(SerialError);
+        expect(emissions).toHaveLength(1);
+        expect(emissions[0]).toBe(rejection);
+        expect(emissions[0].code).toBe(SerialErrorCode.PORT_OPEN_FAILED);
+      } finally {
+        subscription.unsubscribe();
+      }
+    });
+
+    it('does not mutate state$ when a write fails (non-fatal)', async () => {
+      const { stream } = makeStream();
+      const writable = new WritableStream<Uint8Array>({
+        write() {
+          return Promise.reject(new Error('write rejected'));
+        },
+      });
+      const port = makeMockPort(stream, undefined, writable);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      await expect(firstValueFrom(session.send$('x'))).rejects.toMatchObject({
+        code: SerialErrorCode.WRITE_FAILED,
+      });
+
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
+        'connected',
+      );
+    });
+
+    it('routes close failures on disconnect$ to errors$ as CONNECTION_LOST and state -> error', async () => {
+      const { stream } = makeStream();
+      const close = vi.fn().mockRejectedValue(new Error('close failed'));
+      const port = makeMockPort(stream, close);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const errorsPromise = firstValueFrom(session.errors$);
+
+      await expect(
+        firstValueFrom(session.disconnect$()),
+      ).rejects.toMatchObject({
+        name: 'SerialError',
+        code: SerialErrorCode.CONNECTION_LOST,
+      });
+
+      const emitted = await errorsPromise;
+      expect(emitted.code).toBe(SerialErrorCode.CONNECTION_LOST);
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
+        'error',
+      );
+    });
+
+    it('forwards DOMException(NotFoundError) on requestPort as a single OPERATION_CANCELLED emission', async () => {
+      const requestPort = vi
+        .fn()
+        .mockRejectedValue(new DOMException('cancel', 'NotFoundError'));
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        writable: true,
+        value: { serial: { requestPort, getPorts: vi.fn() } },
+      });
+
+      const session = createSerialSession();
+      const emissions: SerialError[] = [];
+      const subscription = session.errors$.subscribe((error) => {
+        emissions.push(error);
+      });
+
+      try {
+        await expect(
+          firstValueFrom(session.connect$()),
+        ).rejects.toMatchObject({
+          code: SerialErrorCode.OPERATION_CANCELLED,
+        });
+
+        expect(emissions).toHaveLength(1);
+        expect(emissions[0].code).toBe(SerialErrorCode.OPERATION_CANCELLED);
+      } finally {
+        subscription.unsubscribe();
+      }
+    });
+
+    it('multiplexes connect, pump, and write failures through the same errors$ channel', async () => {
+      const { stream, controller } = makeStream();
+      const writable = new WritableStream<Uint8Array>({
+        write() {
+          return Promise.reject(new Error('write rejected'));
+        },
+      });
+      const port = makeMockPort(stream, undefined, writable);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const emissions: SerialError[] = [];
+      const subscription = session.errors$.subscribe((error) => {
+        emissions.push(error);
+      });
+
+      try {
+        await firstValueFrom(session.connect$());
+
+        await expect(
+          firstValueFrom(session.send$('x')),
+        ).rejects.toMatchObject({
+          code: SerialErrorCode.WRITE_FAILED,
+        });
+
+        controller.error(new Error('device unplugged'));
+        await flushMicrotasks();
+
+        expect(emissions.map((error) => error.code)).toEqual([
+          SerialErrorCode.WRITE_FAILED,
+          SerialErrorCode.READ_FAILED,
+        ]);
+      } finally {
+        subscription.unsubscribe();
+      }
+    });
+  });
 });

--- a/packages/web-serial-rxjs/tests/session/normalize-serial-error.test.ts
+++ b/packages/web-serial-rxjs/tests/session/normalize-serial-error.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { normalizeSerialError } from '../../src/session/normalize-serial-error';
+
+describe('normalizeSerialError', () => {
+  it('returns SerialError instances unchanged', () => {
+    const original = new SerialError(
+      SerialErrorCode.PORT_NOT_OPEN,
+      'port not open',
+    );
+
+    const normalized = normalizeSerialError(original, {
+      fallbackCode: SerialErrorCode.UNKNOWN,
+    });
+
+    expect(normalized).toBe(original);
+  });
+
+  it('maps DOMException(NotFoundError) to OPERATION_CANCELLED', () => {
+    const dom = new DOMException('No port selected', 'NotFoundError');
+
+    const normalized = normalizeSerialError(dom, {
+      fallbackCode: SerialErrorCode.PORT_OPEN_FAILED,
+    });
+
+    expect(normalized).toBeInstanceOf(SerialError);
+    expect(normalized.code).toBe(SerialErrorCode.OPERATION_CANCELLED);
+    expect(normalized.originalError).toBe(dom);
+  });
+
+  it('wraps arbitrary Error instances using the provided fallback code', () => {
+    const cause = new Error('cannot open');
+
+    const normalized = normalizeSerialError(cause, {
+      fallbackCode: SerialErrorCode.PORT_OPEN_FAILED,
+      messagePrefix: 'Failed to open port',
+    });
+
+    expect(normalized.code).toBe(SerialErrorCode.PORT_OPEN_FAILED);
+    expect(normalized.message).toBe('Failed to open port: cannot open');
+    expect(normalized.originalError).toBe(cause);
+  });
+
+  it('wraps non-Error values into Error causes so originalError is always an Error', () => {
+    const normalized = normalizeSerialError('string failure', {
+      fallbackCode: SerialErrorCode.WRITE_FAILED,
+      messagePrefix: 'Failed to write data',
+    });
+
+    expect(normalized.code).toBe(SerialErrorCode.WRITE_FAILED);
+    expect(normalized.message).toBe('Failed to write data: string failure');
+    expect(normalized.originalError).toBeInstanceOf(Error);
+    expect(normalized.originalError?.message).toBe('string failure');
+  });
+
+  it('uses the default message prefix when one is not provided', () => {
+    const cause = new Error('boom');
+
+    const normalized = normalizeSerialError(cause, {
+      fallbackCode: SerialErrorCode.UNKNOWN,
+    });
+
+    expect(normalized.message).toBe('Serial operation failed: boom');
+  });
+
+  it('passes through non-NotFoundError DOMExceptions using the fallback code', () => {
+    const dom = new DOMException('locked', 'InvalidStateError');
+
+    const normalized = normalizeSerialError(dom, {
+      fallbackCode: SerialErrorCode.CONNECTION_LOST,
+      messagePrefix: 'Failed to close port',
+    });
+
+    expect(normalized.code).toBe(SerialErrorCode.CONNECTION_LOST);
+    expect(normalized.message).toBe('Failed to close port: locked');
+    expect(normalized.originalError).toBe(dom);
+  });
+});


### PR DESCRIPTION
## Summary
<!--
日本語: 何を・なぜ変更したかを1〜3行で書いてください
English: Briefly describe what you changed and why (1–3 lines)
-->
v2 `SerialSession` のエラー処理を単一の `reportError` ヘルパーに集約し、connect / read / write / close / disconnect の各経路で散在していた正規化ロジックを `normalizeSerialError` に一元化しました。親 Issue #199 の完了条件である「エラーが 1 系統 (`errors$`) に統合されている」を満たすためのリファクタです。公開 API は不変で、既存の挙動・メッセージはそのまま維持しています。

## Type of change
<!--
日本語: 該当するものにチェックを入れてください
English: Check the relevant items
-->
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
<!--
日本語: 関連する Issue があれば記載してください
English: Link related issues (use "Fixes #123" to auto-close)
-->
- Fixes #204
- Refs #199

## What changed?
<!--
日本語: 主な変更点を箇条書きで書いてください
English: List the main changes in bullet points
-->
- `packages/web-serial-rxjs/src/session/normalize-serial-error.ts` を新設し、`DOMException('NotFoundError') → OPERATION_CANCELLED` を含む全マッピングと単体テストを追加。
- `read-pump.ts` の内部 `normalizeError` を新ユーティリティに置き換え、エラー分類の重複実装を解消。
- `create-serial-session.ts` に単一エントリの `reportError(error, severity, options)` を導入し、connect / disconnect / send / pump のエラーを正規化・`errors$` 配信・`state$` 遷移・pump/port 後始末まで一括で扱うように統合。
- write 失敗を非 fatal として扱い、書き込みエラーで session state を壊さない設計意図を実装・JSDoc・テストで明示化。
- `SerialSession.errors$` の JSDoc を統合後の挙動 (call-site subscriber と同一インスタンス配信、fatal/非 fatal の区別) に追従。
- 4 経路のエラーが `errors$` に集約されること、fatal/非 fatal の state 挙動差分を回帰テストとして追加。

## API / Compatibility
<!--
日本語: 公開 API や互換性への影響があれば明記してください
English: Describe any impact on public APIs or compatibility
-->
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

公開エクスポート (`createSerialSession` / `SerialSession` / `SerialSessionOptions` / `SerialError` / `SerialErrorCode` / etc.) に差分はありません。エラーコードのマッピング・メッセージ文言も既存挙動を維持しています。

## How to test
<!--
日本語: 動作確認の手順を具体的に書いてください
English: Describe how reviewers can test this change
-->
1. `pnpm install`
2. `pnpm -w nx run web-serial-rxjs:test`（153 件全パス、うち `tests/session/` は 50 件）
3. `pnpm -w nx run web-serial-rxjs:lint`（本 PR で追加・編集したファイルに警告なし）
4. `pnpm -w nx run web-serial-rxjs:build`
5. 主要な確認ポイント:
   - `tests/session/normalize-serial-error.test.ts`: NotFoundError → OPERATION_CANCELLED など正規化ルール。
   - `tests/session/create-serial-session.test.ts` の `errors$ integration (#204)` ブロック: connect 失敗 / pump 失敗 / write 失敗 / close 失敗が同一 `errors$` で観測でき、write 失敗時のみ `state$` が `'connected'` のまま保持されること。

## Environment (if relevant)
<!--
日本語: バグ修正・挙動変更の場合は記載してください
English: Required for bug fixes or behavior changes
-->
- Browser: Chrome / Edge / Opera / etc. (version: )
- OS: macOS
- web-serial-rxjs version (for verification): 0.2.0 (作業ブランチ)
- RxJS version: ^7.8.0

## Checklist
<!--
日本語: PR 作成前の確認事項です
English: Please confirm before submitting
-->
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)