### PR TITLE
refactor(example-angular): Angular example を SerialSession 化 (#205)

### DIFF
--- a/apps/example-angular/src/app/app.html
+++ b/apps/example-angular/src/app/app.html
@@ -10,9 +10,9 @@
       <h2>ブラウザサポート</h2>
       <div
         class="status-message"
-        [ngClass]="(browserSupported$ | async) ? 'success' : 'error'"
+        [ngClass]="browserSupported ? 'success' : 'error'"
       >
-        {{ (browserSupported$ | async) ? 'ブラウザは Web Serial API
+        {{ browserSupported ? 'ブラウザは Web Serial API
         をサポートしています。' : 'このブラウザは Web Serial API
         をサポートしていません。Chrome、Edge、Opera などの Chromium
         ベースのブラウザをご使用ください。' }}
@@ -28,7 +28,7 @@
           id="baud-rate"
           class="form-control"
           [(ngModel)]="baudRate"
-          [disabled]="getConnected(connectionState$ | async)"
+          [disabled]="connected"
         >
           <option [value]="9600">9600</option>
           <option [value]="19200">19200</option>
@@ -39,40 +39,22 @@
       </div>
       <div class="button-group">
         <button
-          class="btn btn-outline"
-          (click)="handleRequestPort()"
-          [disabled]="
-            !getBrowserSupported(browserSupported$ | async) ||
-            getConnected(connectionState$ | async) ||
-            getConnecting(connectionState$ | async)
-          "
-        >
-          ポートを選択
-        </button>
-        <button
           class="btn btn-primary"
           (click)="handleConnect()"
-          [disabled]="
-            !getBrowserSupported(browserSupported$ | async) ||
-            getConnected(connectionState$ | async) ||
-            getConnecting(connectionState$ | async)
-          "
+          [disabled]="!browserSupported || connected || connecting"
         >
           接続
         </button>
         <button
           class="btn btn-secondary"
           (click)="handleDisconnect()"
-          [disabled]="
-            !getConnected(connectionState$ | async) ||
-            getDisconnecting(connectionState$ | async)
-          "
+          [disabled]="!connected || disconnecting"
         >
           切断
         </button>
       </div>
-      <div class="status-message" [ngClass]="(status$ | async)?.type">
-        {{ (status$ | async)?.message }}
+      <div class="status-message" [ngClass]="status.type">
+        {{ status.message }}
       </div>
     </section>
 
@@ -88,15 +70,13 @@
             class="form-control"
             [(ngModel)]="sendInput"
             (keydown)="handleKeyDown($event)"
-            [disabled]="!getConnected(connectionState$ | async)"
+            [disabled]="!connected"
             placeholder="送信するテキストを入力..."
           />
           <button
             class="btn btn-primary"
             (click)="handleSend()"
-            [disabled]="
-              !getConnected(connectionState$ | async) || !sendInput.trim()
-            "
+            [disabled]="!connected || !sendInput.trim()"
           >
             送信
           </button>
@@ -112,7 +92,7 @@
         <textarea
           id="receive-output"
           class="form-control receive-output"
-          [value]="receivedData$ | async"
+          [value]="receivedData()"
           readonly
           placeholder="受信したデータがここに表示されます..."
         ></textarea>
@@ -121,7 +101,7 @@
         <button
           class="btn btn-secondary"
           (click)="clearReceivedData()"
-          [disabled]="!hasReceivedData(receivedData$ | async)"
+          [disabled]="!hasReceivedData"
         >
           クリア
         </button>

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -1,10 +1,12 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject } from '@angular/core';
+import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { Observable, map } from 'rxjs';
-import type { SerialConnectionState } from './services/serial-client.service';
+import type { SerialSessionState } from '@gurezo/web-serial-rxjs';
 import { SerialClientService } from './services/serial-client.service';
+
+type StatusType = 'info' | 'success' | 'error';
 
 @Component({
   imports: [CommonModule, FormsModule, RouterModule],
@@ -17,94 +19,109 @@ export class App {
   sendInput = '';
 
   private readonly serialService = inject(SerialClientService);
+  private readonly destroyRef = inject(DestroyRef);
 
-  browserSupported$: Observable<boolean>;
-  connectionState$: Observable<
-    import('./services/serial-client.service').SerialConnectionState
-  >;
-  receivedData$: Observable<string>;
-  status$: Observable<{ type: string; message: string }>;
+  readonly browserSupported = this.serialService.isBrowserSupported();
+  readonly state = signal<SerialSessionState>('idle');
+  readonly receivedData = signal('');
+  readonly errorMessage = signal<string | null>(null);
 
   constructor() {
-    this.browserSupported$ = this.serialService.browserSupported;
-    this.connectionState$ = this.serialService.connectionState;
-    this.receivedData$ = this.serialService.receivedData;
+    this.serialService.state$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((state) => {
+        this.state.set(state);
+        if (state === 'connected' || state === 'idle') {
+          this.errorMessage.set(null);
+        }
+      });
 
-    // ステータスメッセージを計算
-    this.status$ = this.connectionState$.pipe(
-      map((state) => {
-        if (state.error) {
-          return { type: 'error', message: state.error };
-        }
-        if (state.connecting) {
-          return { type: 'info', message: '接続中...' };
-        }
-        if (state.disconnecting) {
-          return { type: 'info', message: '切断中...' };
-        }
-        if (state.connected) {
-          return { type: 'success', message: 'シリアルポートに接続しました。' };
-        }
+    this.serialService.receive$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((chunk) => {
+        this.receivedData.update((prev) => prev + chunk);
+      });
+
+    this.serialService.errors$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((error) => {
+        this.errorMessage.set(error.message);
+      });
+  }
+
+  get connected(): boolean {
+    return this.state() === 'connected';
+  }
+
+  get connecting(): boolean {
+    return this.state() === 'connecting';
+  }
+
+  get disconnecting(): boolean {
+    return this.state() === 'disconnecting';
+  }
+
+  get hasReceivedData(): boolean {
+    return this.receivedData().length > 0;
+  }
+
+  get status(): { type: StatusType; message: string } {
+    const error = this.errorMessage();
+    if (error) {
+      return { type: 'error', message: `エラー: ${error}` };
+    }
+    switch (this.state()) {
+      case 'connecting':
+        return { type: 'info', message: '接続中...' };
+      case 'disconnecting':
+        return { type: 'info', message: '切断中...' };
+      case 'connected':
+        return { type: 'success', message: 'シリアルポートに接続しました。' };
+      case 'unsupported':
+        return {
+          type: 'error',
+          message:
+            'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
+        };
+      case 'error':
+        return { type: 'error', message: 'エラーが発生しました。' };
+      default:
         return { type: 'info', message: 'シリアルポートに接続していません。' };
-      }),
-    );
-  }
-
-  /**
-   * 接続ボタンのハンドラ
-   */
-  async handleConnect(): Promise<void> {
-    try {
-      await this.serialService.connectAsync(this.baudRate);
-    } catch (error) {
-      // エラーは SerialClientService 内で処理される
-      console.error('接続エラー:', error);
     }
   }
 
-  /**
-   * 切断ボタンのハンドラ
-   */
-  async handleDisconnect(): Promise<void> {
-    try {
-      await this.serialService.disconnectAsync();
-    } catch (error) {
-      // エラーは SerialClientService 内で処理される
-      console.error('切断エラー:', error);
-    }
+  handleConnect(): void {
+    this.errorMessage.set(null);
+    this.serialService.connect$(this.baudRate).subscribe({
+      error: (error: unknown) => {
+        console.error('接続エラー:', error);
+      },
+    });
   }
 
-  /**
-   * ポートリクエストボタンのハンドラ
-   */
-  async handleRequestPort(): Promise<void> {
-    try {
-      await this.serialService.requestPortAsync();
-    } catch (error) {
-      // エラーは SerialClientService 内で処理される
-      console.error('ポート選択エラー:', error);
-    }
+  handleDisconnect(): void {
+    this.serialService.disconnect$().subscribe({
+      error: (error: unknown) => {
+        console.error('切断エラー:', error);
+      },
+    });
   }
 
-  /**
-   * 送信ボタンのハンドラ
-   */
-  async handleSend(): Promise<void> {
-    if (!this.sendInput.trim()) {
+  handleSend(): void {
+    const text = this.sendInput.trim();
+    if (!text) {
       return;
     }
-
-    try {
-      await this.serialService.sendAsync(this.sendInput);
-      this.sendInput = ''; // 送信成功後に入力欄をクリア
-    } catch (error) {
-      console.error('送信エラー:', error);
-    }
+    this.serialService.send$(`${text}\n`).subscribe({
+      next: () => {
+        this.sendInput = '';
+      },
+      error: (error: unknown) => {
+        console.error('送信エラー:', error);
+      },
+    });
   }
 
-  /**
-   * Enter キーで送信
-   */
   handleKeyDown(event: KeyboardEvent): void {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
@@ -112,45 +129,7 @@ export class App {
     }
   }
 
-  /**
-   * 受信データをクリア
-   */
   clearReceivedData(): void {
-    this.serialService.clearReceivedData();
-  }
-
-  /**
-   * ヘルパーメソッド: ブラウザサポート状態を取得
-   */
-  getBrowserSupported(bs: boolean | null | undefined): boolean {
-    return bs ?? false;
-  }
-
-  /**
-   * ヘルパーメソッド: 接続状態を取得
-   */
-  getConnected(state: SerialConnectionState | null | undefined): boolean {
-    return state?.connected ?? false;
-  }
-
-  /**
-   * ヘルパーメソッド: 接続中状態を取得
-   */
-  getConnecting(state: SerialConnectionState | null | undefined): boolean {
-    return state?.connecting ?? false;
-  }
-
-  /**
-   * ヘルパーメソッド: 切断中状態を取得
-   */
-  getDisconnecting(state: SerialConnectionState | null | undefined): boolean {
-    return state?.disconnecting ?? false;
-  }
-
-  /**
-   * ヘルパーメソッド: 受信データが空でないか
-   */
-  hasReceivedData(data: string | null | undefined): boolean {
-    return !!data;
+    this.receivedData.set('');
   }
 }

--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -1,66 +1,85 @@
 import { TestBed } from '@angular/core/testing';
-import type { SerialClient } from '@gurezo/web-serial-rxjs';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
-import { firstValueFrom, of, throwError } from 'rxjs';
-import { tap } from 'rxjs/operators';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+import { BehaviorSubject, firstValueFrom, of, Subject, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialClientService } from './serial-client.service';
 
-// Mock the web-serial-rxjs library
-vi.mock('@gurezo/web-serial-rxjs', () => {
-  let isConnected = false;
-  const mockClient = {
-    get connected() {
-      return isConnected;
-    },
-    currentPort: null,
-    connect: vi.fn(() =>
-      of(undefined).pipe(
-        tap(() => {
-          isConnected = true;
-        }),
-      ),
-    ),
-    disconnect: vi.fn(() =>
-      of(undefined).pipe(
-        tap(() => {
-          isConnected = false;
-        }),
-      ),
-    ),
-    requestPort: vi.fn(() => of({} as unknown as SerialPort)),
-    get bytes$() {
-      return of(new Uint8Array([72, 101, 108, 108, 111]));
-    },
-    get text$() {
-      return of('Hello');
-    },
-    get lines$() {
-      return of('Hello');
-    },
-    send$: vi.fn(() => of(undefined)),
-    getPorts: vi.fn(() => of([])),
+interface MockSession {
+  session: SerialSession;
+  stateSubject: BehaviorSubject<webSerialRxjs.SerialSessionState>;
+  receiveSubject: Subject<string>;
+  errorsSubject: Subject<webSerialRxjs.SerialError>;
+  connect$: ReturnType<typeof vi.fn>;
+  disconnect$: ReturnType<typeof vi.fn>;
+  send$: ReturnType<typeof vi.fn>;
+  isBrowserSupported: ReturnType<typeof vi.fn>;
+}
+
+const createMockSession = (): MockSession => {
+  const stateSubject = new BehaviorSubject<webSerialRxjs.SerialSessionState>(
+    'idle',
+  );
+  const receiveSubject = new Subject<string>();
+  const errorsSubject = new Subject<webSerialRxjs.SerialError>();
+  const connect$ = vi.fn(() => of(undefined));
+  const disconnect$ = vi.fn(() => of(undefined));
+  const send$ = vi.fn(() => of(undefined));
+  const isBrowserSupported = vi.fn(() => true);
+
+  const session: SerialSession = {
+    isBrowserSupported,
+    connect$,
+    disconnect$,
+    send$,
+    state$: stateSubject.asObservable(),
+    errors$: errorsSubject.asObservable(),
+    receive$: receiveSubject.asObservable(),
   };
 
   return {
-    createSerialClient: vi.fn(() => mockClient) as unknown as (options?: {
-      baudRate?: number;
-    }) => SerialClient,
-    isBrowserSupported: vi.fn(() => true),
-    SerialError: class MockSerialError extends Error {
-      constructor(message: string) {
-        super(message);
-        this.name = 'SerialError';
-      }
-    },
+    session,
+    stateSubject,
+    receiveSubject,
+    errorsSubject,
+    connect$,
+    disconnect$,
+    send$,
+    isBrowserSupported,
+  };
+};
+
+let mockSessions: MockSession[] = [];
+
+vi.mock('@gurezo/web-serial-rxjs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
+      '@gurezo/web-serial-rxjs',
+    );
+  return {
+    ...actual,
+    createSerialSession: vi.fn(() => {
+      const mock = createMockSession();
+      mockSessions.push(mock);
+      return mock.session;
+    }),
   };
 });
+
+const latestMock = (): MockSession => {
+  const mock = mockSessions.at(-1);
+  if (!mock) {
+    throw new Error('createSerialSession was not called');
+  }
+  return mock;
+};
 
 describe('SerialClientService', () => {
   let service: SerialClientService;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSessions = [];
     TestBed.configureTestingModule({});
     service = TestBed.inject(SerialClientService);
   });
@@ -69,150 +88,85 @@ describe('SerialClientService', () => {
     vi.restoreAllMocks();
   });
 
-  it('should be created', () => {
+  it('should create a session on construction', () => {
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(webSerialRxjs.createSerialSession)).toHaveBeenCalledWith({
+      baudRate: 9600,
+    });
     expect(service).toBeTruthy();
   });
 
-  it('should initialize with default values', async () => {
-    const browserSupported = await firstValueFrom(service.browserSupported);
-    expect(browserSupported).toBe(true);
-
-    const connectionState = await firstValueFrom(service.connectionState);
-    expect(connectionState.connected).toBe(false);
-    expect(connectionState.connecting).toBe(false);
-    expect(connectionState.disconnecting).toBe(false);
-    expect(connectionState.error).toBe(null);
+  it('should expose browser support via the session', () => {
+    expect(service.isBrowserSupported()).toBe(true);
+    expect(latestMock().isBrowserSupported).toHaveBeenCalled();
   });
 
-  it('should check browser support on initialization', () => {
-    expect(vi.mocked(webSerialRxjs.isBrowserSupported)).toHaveBeenCalled();
+  it('should emit the initial idle state on state$', async () => {
+    const state = await firstValueFrom(service.state$);
+    expect(state).toBe('idle');
   });
 
-  it('should connect to serial port', async () => {
-    const initialState = await firstValueFrom(service.connectionState);
-    expect(initialState.connected).toBe(false);
+  it('should forward session state transitions', async () => {
+    const mock = latestMock();
+    mock.stateSubject.next('connecting');
+    mock.stateSubject.next('connected');
 
-    await firstValueFrom(service.connect());
-
-    // Wait a bit for state updates
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const newState = await firstValueFrom(service.connectionState);
-    expect(newState.connected).toBe(true);
-    expect(newState.connecting).toBe(false);
+    const state = await firstValueFrom(service.state$);
+    expect(state).toBe('connected');
   });
 
-  it('should disconnect from serial port', async () => {
-    // First connect
-    await firstValueFrom(service.connect());
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const connectedState = await firstValueFrom(service.connectionState);
-    expect(connectedState.connected).toBe(true);
-
-    // Then disconnect
-    await firstValueFrom(service.disconnect());
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const disconnectedState = await firstValueFrom(service.connectionState);
-    expect(disconnectedState.connected).toBe(false);
-    expect(disconnectedState.disconnecting).toBe(false);
+  it('should connect through the session', async () => {
+    await firstValueFrom(service.connect$());
+    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should request port', async () => {
-    await firstValueFrom(service.requestPort());
+  it('should recreate the session when baud rate changes', async () => {
+    await firstValueFrom(service.connect$(115200));
 
-    const connectionState = await firstValueFrom(service.connectionState);
-    expect(connectionState.error).toBe(null);
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenLastCalledWith({ baudRate: 115200 });
+    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should send data when connected', async () => {
-    // Connect first
-    await firstValueFrom(service.connect());
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const connectedState = await firstValueFrom(service.connectionState);
-    expect(connectedState.connected).toBe(true);
-
-    // Send data
-    await firstValueFrom(service.send('test data'));
-
-    // No error should occur
-    const finalState = await firstValueFrom(service.connectionState);
-    expect(finalState.error).toBe(null);
+  it('should disconnect through the session', async () => {
+    await firstValueFrom(service.disconnect$());
+    expect(latestMock().disconnect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should clear received data', async () => {
-    service.clearReceivedData();
-
-    const receivedData = await firstValueFrom(service.receivedData);
-    expect(receivedData).toBe('');
+  it('should send payloads through the session', async () => {
+    await firstValueFrom(service.send$('hello'));
+    expect(latestMock().send$).toHaveBeenCalledWith('hello');
   });
 
-  it('should handle connection errors', async () => {
-    // Create a new service instance to test error handling
-    const errorService = new SerialClientService();
+  it('should propagate connect errors', async () => {
+    const mock = latestMock();
+    const boom = new Error('connect failed');
+    mock.connect$.mockReturnValueOnce(throwError(() => boom));
 
-    // Mock createSerialClient to return a client that throws on connect
-    const errorClient = {
-      get connected() {
-        return false;
-      },
-      currentPort: null,
-      connect: vi.fn(() => throwError(() => new Error('Connection failed'))),
-      disconnect: vi.fn(() => of(undefined)),
-      requestPort: vi.fn(() => of({} as unknown as SerialPort)),
-      get bytes$() {
-        return of(new Uint8Array());
-      },
-      get text$() {
-        return of('');
-      },
-      get lines$() {
-        return of('');
-      },
-      send$: vi.fn(() => of(undefined)),
-      getPorts: vi.fn(() => of([])),
-    };
+    await expect(firstValueFrom(service.connect$())).rejects.toBe(boom);
+  });
 
-    vi.mocked(webSerialRxjs.createSerialClient).mockReturnValueOnce(
-      errorClient as unknown as SerialClient,
+  it('should forward incoming receive$ chunks', async () => {
+    const mock = latestMock();
+    const pending = firstValueFrom(service.receive$);
+    mock.receiveSubject.next('chunk-1');
+    await expect(pending).resolves.toBe('chunk-1');
+  });
+
+  it('should forward errors$ emissions', async () => {
+    const mock = latestMock();
+    const pending = firstValueFrom(service.errors$);
+    const error = new webSerialRxjs.SerialError(
+      webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+      'boom',
     );
-
-    try {
-      await firstValueFrom(errorService.connect());
-    } catch {
-      // Expected to throw
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const errorState = await firstValueFrom(errorService.connectionState);
-    expect(errorState.error).toBeTruthy();
-    expect(errorState.connected).toBe(false);
-  });
-
-  it('should provide async methods', async () => {
-    // Test connectAsync
-    await service.connectAsync(9600);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const connectedState = await firstValueFrom(service.connectionState);
-    expect(connectedState.connected).toBe(true);
-
-    // Test disconnectAsync
-    await service.disconnectAsync();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const disconnectedState = await firstValueFrom(service.connectionState);
-    expect(disconnectedState.connected).toBe(false);
-
-    // Test requestPortAsync
-    await service.requestPortAsync();
-
-    // Test sendAsync
-    await service.connectAsync();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    await service.sendAsync('test');
+    mock.errorsSubject.next(error);
+    await expect(pending).resolves.toBe(error);
   });
 });

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -1,443 +1,69 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import {
-  createSerialClient,
-  isBrowserSupported,
-  SerialClient,
+  createSerialSession,
   SerialError,
+  SerialSession,
+  SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  firstValueFrom,
-  Observable,
-  Subscription,
-} from 'rxjs';
+import { Observable, ReplaySubject, switchMap } from 'rxjs';
 
 /**
- * SerialClient の接続状態を表す型
- */
-export interface SerialConnectionState {
-  /** 接続中かどうか */
-  connected: boolean;
-  /** 接続中かどうか */
-  connecting: boolean;
-  /** 切断中かどうか */
-  disconnecting: boolean;
-  /** エラーが発生したかどうか */
-  error: string | null;
-}
-
-/**
- * Web Serial API を使用するための Angular Service
+ * v2 SerialSession を薄くラップした Angular Service。
+ *
+ * 状態 (`state$`)・受信 (`receive$`)・エラー (`errors$`) はライブラリ側の
+ * ストリームをそのまま公開する。旧実装にあった `BehaviorSubject` ベースの
+ * 接続状態再合成・`text$` 手動購読・read loop 管理は一切持たない。
+ *
+ * @see https://github.com/gurezo/web-serial-rxjs/issues/199
+ * @see https://github.com/gurezo/web-serial-rxjs/issues/205
  */
 @Injectable({ providedIn: 'root' })
 export class SerialClientService implements OnDestroy {
-  private client: SerialClient | null = null;
-  private readSubscription: Subscription | null = null;
-  private stateSubscription: Subscription | null = null;
-  private baudRate = 9600;
+  private readonly sessions$ = new ReplaySubject<SerialSession>(1);
+  private currentSession: SerialSession;
+  private currentBaudRate: number;
 
-  private readonly browserSupported$ = new BehaviorSubject<boolean>(false);
-  private readonly connectionState$ =
-    new BehaviorSubject<SerialConnectionState>({
-      connected: false,
-      connecting: false,
-      disconnecting: false,
-      error: null,
-    });
-  private readonly receivedData$ = new BehaviorSubject<string>('');
-
-  /**
-   * ブラウザサポート状態のObservable
-   */
-  get browserSupported(): Observable<boolean> {
-    return this.browserSupported$.asObservable();
-  }
-
-  /**
-   * 接続状態のObservable
-   */
-  get connectionState(): Observable<SerialConnectionState> {
-    return this.connectionState$.asObservable();
-  }
-
-  /**
-   * 受信データのObservable
-   */
-  get receivedData(): Observable<string> {
-    return this.receivedData$.asObservable();
-  }
+  readonly state$: Observable<SerialSessionState>;
+  readonly receive$: Observable<string>;
+  readonly errors$: Observable<SerialError>;
 
   constructor() {
-    // ブラウザサポートをチェック
-    const supported = isBrowserSupported();
-    this.browserSupported$.next(supported);
+    this.currentBaudRate = 9600;
+    this.currentSession = createSerialSession({
+      baudRate: this.currentBaudRate,
+    });
+    this.sessions$.next(this.currentSession);
+
+    this.state$ = this.sessions$.pipe(switchMap((session) => session.state$));
+    this.receive$ = this.sessions$.pipe(
+      switchMap((session) => session.receive$),
+    );
+    this.errors$ = this.sessions$.pipe(switchMap((session) => session.errors$));
   }
 
   ngOnDestroy(): void {
-    this.cleanup();
+    this.currentSession.disconnect$().subscribe({ error: () => void 0 });
+    this.sessions$.complete();
   }
 
-  /**
-   * クリーンアップ処理
-   */
-  private cleanup(): void {
-    if (this.readSubscription) {
-      this.readSubscription.unsubscribe();
-      this.readSubscription = null;
-    }
-    if (this.stateSubscription) {
-      this.stateSubscription.unsubscribe();
-      this.stateSubscription = null;
-    }
-    if (this.client?.connected) {
-      this.client.disconnect().subscribe();
-    }
+  isBrowserSupported(): boolean {
+    return this.currentSession.isBrowserSupported();
   }
 
-  /**
-   * 読み取りを開始
-   */
-  private startReading(): void {
-    if (!this.client || !this.client.connected) {
-      return;
+  connect$(baudRate?: number): Observable<void> {
+    if (baudRate !== undefined && baudRate !== this.currentBaudRate) {
+      this.currentBaudRate = baudRate;
+      this.currentSession = createSerialSession({ baudRate });
+      this.sessions$.next(this.currentSession);
     }
-
-    // 既存の購読を停止
-    if (this.readSubscription) {
-      this.readSubscription.unsubscribe();
-      this.readSubscription = null;
-    }
-
-    const readStream$ = this.client.text$;
-
-    this.readSubscription = readStream$.subscribe({
-      next: (text: string) => {
-        // 受信データを追加
-        this.receivedData$.next(this.receivedData$.value + text);
-      },
-      error: (error: unknown) => {
-        let message = '読み取りエラーが発生しました。';
-        if (error instanceof SerialError) {
-          message = `エラー: ${error.message}`;
-        } else if (error instanceof Error) {
-          message = `エラー: ${error.message}`;
-        }
-        this.connectionState$.next({
-          ...this.connectionState$.value,
-          error: message,
-        });
-        // 読み取りエラー時は切断
-        this.disconnect();
-      },
-    });
+    return this.currentSession.connect$();
   }
 
-  /**
-   * 読み取りを停止
-   */
-  private stopReading(): void {
-    if (this.readSubscription) {
-      this.readSubscription.unsubscribe();
-      this.readSubscription = null;
-    }
+  disconnect$(): Observable<void> {
+    return this.currentSession.disconnect$();
   }
 
-  private subscribeState(): void {
-    if (!this.client) {
-      return;
-    }
-    const state$ = (this.client as unknown as { state$?: Observable<unknown> })
-      .state$;
-    if (!state$ || typeof state$.subscribe !== 'function') {
-      return;
-    }
-    if (this.stateSubscription) {
-      this.stateSubscription.unsubscribe();
-    }
-    this.stateSubscription = this.client.state$.subscribe((state) => {
-      if (state.kind === 'error') {
-        this.connectionState$.next({
-          connected: false,
-          connecting: false,
-          disconnecting: false,
-          error: `エラー: ${state.error.message}`,
-        });
-        return;
-      }
-
-      this.connectionState$.next({
-        ...this.connectionState$.value,
-        connected: state.kind === 'connected',
-        connecting: state.kind === 'connecting',
-        disconnecting: state.kind === 'disconnecting',
-      });
-      if (state.kind === 'unsupported' && !state.support.supported) {
-        this.connectionState$.next({
-          ...this.connectionState$.value,
-          error: state.support.reason,
-        });
-      }
-    });
-  }
-
-  /**
-   * 接続を開始
-   */
-  connect(baudRate?: number): Observable<void> {
-    if (baudRate) {
-      this.baudRate = baudRate;
-    }
-
-    if (!this.client) {
-      this.client = createSerialClient({
-        baudRate: this.baudRate,
-      });
-      this.subscribeState();
-    }
-
-    this.connectionState$.next({
-      connected: false,
-      connecting: true,
-      disconnecting: false,
-      error: null,
-    });
-
-    return new Observable<void>((observer) => {
-      if (!this.client) {
-        observer.error(new Error('SerialClient が初期化されていません'));
-        return;
-      }
-
-      const subscription = this.client.connect().subscribe({
-        next: () => {
-          this.connectionState$.next({
-            connected: true,
-            connecting: false,
-            disconnecting: false,
-            error: null,
-          });
-          this.startReading();
-          observer.next();
-          observer.complete();
-        },
-        error: (error: unknown) => {
-          let message = '接続エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          this.connectionState$.next({
-            connected: false,
-            connecting: false,
-            disconnecting: false,
-            error: message,
-          });
-          observer.error(error);
-        },
-      });
-
-      return () => {
-        subscription.unsubscribe();
-      };
-    });
-  }
-
-  /**
-   * 切断
-   */
-  disconnect(): Observable<void> {
-    if (!this.client || !this.client.connected) {
-      return new Observable<void>((observer) => {
-        observer.next();
-        observer.complete();
-      });
-    }
-
-    this.stopReading();
-
-    this.connectionState$.next({
-      ...this.connectionState$.value,
-      disconnecting: true,
-    });
-
-    return new Observable<void>((observer) => {
-      if (!this.client) {
-        observer.next();
-        observer.complete();
-        return;
-      }
-
-      const subscription = this.client.disconnect().subscribe({
-        next: () => {
-          this.connectionState$.next({
-            connected: false,
-            connecting: false,
-            disconnecting: false,
-            error: null,
-          });
-          observer.next();
-          observer.complete();
-        },
-        error: (error: unknown) => {
-          let message = '切断エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          // エラーが発生しても UI は切断状態にする
-          this.connectionState$.next({
-            connected: false,
-            connecting: false,
-            disconnecting: false,
-            error: message,
-          });
-          observer.error(error);
-        },
-      });
-
-      return () => {
-        subscription.unsubscribe();
-      };
-    });
-  }
-
-  /**
-   * ポートをリクエスト
-   */
-  requestPort(): Observable<void> {
-    if (!this.client) {
-      this.client = createSerialClient({
-        baudRate: this.baudRate,
-      });
-    }
-
-    return new Observable<void>((observer) => {
-      if (!this.client) {
-        observer.error(new Error('SerialClient が初期化されていません'));
-        return;
-      }
-
-      const subscription = this.client.requestPort().subscribe({
-        next: () => {
-          this.connectionState$.next({
-            ...this.connectionState$.value,
-            error: null,
-          });
-          observer.next();
-          observer.complete();
-        },
-        error: (error: unknown) => {
-          let message = 'ポート選択エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          this.connectionState$.next({
-            ...this.connectionState$.value,
-            error: message,
-          });
-          observer.error(error);
-        },
-      });
-
-      return () => {
-        subscription.unsubscribe();
-      };
-    });
-  }
-
-  /**
-   * データを送信
-   */
-  send(data: string): Observable<void> {
-    if (!this.client || !this.client.connected) {
-      return new Observable<void>((observer) => {
-        observer.error(
-          new Error(
-            '接続されていません。先にシリアルポートに接続してください。',
-          ),
-        );
-      });
-    }
-
-    const text = data.trim();
-    if (!text) {
-      return new Observable<void>((observer) => {
-        observer.next();
-        observer.complete();
-      });
-    }
-
-    // テキストを Uint8Array に変換（UTF-8 エンコード）
-    const payload = `${text}\n`;
-
-    return new Observable<void>((observer) => {
-      if (!this.client) {
-        observer.error(new Error('SerialClient が初期化されていません'));
-        return;
-      }
-
-      const subscription = this.client.send$(payload).subscribe({
-        next: () => {
-          observer.next();
-          observer.complete();
-        },
-        error: (error: unknown) => {
-          let message = '送信エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          this.connectionState$.next({
-            ...this.connectionState$.value,
-            error: message,
-          });
-          observer.error(error);
-        },
-      });
-
-      return () => {
-        subscription.unsubscribe();
-      };
-    });
-  }
-
-  /**
-   * 受信データをクリア
-   */
-  clearReceivedData(): void {
-    this.receivedData$.next('');
-  }
-
-  /**
-   * Promise版の接続メソッド（コンポーネントでの使用を簡単にするため）
-   */
-  async connectAsync(baudRate?: number): Promise<void> {
-    return firstValueFrom(this.connect(baudRate));
-  }
-
-  /**
-   * Promise版の切断メソッド（コンポーネントでの使用を簡単にするため）
-   */
-  async disconnectAsync(): Promise<void> {
-    return firstValueFrom(this.disconnect());
-  }
-
-  /**
-   * Promise版のポートリクエストメソッド（コンポーネントでの使用を簡単にするため）
-   */
-  async requestPortAsync(): Promise<void> {
-    return firstValueFrom(this.requestPort());
-  }
-
-  /**
-   * Promise版の送信メソッド（コンポーネントでの使用を簡単にするため）
-   */
-  async sendAsync(data: string): Promise<void> {
-    return firstValueFrom(this.send(data));
+  send$(data: string | Uint8Array): Observable<void> {
+    return this.currentSession.send$(data);
   }
 }


### PR DESCRIPTION
## Summary
<!--
日本語: 何を・なぜ変更したかを1〜3行で書いてください
English: Briefly describe what you changed and why (1–3 lines)
-->
Angular example を v2 `SerialSession` API ベースに書き換え、アプリ側に残っていた `BehaviorSubject` ベースの接続状態再合成・`text$` の手動購読ループ・Promise ラッパーを削除し、`state$` / `receive$` / `errors$` を直接利用する構成に揃えた (#199 の完了条件である「apps から state 管理コードを消す」の Angular 分)。

## Type of change
<!--
日本語: 該当するものにチェックを入れてください
English: Check the relevant items
-->
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
<!--
日本語: 関連する Issue があれば記載してください
English: Link related issues (use "Fixes #123" to auto-close)
-->
- Fixes #205
- refs #199 (Angular example の完了条件分のみ達成。旧 API 削除・Vue/React/Svelte refactor は別 PR)

## What changed?
<!--
日本語: 主な変更点を箇条書きで書いてください
English: List the main changes in bullet points
-->
- \`apps/example-angular/src/app/services/serial-client.service.ts\` を \`createSerialSession\` を保持するだけの薄いラッパーに書き換え (443 → 69 行)。\`BehaviorSubject<SerialConnectionState>\` / \`receivedData$\` / \`startReading\`/\`stopReading\` / \`subscribeState\` / \`connectAsync\` ほか Promise ラッパーをすべて削除。
- \`apps/example-angular/src/app/app.ts\` / \`app.html\` を \`state$\` / \`receive$\` / \`errors$\` の直接購読に変更。\`SerialSessionState\` の文字列比較と Angular Signal + \`takeUntilDestroyed\` で UI を駆動し、ポート選択ボタンと \`SerialConnectionState\` 型・ヘルパー getter 群を撤去。
- \`apps/example-angular/src/app/services/serial-client.service.spec.ts\` を \`createSerialSession\` モックに再構築。state 遷移伝播・baudRate 変更時のセッション再生成・\`receive$\` / \`errors$\` の透過・\`connect$\` エラー伝播を検証。

## API / Compatibility
<!--
日本語: 公開 API や互換性への影響があれば明記してください
English: Describe any impact on public APIs or compatibility
-->
- [x] Public API changes (export / function signature / behavior)
  - Details: \`@gurezo/web-serial-rxjs\` 自体の public API は変更なし。Angular example 内部の \`SerialClientService\` のシグネチャは刷新 (旧: \`connectionState\` / \`receivedData\` / \`connectAsync\` 等 → 新: \`state$\` / \`receive$\` / \`errors$\` / \`connect$\` / \`disconnect$\` / \`send$\`)。example アプリのみ利用する内部 API のため互換性影響は限定的。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
<!--
日本語: 動作確認の手順を具体的に書いてください
English: Describe how reviewers can test this change
-->
1. \`pnpm install\`
2. \`pnpm nx run example-angular:test\` がすべて green であることを確認 (12 tests)
3. \`pnpm nx run example-angular:lint\` が error なしであることを確認
4. \`pnpm nx run example-angular:serve\` で Chromium 系ブラウザから起動し、接続 → 受信 → 送信 → 切断のライフサイクルと、USB 抜去時に \`state$\` が \`error\` に遷移しエラー表示が更新されることを確認

## Environment (if relevant)
<!--
日本語: バグ修正・挙動変更の場合は記載してください
English: Required for bug fixes or behavior changes
-->
- Browser: Chrome / Edge / Opera (Chromium 系)
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): workspace 最新 (v2 SerialSession API)
- RxJS version: workspace 固定

## Checklist
<!--
日本語: PR 作成前の確認事項です
English: Please confirm before submitting
-->
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)