### PR TITLE
refactor(example-vue): Vue example を SerialSession API に移行 (refs #206 #199)

### DIFF
--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -1,144 +1,100 @@
+import type {
+  SerialError,
+  SerialSession,
+  SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
 import { mount } from '@vue/test-utils';
-// @ts-expect-error - Mocked module, types not needed at runtime
-import type { SerialClient } from '@gurezo/web-serial-rxjs';
-import type { Observable } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // @ts-expect-error - Vue SFC file, types are defined in vue-shims.d.ts
 import App from './App.vue';
 
-// Mock the web-serial-rxjs library
-vi.mock('@gurezo/web-serial-rxjs', () => {
-  let isConnected = false;
-  const mockClient = {
-    get connected() {
-      return isConnected;
-    },
-    currentPort: null,
-    connect: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const timeoutId = setTimeout(() => {
-            isConnected = true;
-            if (observer.next) {
-              observer.next();
-            }
-            if (observer.complete) {
-              observer.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as () => Observable<void>,
-    disconnect: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const obs = observer;
-          const timeoutId = setTimeout(() => {
-            isConnected = false;
-            if (obs?.next) {
-              obs.next();
-            }
-            if (obs?.complete) {
-              obs.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as () => Observable<void>,
-    requestPort: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: (port: SerialPort) => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const timeoutId = setTimeout(() => {
-            if (observer.next) {
-              observer.next({} as SerialPort);
-            }
-            if (observer.complete) {
-              observer.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as () => Observable<SerialPort>,
-    text$: {
-      subscribe: vi.fn(() => ({
-        unsubscribe: vi.fn(),
-      })) as unknown as (observer: {
-        next?: (text: string) => void;
-        error?: (error: unknown) => void;
-        complete?: () => void;
-      }) => { unsubscribe: () => void },
-    } as unknown as Observable<string>,
-    send$: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const timeoutId = setTimeout(() => {
-            if (observer.next) {
-              observer.next();
-            }
-            if (observer.complete) {
-              observer.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as (data: string) => Observable<void>,
-    getPorts: vi.fn(() => ({
-      subscribe: vi.fn(),
-    })) as unknown as () => Observable<SerialPort[]>,
+interface MockSession {
+  session: SerialSession;
+  stateSubject: BehaviorSubject<SerialSessionState>;
+  receiveSubject: Subject<string>;
+  errorsSubject: Subject<SerialError>;
+  connect$: ReturnType<typeof vi.fn>;
+  disconnect$: ReturnType<typeof vi.fn>;
+  send$: ReturnType<typeof vi.fn>;
+  isBrowserSupported: ReturnType<typeof vi.fn>;
+}
+
+const createMockSession = (): MockSession => {
+  const stateSubject = new BehaviorSubject<SerialSessionState>('idle');
+  const receiveSubject = new Subject<string>();
+  const errorsSubject = new Subject<SerialError>();
+  const connect$ = vi.fn(() => {
+    stateSubject.next('connecting');
+    stateSubject.next('connected');
+    return of(undefined);
+  });
+  const disconnect$ = vi.fn(() => {
+    stateSubject.next('disconnecting');
+    stateSubject.next('idle');
+    return of(undefined);
+  });
+  const send$ = vi.fn(() => of(undefined));
+  const isBrowserSupported = vi.fn(() => true);
+
+  const session: SerialSession = {
+    isBrowserSupported,
+    connect$,
+    disconnect$,
+    send$,
+    state$: stateSubject.asObservable(),
+    errors$: errorsSubject.asObservable(),
+    receive$: receiveSubject.asObservable(),
   };
 
   return {
-    createSerialClient: vi.fn(() => mockClient) as unknown as (options?: {
-      baudRate?: number;
-    }) => SerialClient,
-    isBrowserSupported: vi.fn(() => true),
-    SerialError: class MockSerialError extends Error {
-      constructor(message: string) {
-        super(message);
-        this.name = 'SerialError';
-      }
-    },
+    session,
+    stateSubject,
+    receiveSubject,
+    errorsSubject,
+    connect$,
+    disconnect$,
+    send$,
+    isBrowserSupported,
+  };
+};
+
+let mockSessions: MockSession[] = [];
+
+vi.mock('@gurezo/web-serial-rxjs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
+      '@gurezo/web-serial-rxjs',
+    );
+  return {
+    ...actual,
+    createSerialSession: vi.fn(() => {
+      const mock = createMockSession();
+      mockSessions.push(mock);
+      return mock.session;
+    }),
   };
 });
+
+const latestMock = (): MockSession => {
+  const mock = mockSessions.at(-1);
+  if (!mock) {
+    throw new Error('createSerialSession was not called');
+  }
+  return mock;
+};
 
 describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSessions = [];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should render the app', () => {
+  it('should render the app header', () => {
     const wrapper = mount(App);
     expect(wrapper.text()).toContain('Web Serial RxJS - Vue Example');
     expect(wrapper.text()).toContain(
@@ -146,30 +102,29 @@ describe('App', () => {
     );
   });
 
-  it('should display browser support status', async () => {
+  it('should display browser support status', () => {
     const wrapper = mount(App);
-    // Wait for onMounted to execute
-    await new Promise((resolve) => setTimeout(resolve, 10));
     expect(wrapper.text()).toContain(
       'ブラウザは Web Serial API をサポートしています。',
     );
   });
 
-  it('should have connection buttons', () => {
+  it('should render connect and disconnect buttons (no port picker)', () => {
     const wrapper = mount(App);
-    expect(wrapper.text()).toContain('ポートを選択');
-    expect(wrapper.text()).toContain('接続');
-    expect(wrapper.text()).toContain('切断');
+    const text = wrapper.text();
+    expect(text).toContain('接続');
+    expect(text).toContain('切断');
+    expect(text).not.toContain('ポートを選択');
   });
 
-  it('should have baud rate selector', () => {
+  it('should have baud rate selector defaulting to 9600', () => {
     const wrapper = mount(App);
     const baudRateSelect = wrapper.find('#baud-rate');
     expect(baudRateSelect.exists()).toBe(true);
     expect((baudRateSelect.element as HTMLSelectElement).value).toBe('9600');
   });
 
-  it('should change baud rate', async () => {
+  it('should change baud rate value', async () => {
     const wrapper = mount(App);
     const baudRateSelect = wrapper.find('#baud-rate');
 
@@ -177,71 +132,64 @@ describe('App', () => {
     expect((baudRateSelect.element as HTMLSelectElement).value).toBe('115200');
   });
 
-  it('should connect when connect button is clicked', async () => {
+  it('should show connected status after clicking connect', async () => {
     const wrapper = mount(App);
-    // Wait for onMounted to execute
-    await new Promise((resolve) => setTimeout(resolve, 10));
 
-    const connectButtons = wrapper.findAll('.btn-primary');
-    const connectButton = connectButtons[0]; // First primary button is connect
-
+    const connectButton = wrapper.findAll('.btn-primary')[0];
     await connectButton.trigger('click');
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await wrapper.vm.$nextTick();
 
+    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
     expect(wrapper.text()).toContain('シリアルポートに接続しました。');
   });
 
-  it('should disconnect when disconnect button is clicked', async () => {
+  it('should show disconnected status after clicking disconnect', async () => {
     const wrapper = mount(App);
-    // Wait for onMounted to execute
-    await new Promise((resolve) => setTimeout(resolve, 10));
 
-    // First connect
-    const connectButtons = wrapper.findAll('.btn-primary');
-    const connectButton = connectButtons[0];
+    const connectButton = wrapper.findAll('.btn-primary')[0];
     await connectButton.trigger('click');
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await wrapper.vm.$nextTick();
 
-    expect(wrapper.text()).toContain('シリアルポートに接続しました。');
-
-    // Then disconnect
     const disconnectButton = wrapper.find('.btn-secondary');
     await disconnectButton.trigger('click');
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await wrapper.vm.$nextTick();
 
+    expect(latestMock().disconnect$).toHaveBeenCalledTimes(1);
     expect(wrapper.text()).toContain('シリアルポートに接続していません。');
   });
 
-  it('should send data when send button is clicked', async () => {
+  it('should send data through the session and clear the input', async () => {
     const wrapper = mount(App);
-    // Wait for onMounted to execute
-    await new Promise((resolve) => setTimeout(resolve, 10));
 
-    // Connect first
-    const connectButtons = wrapper.findAll('.btn-primary');
-    const connectButton = connectButtons[0];
+    const connectButton = wrapper.findAll('.btn-primary')[0];
     await connectButton.trigger('click');
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await wrapper.vm.$nextTick();
 
-    expect(wrapper.text()).toContain('シリアルポートに接続しました。');
-
-    // Enter data and send
     const sendInput = wrapper.find('#send-input');
-    const sendButton = connectButtons[1]; // Second primary button is send
+    const sendButton = wrapper.findAll('.btn-primary')[1];
 
     await sendInput.setValue('test message');
     await sendButton.trigger('click');
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await wrapper.vm.$nextTick();
 
-    // Input should be cleared after sending
+    expect(latestMock().send$).toHaveBeenCalledWith('test message\n');
     expect((sendInput.element as HTMLInputElement).value).toBe('');
   });
 
-  it('should clear received data when clear button is clicked', async () => {
+  it('should disable the clear button when there is no received data', () => {
     const wrapper = mount(App);
 
     const clearButton = wrapper.find('.btn-secondary');
-    // Should be disabled when no data
     expect(clearButton.attributes('disabled')).toBeDefined();
+  });
+
+  it('should display errorMessage when errors$ emits', async () => {
+    const wrapper = mount(App);
+    const mock = latestMock();
+
+    mock.errorsSubject.next({ message: 'write failed' } as SerialError);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.text()).toContain('エラー: write failed');
   });
 });

--- a/apps/example-vue/src/app/App.vue
+++ b/apps/example-vue/src/app/App.vue
@@ -1,104 +1,88 @@
 <script setup lang="ts">
-import { ref, computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useSerialClient } from '../composables/useSerialClient';
 
-/**
- * メインアプリケーションコンポーネント
- */
+type StatusType = 'info' | 'success' | 'error';
+
 const baudRate = ref(9600);
 const sendInput = ref('');
 
 const {
   browserSupported,
-  connectionState,
+  state,
   receivedData,
-  connect,
-  disconnect,
-  requestPort,
-  send,
+  errorMessage,
+  connect$,
+  disconnect$,
+  send$,
   clearReceivedData,
 } = useSerialClient(baudRate.value);
 
-/**
- * 接続ボタンのハンドラ
- */
-const handleConnect = async () => {
-  try {
-    await connect(baudRate.value);
-  } catch (error) {
-    // エラーは useSerialClient 内で処理される
-    console.error('接続エラー:', error);
+const connected = computed(() => state.value === 'connected');
+const connecting = computed(() => state.value === 'connecting');
+const disconnecting = computed(() => state.value === 'disconnecting');
+
+const status = computed<{ type: StatusType; message: string }>(() => {
+  if (errorMessage.value) {
+    return { type: 'error', message: `エラー: ${errorMessage.value}` };
   }
+  switch (state.value) {
+    case 'connecting':
+      return { type: 'info', message: '接続中...' };
+    case 'disconnecting':
+      return { type: 'info', message: '切断中...' };
+    case 'connected':
+      return { type: 'success', message: 'シリアルポートに接続しました。' };
+    case 'unsupported':
+      return {
+        type: 'error',
+        message:
+          'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
+      };
+    case 'error':
+      return { type: 'error', message: 'エラーが発生しました。' };
+    default:
+      return { type: 'info', message: 'シリアルポートに接続していません。' };
+  }
+});
+
+const handleConnect = () => {
+  connect$(baudRate.value).subscribe({
+    error: (error: unknown) => {
+      console.error('接続エラー:', error);
+    },
+  });
 };
 
-/**
- * 切断ボタンのハンドラ
- */
-const handleDisconnect = async () => {
-  try {
-    await disconnect();
-  } catch (error) {
-    // エラーは useSerialClient 内で処理される
-    console.error('切断エラー:', error);
-  }
+const handleDisconnect = () => {
+  disconnect$().subscribe({
+    error: (error: unknown) => {
+      console.error('切断エラー:', error);
+    },
+  });
 };
 
-/**
- * ポートリクエストボタンのハンドラ
- */
-const handleRequestPort = async () => {
-  try {
-    await requestPort();
-  } catch (error) {
-    // エラーは useSerialClient 内で処理される
-    console.error('ポート選択エラー:', error);
-  }
-};
-
-/**
- * 送信ボタンのハンドラ
- */
-const handleSend = async () => {
-  if (!sendInput.value.trim()) {
+const handleSend = () => {
+  const text = sendInput.value.trim();
+  if (!text) {
     return;
   }
-
-  try {
-    await send(sendInput.value);
-    sendInput.value = ''; // 送信成功後に入力欄をクリア
-  } catch (error) {
-    console.error('送信エラー:', error);
-  }
+  send$(`${text}\n`).subscribe({
+    next: () => {
+      sendInput.value = '';
+    },
+    error: (error: unknown) => {
+      console.error('送信エラー:', error);
+    },
+  });
 };
 
-/**
- * Enter キーで送信
- */
 const handleKeyDown = (e: KeyboardEvent) => {
   if (e.key === 'Enter' && !e.shiftKey) {
     e.preventDefault();
     handleSend();
   }
 };
-
-/**
- * ステータスメッセージを取得
- */
-const status = computed(() => {
-  if (connectionState.value.error) {
-    return { type: 'error', message: connectionState.value.error };
-  }
-  if (connectionState.value.connecting) {
-    return { type: 'info', message: '接続中...' };
-  }
-  if (connectionState.value.disconnecting) {
-    return { type: 'info', message: '切断中...' };
-  }
-  if (connectionState.value.connected) {
-    return { type: 'success', message: 'シリアルポートに接続しました。' };
-  }
-  return { type: 'info', message: 'シリアルポートに接続していません。' };
-});
 </script>
 
 <template>
@@ -138,7 +122,7 @@ const status = computed(() => {
             class="form-control"
             :value="baudRate"
             @change="(e) => (baudRate = Number((e.target as HTMLSelectElement).value))"
-            :disabled="connectionState.connected"
+            :disabled="connected"
           >
             <option :value="9600">9600</option>
             <option :value="19200">19200</option>
@@ -149,33 +133,16 @@ const status = computed(() => {
         </div>
         <div class="button-group">
           <button
-            class="btn btn-outline"
-            @click="handleRequestPort"
-            :disabled="
-              !browserSupported ||
-              connectionState.connected ||
-              connectionState.connecting
-            "
-          >
-            ポートを選択
-          </button>
-          <button
             class="btn btn-primary"
             @click="handleConnect"
-            :disabled="
-              !browserSupported ||
-              connectionState.connected ||
-              connectionState.connecting
-            "
+            :disabled="!browserSupported || connected || connecting"
           >
             接続
           </button>
           <button
             class="btn btn-secondary"
             @click="handleDisconnect"
-            :disabled="
-              !connectionState.connected || connectionState.disconnecting
-            "
+            :disabled="!connected || disconnecting"
           >
             切断
           </button>
@@ -197,13 +164,13 @@ const status = computed(() => {
               class="form-control"
               v-model="sendInput"
               @keydown="handleKeyDown"
-              :disabled="!connectionState.connected"
+              :disabled="!connected"
               placeholder="送信するテキストを入力..."
             />
             <button
               class="btn btn-primary"
               @click="handleSend"
-              :disabled="!connectionState.connected || !sendInput.trim()"
+              :disabled="!connected || !sendInput.trim()"
             >
               送信
             </button>

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -1,294 +1,227 @@
-import { mount } from '@vue/test-utils';
-// @ts-expect-error - Mocked module, types not needed at runtime
-import type { SerialClient } from '@gurezo/web-serial-rxjs';
-// @ts-expect-error - Mocked module, types not needed at runtime
+import type {
+  SerialError,
+  SerialSession,
+  SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
-import type { Observable } from 'rxjs';
+import { mount } from '@vue/test-utils';
+import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSerialClient } from './useSerialClient';
 
-// Test component to use the composable
-const TestComponent = {
-  setup() {
-    const serialClient = useSerialClient(9600);
-    // Expose all properties for testing by using them in template
-    return {
-      ...serialClient,
-      // Also expose as methods for easier access
-      getBrowserSupported: () => serialClient.browserSupported.value,
-      getConnectionState: () => serialClient.connectionState.value,
-      getReceivedData: () => serialClient.receivedData.value,
-    };
-  },
-  template:
-    '<div>{{ browserSupported }} {{ connectionState.connected }} {{ receivedData }}</div>',
-} as any;
+interface MockSession {
+  session: SerialSession;
+  stateSubject: BehaviorSubject<SerialSessionState>;
+  receiveSubject: Subject<string>;
+  errorsSubject: Subject<SerialError>;
+  connect$: ReturnType<typeof vi.fn>;
+  disconnect$: ReturnType<typeof vi.fn>;
+  send$: ReturnType<typeof vi.fn>;
+  isBrowserSupported: ReturnType<typeof vi.fn>;
+}
 
-// Mock the web-serial-rxjs library
-vi.mock('@gurezo/web-serial-rxjs', () => {
-  let isConnected = false;
-  const mockClient = {
-    get connected() {
-      return isConnected;
-    },
-    currentPort: null,
-    connect: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const timeoutId = setTimeout(() => {
-            isConnected = true;
-            if (observer.next) {
-              observer.next();
-            }
-            if (observer.complete) {
-              observer.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as () => Observable<void>,
-    disconnect: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const obs = observer;
-          const timeoutId = setTimeout(() => {
-            isConnected = false;
-            if (obs?.next) {
-              obs.next();
-            }
-            if (obs?.complete) {
-              obs.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as () => Observable<void>,
-    requestPort: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: (port: SerialPort) => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const timeoutId = setTimeout(() => {
-            if (observer.next) {
-              observer.next({} as SerialPort);
-            }
-            if (observer.complete) {
-              observer.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as () => Observable<SerialPort>,
-    text$: {
-      subscribe: vi.fn(() => ({
-        unsubscribe: vi.fn(),
-      })) as unknown as (observer: {
-        next?: (text: string) => void;
-        error?: (error: unknown) => void;
-        complete?: () => void;
-      }) => { unsubscribe: () => void },
-    } as unknown as Observable<string>,
-    send$: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          const timeoutId = setTimeout(() => {
-            if (observer.next) {
-              observer.next();
-            }
-            if (observer.complete) {
-              observer.complete();
-            }
-          }, 0);
-          return {
-            unsubscribe: () => clearTimeout(timeoutId),
-          };
-        },
-      ),
-    })) as unknown as (data: string) => Observable<void>,
-    getPorts: vi.fn(() => ({
-      subscribe: vi.fn(),
-    })) as unknown as () => Observable<SerialPort[]>,
+const createMockSession = (): MockSession => {
+  const stateSubject = new BehaviorSubject<SerialSessionState>('idle');
+  const receiveSubject = new Subject<string>();
+  const errorsSubject = new Subject<SerialError>();
+  const connect$ = vi.fn(() => of(undefined));
+  const disconnect$ = vi.fn(() => of(undefined));
+  const send$ = vi.fn(() => of(undefined));
+  const isBrowserSupported = vi.fn(() => true);
+
+  const session: SerialSession = {
+    isBrowserSupported,
+    connect$,
+    disconnect$,
+    send$,
+    state$: stateSubject.asObservable(),
+    errors$: errorsSubject.asObservable(),
+    receive$: receiveSubject.asObservable(),
   };
 
   return {
-    createSerialClient: vi.fn(() => mockClient) as unknown as (options?: {
-      baudRate?: number;
-    }) => SerialClient,
-    isBrowserSupported: vi.fn(() => true),
-    SerialError: class MockSerialError extends Error {
-      constructor(message: string) {
-        super(message);
-        this.name = 'SerialError';
-      }
-    },
+    session,
+    stateSubject,
+    receiveSubject,
+    errorsSubject,
+    connect$,
+    disconnect$,
+    send$,
+    isBrowserSupported,
+  };
+};
+
+let mockSessions: MockSession[] = [];
+
+vi.mock('@gurezo/web-serial-rxjs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
+      '@gurezo/web-serial-rxjs',
+    );
+  return {
+    ...actual,
+    createSerialSession: vi.fn(() => {
+      const mock = createMockSession();
+      mockSessions.push(mock);
+      return mock.session;
+    }),
   };
 });
+
+const latestMock = (): MockSession => {
+  const mock = mockSessions.at(-1);
+  if (!mock) {
+    throw new Error('createSerialSession was not called');
+  }
+  return mock;
+};
+
+// Test harness that mounts the composable inside a component so
+// `onUnmounted` works as in real usage.
+const TestComponent = {
+  setup() {
+    const api = useSerialClient(9600);
+    return { api };
+  },
+  template: '<div />',
+} as const;
+
+const mountHarness = () => {
+  const wrapper = mount(TestComponent);
+  return {
+    wrapper,
+    api: (wrapper.vm as unknown as { api: ReturnType<typeof useSerialClient> })
+      .api,
+  };
+};
 
 describe('useSerialClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSessions = [];
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should initialize with default values', async () => {
-    const wrapper = mount(TestComponent);
-    await wrapper.vm.$nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const vm = wrapper.vm as any;
-    expect(vm.getBrowserSupported()).toBe(true);
-    expect(vm.getConnectionState().connected).toBe(false);
-    expect(vm.getConnectionState().connecting).toBe(false);
-    expect(vm.getConnectionState().disconnecting).toBe(false);
-    expect(vm.getConnectionState().error).toBe(null);
-    expect(vm.getReceivedData()).toBe('');
+  it('should create a session with the initial baud rate', () => {
+    mountHarness();
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenCalledTimes(1);
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenCalledWith({ baudRate: 9600 });
   });
 
-  it('should check browser support on mount', async () => {
-    mount(TestComponent);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(vi.mocked(webSerialRxjs.isBrowserSupported)).toHaveBeenCalled();
+  it('should initialize with default refs', () => {
+    const { api } = mountHarness();
+    expect(api.browserSupported.value).toBe(true);
+    expect(api.state.value).toBe('idle');
+    expect(api.receivedData.value).toBe('');
+    expect(api.errorMessage.value).toBe(null);
   });
 
-  it('should connect to serial port', async () => {
-    const wrapper = mount(TestComponent);
-    await wrapper.vm.$nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+  it('should forward session state transitions to the state ref', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
 
-    const vm = wrapper.vm as any;
-    expect(vm.getConnectionState().connected).toBe(false);
+    mock.stateSubject.next('connecting');
+    expect(api.state.value).toBe('connecting');
 
-    await vm.connect();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(vm.getConnectionState().connected).toBe(true);
-    expect(vm.getConnectionState().connecting).toBe(false);
+    mock.stateSubject.next('connected');
+    expect(api.state.value).toBe('connected');
   });
 
-  it('should disconnect from serial port', async () => {
-    const wrapper = mount(TestComponent);
-    await wrapper.vm.$nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+  it('should clear errorMessage when returning to idle or connected', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
 
-    const vm = wrapper.vm as any;
-    // First connect
-    await vm.connect();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    mock.errorsSubject.next({ message: 'boom' } as SerialError);
+    expect(api.errorMessage.value).toBe('boom');
 
-    expect(vm.getConnectionState().connected).toBe(true);
-
-    // Then disconnect
-    await vm.disconnect();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(vm.getConnectionState().connected).toBe(false);
-    expect(vm.getConnectionState().disconnecting).toBe(false);
+    mock.stateSubject.next('connected');
+    expect(api.errorMessage.value).toBe(null);
   });
 
-  it('should request port', async () => {
-    const wrapper = mount(TestComponent);
-    await wrapper.vm.$nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const vm = wrapper.vm as any;
-    await vm.requestPort();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(vm.getConnectionState().error).toBe(null);
+  it('should connect through the session', () => {
+    const { api } = mountHarness();
+    api.connect$().subscribe();
+    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should send data when connected', async () => {
-    const wrapper = mount(TestComponent);
-    await wrapper.vm.$nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+  it('should recreate the session when baud rate changes', () => {
+    const { api } = mountHarness();
+    api.connect$(115200).subscribe();
 
-    const vm = wrapper.vm as any;
-    // Connect first
-    await vm.connect();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(vm.getConnectionState().connected).toBe(true);
-
-    // Send data
-    await vm.send('test data');
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    // No error should occur
-    expect(vm.getConnectionState().error).toBe(null);
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenCalledTimes(2);
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenLastCalledWith({ baudRate: 115200 });
+    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should clear received data', async () => {
-    const wrapper = mount(TestComponent);
-    await wrapper.vm.$nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    const vm = wrapper.vm as any;
-    vm.clearReceivedData();
-    expect(vm.getReceivedData()).toBe('');
+  it('should disconnect through the session', () => {
+    const { api } = mountHarness();
+    api.disconnect$().subscribe();
+    expect(latestMock().disconnect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should handle connection errors', async () => {
-    const mockClient = vi.mocked(webSerialRxjs.createSerialClient)({
-      baudRate: 9600,
-    }) as any;
+  it('should send payloads through the session', () => {
+    const { api } = mountHarness();
+    api.send$('hello').subscribe();
+    expect(latestMock().send$).toHaveBeenCalledWith('hello');
+  });
 
-    // Mock connect to throw an error
-    mockClient.connect = vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          setTimeout(() => {
-            if (observer.error) {
-              observer.error(new Error('Connection failed'));
-            }
-          }, 0);
-        },
-      ),
-    })) as unknown as () => Observable<void>;
+  it('should append incoming receive$ chunks to receivedData', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
 
-    const wrapper = mount(TestComponent);
-    await wrapper.vm.$nextTick();
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    mock.receiveSubject.next('chunk-1');
+    mock.receiveSubject.next('chunk-2');
 
-    const vm = wrapper.vm as any;
-    try {
-      await vm.connect();
-    } catch {
-      // Expected to throw
-    }
+    expect(api.receivedData.value).toBe('chunk-1chunk-2');
+  });
 
-    await new Promise((resolve) => setTimeout(resolve, 10));
+  it('should set errorMessage from errors$ emissions', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
 
-    expect(vm.getConnectionState().error).toBeTruthy();
-    expect(vm.getConnectionState().connected).toBe(false);
+    mock.errorsSubject.next({ message: 'write failed' } as SerialError);
+    expect(api.errorMessage.value).toBe('write failed');
+  });
+
+  it('should propagate connect$ errors to subscribers', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
+    const boom = new Error('connect failed');
+    mock.connect$.mockReturnValueOnce(throwError(() => boom));
+
+    const errorHandler = vi.fn();
+    api.connect$().subscribe({ error: errorHandler });
+
+    expect(errorHandler).toHaveBeenCalledWith(boom);
+  });
+
+  it('should clear received data', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
+    mock.receiveSubject.next('chunk-1');
+
+    expect(api.receivedData.value).toBe('chunk-1');
+    api.clearReceivedData();
+    expect(api.receivedData.value).toBe('');
+  });
+
+  it('should disconnect the session on unmount', () => {
+    const { wrapper } = mountHarness();
+    const mock = latestMock();
+
+    wrapper.unmount();
+
+    expect(mock.disconnect$).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,386 +1,96 @@
 import {
-  createSerialClient,
-  isBrowserSupported,
-  SerialClient,
-  SerialError,
+  createSerialSession,
+  type SerialError,
+  type SerialSession,
+  type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import type { Observable, Subscription } from 'rxjs';
-import { onMounted, onUnmounted, ref, type Ref } from 'vue';
+import { Observable, ReplaySubject, switchMap } from 'rxjs';
+import { onUnmounted, ref, type Ref } from 'vue';
 
 /**
- * SerialClient の接続状態を表す型
- */
-export interface SerialConnectionState {
-  /** 接続中かどうか */
-  connected: boolean;
-  /** 接続中かどうか */
-  connecting: boolean;
-  /** 切断中かどうか */
-  disconnecting: boolean;
-  /** エラーが発生したかどうか */
-  error: string | null;
-}
-
-/**
- * useSerialClient Composable の戻り値の型
+ * v2 `SerialSession` を薄くラップした Vue Composable。
+ *
+ * `state$` / `receive$` / `errors$` をそのままリアクティブな `Ref` に反映し、
+ * BehaviorSubject 的な接続状態再合成、`text$` の手動購読、read loop 管理は
+ * 一切持たない。
+ *
+ * @see https://github.com/gurezo/web-serial-rxjs/issues/199
+ * @see https://github.com/gurezo/web-serial-rxjs/issues/206
  */
 export interface UseSerialClientReturn {
-  /** ブラウザサポート状態 */
   browserSupported: Ref<boolean>;
-  /** 接続状態 */
-  connectionState: Ref<SerialConnectionState>;
-  /** 受信したデータ */
+  state: Ref<SerialSessionState>;
   receivedData: Ref<string>;
-  /** 接続を開始する関数 */
-  connect: (baudRate?: number) => Promise<void>;
-  /** 切断する関数 */
-  disconnect: () => Promise<void>;
-  /** ポートをリクエストする関数 */
-  requestPort: () => Promise<void>;
-  /** データを送信する関数 */
-  send: (data: string) => Promise<void>;
-  /** 受信データをクリアする関数 */
+  errorMessage: Ref<string | null>;
+  connect$: (baudRate?: number) => Observable<void>;
+  disconnect$: () => Observable<void>;
+  send$: (data: string | Uint8Array) => Observable<void>;
   clearReceivedData: () => void;
 }
 
-/**
- * Web Serial API を使用するためのComposable関数
- *
- * @param initialBaudRate - 初期ボーレート（デフォルト: 9600）
- * @returns SerialClient の操作と状態を提供するオブジェクト
- */
 export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
-  const browserSupported = ref(false);
-  const connectionState = ref<SerialConnectionState>({
-    connected: false,
-    connecting: false,
-    disconnecting: false,
-    error: null,
+  const sessions$ = new ReplaySubject<SerialSession>(1);
+  let currentSession: SerialSession = createSerialSession({
+    baudRate: initialBaudRate,
   });
+  let currentBaudRate = initialBaudRate;
+  sessions$.next(currentSession);
+
+  const browserSupported = ref(currentSession.isBrowserSupported());
+  const state = ref<SerialSessionState>('idle');
   const receivedData = ref('');
+  const errorMessage = ref<string | null>(null);
 
-  const clientRef: Ref<SerialClient | null> = ref(null);
-  const readSubscriptionRef: Ref<Subscription | null> = ref(null);
-  const stateSubscriptionRef: Ref<Subscription | null> = ref(null);
-  const baudRateRef = ref(initialBaudRate);
-
-  // ブラウザサポートをチェック
-  onMounted(() => {
-    const supported = isBrowserSupported();
-    browserSupported.value = supported;
-  });
-
-  // クリーンアップ: コンポーネントのアンマウント時に接続を切断
-  onUnmounted(() => {
-    if (readSubscriptionRef.value) {
-      readSubscriptionRef.value.unsubscribe();
-      readSubscriptionRef.value = null;
-    }
-    if (stateSubscriptionRef.value) {
-      stateSubscriptionRef.value.unsubscribe();
-      stateSubscriptionRef.value = null;
-    }
-    if (clientRef.value?.connected) {
-      clientRef.value.disconnect().subscribe();
-    }
-  });
-
-  /**
-   * 読み取りを開始
-   */
-  const startReading = () => {
-    if (!clientRef.value || !clientRef.value.connected) {
-      return;
-    }
-
-    // 既存の購読を停止
-    if (readSubscriptionRef.value) {
-      readSubscriptionRef.value.unsubscribe();
-      readSubscriptionRef.value = null;
-    }
-
-    const readStream$ = clientRef.value.text$;
-
-    readSubscriptionRef.value = readStream$.subscribe({
-      next: (text: string) => {
-        // 受信データを追加
-        receivedData.value = receivedData.value + text;
-      },
-      error: (error: unknown) => {
-        let message = '読み取りエラーが発生しました。';
-        if (error instanceof SerialError) {
-          message = `エラー: ${error.message}`;
-        } else if (error instanceof Error) {
-          message = `エラー: ${error.message}`;
-        }
-        connectionState.value = {
-          ...connectionState.value,
-          error: message,
-        };
-        // 読み取りエラー時は切断
-        disconnect();
-      },
-    });
-  };
-
-  /**
-   * 読み取りを停止
-   */
-  const stopReading = () => {
-    if (readSubscriptionRef.value) {
-      readSubscriptionRef.value.unsubscribe();
-      readSubscriptionRef.value = null;
-    }
-  };
-
-  const subscribeState = () => {
-    if (!clientRef.value) {
-      return;
-    }
-    const state$ = (clientRef.value as unknown as { state$?: Observable<unknown> })
-      .state$;
-    if (!state$ || typeof state$.subscribe !== 'function') {
-      return;
-    }
-    if (stateSubscriptionRef.value) {
-      stateSubscriptionRef.value.unsubscribe();
-    }
-    stateSubscriptionRef.value = clientRef.value.state$.subscribe((state) => {
-      if (state.kind === 'error') {
-        connectionState.value = {
-          connected: false,
-          connecting: false,
-          disconnecting: false,
-          error: `エラー: ${state.error.message}`,
-        };
-        return;
-      }
-
-      connectionState.value = {
-        ...connectionState.value,
-        connected: state.kind === 'connected',
-        connecting: state.kind === 'connecting',
-        disconnecting: state.kind === 'disconnecting',
-      };
-      if (state.kind === 'unsupported' && !state.support.supported) {
-        connectionState.value = {
-          ...connectionState.value,
-          error: state.support.reason,
-        };
+  const stateSub = sessions$
+    .pipe(switchMap((session) => session.state$))
+    .subscribe((next) => {
+      state.value = next;
+      if (next === 'connected' || next === 'idle') {
+        errorMessage.value = null;
       }
     });
-  };
-
-  /**
-   * 接続を開始
-   */
-  const connect = async (baudRate?: number): Promise<void> => {
-    if (baudRate) {
-      baudRateRef.value = baudRate;
-    }
-
-    if (!clientRef.value) {
-      clientRef.value = createSerialClient({
-        baudRate: baudRateRef.value,
-      });
-      subscribeState();
-    }
-
-    connectionState.value = {
-      connected: false,
-      connecting: true,
-      disconnecting: false,
-      error: null,
-    };
-
-    return new Promise((resolve, reject) => {
-      if (!clientRef.value) {
-        reject(new Error('SerialClient が初期化されていません'));
-        return;
-      }
-
-      clientRef.value.connect().subscribe({
-        next: () => {
-          connectionState.value = {
-            connected: true,
-            connecting: false,
-            disconnecting: false,
-            error: null,
-          };
-          startReading();
-          resolve();
-        },
-        error: (error: unknown) => {
-          let message = '接続エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          connectionState.value = {
-            connected: false,
-            connecting: false,
-            disconnecting: false,
-            error: message,
-          };
-          reject(error);
-        },
-      });
+  const receiveSub = sessions$
+    .pipe(switchMap((session) => session.receive$))
+    .subscribe((chunk) => {
+      receivedData.value = receivedData.value + chunk;
     });
-  };
-
-  /**
-   * 切断
-   */
-  const disconnect = async (): Promise<void> => {
-    if (!clientRef.value || !clientRef.value.connected) {
-      return;
-    }
-
-    stopReading();
-
-    connectionState.value = {
-      ...connectionState.value,
-      disconnecting: true,
-    };
-
-    return new Promise((resolve, reject) => {
-      if (!clientRef.value) {
-        resolve();
-        return;
-      }
-
-      clientRef.value.disconnect().subscribe({
-        next: () => {
-          connectionState.value = {
-            connected: false,
-            connecting: false,
-            disconnecting: false,
-            error: null,
-          };
-          resolve();
-        },
-        error: (error: unknown) => {
-          let message = '切断エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          // エラーが発生しても UI は切断状態にする
-          connectionState.value = {
-            connected: false,
-            connecting: false,
-            disconnecting: false,
-            error: message,
-          };
-          reject(error);
-        },
-      });
+  const errorsSub = sessions$
+    .pipe(switchMap((session) => session.errors$))
+    .subscribe((error: SerialError) => {
+      errorMessage.value = error.message;
     });
-  };
 
-  /**
-   * ポートをリクエスト
-   */
-  const requestPort = async (): Promise<void> => {
-    if (!clientRef.value) {
-      clientRef.value = createSerialClient({
-        baudRate: baudRateRef.value,
-      });
+  const connect$ = (baudRate?: number): Observable<void> => {
+    if (baudRate !== undefined && baudRate !== currentBaudRate) {
+      currentBaudRate = baudRate;
+      currentSession = createSerialSession({ baudRate });
+      sessions$.next(currentSession);
     }
-
-    return new Promise((resolve, reject) => {
-      if (!clientRef.value) {
-        reject(new Error('SerialClient が初期化されていません'));
-        return;
-      }
-
-      clientRef.value.requestPort().subscribe({
-        next: () => {
-          connectionState.value = {
-            ...connectionState.value,
-            error: null,
-          };
-          resolve();
-        },
-        error: (error: unknown) => {
-          let message = 'ポート選択エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          connectionState.value = {
-            ...connectionState.value,
-            error: message,
-          };
-          reject(error);
-        },
-      });
-    });
+    return currentSession.connect$();
   };
-
-  /**
-   * データを送信
-   */
-  const send = async (data: string): Promise<void> => {
-    if (!clientRef.value || !clientRef.value.connected) {
-      throw new Error(
-        '接続されていません。先にシリアルポートに接続してください。',
-      );
-    }
-
-    const text = data.trim();
-    if (!text) {
-      return;
-    }
-
-    // テキストを Uint8Array に変換（UTF-8 エンコード）
-    const payload = `${text}\n`;
-
-    return new Promise((resolve, reject) => {
-      if (!clientRef.value) {
-        reject(new Error('SerialClient が初期化されていません'));
-        return;
-      }
-
-      clientRef.value.send$(payload).subscribe({
-        next: () => {
-          resolve();
-        },
-        error: (error: unknown) => {
-          let message = '送信エラーが発生しました。';
-          if (error instanceof SerialError) {
-            message = `エラー: ${error.message}`;
-          } else if (error instanceof Error) {
-            message = `エラー: ${error.message}`;
-          }
-          connectionState.value = {
-            ...connectionState.value,
-            error: message,
-          };
-          reject(error);
-        },
-      });
-    });
-  };
-
-  /**
-   * 受信データをクリア
-   */
-  const clearReceivedData = () => {
+  const disconnect$ = (): Observable<void> => currentSession.disconnect$();
+  const send$ = (data: string | Uint8Array): Observable<void> =>
+    currentSession.send$(data);
+  const clearReceivedData = (): void => {
     receivedData.value = '';
   };
 
+  onUnmounted(() => {
+    stateSub.unsubscribe();
+    receiveSub.unsubscribe();
+    errorsSub.unsubscribe();
+    currentSession.disconnect$().subscribe({ error: () => void 0 });
+    sessions$.complete();
+  });
+
   return {
     browserSupported,
-    connectionState,
+    state,
     receivedData,
-    connect,
-    disconnect,
-    requestPort,
-    send,
+    errorMessage,
+    connect$,
+    disconnect$,
+    send$,
     clearReceivedData,
   };
 }


### PR DESCRIPTION
## Summary
<!--
日本語: 何を・なぜ変更したかを1〜3行で書いてください
English: Briefly describe what you changed and why (1–3 lines)
-->
Vue example を v1 `SerialClient` ベースの composable から v2 `SerialSession` ベースへ移行し、apps 側に残っていた `BehaviorSubject` 的な状態再合成・`text$` の手動購読・read loop 管理・Promise ラップを撤去した。Angular example (#205) と同じ「薄いラッパ + `state$` / `receive$` / `errors$` 直接購読」構造に揃え、Issue #199 が掲げた apps のコード削減方針を Vue でも実現する。

## Type of change
<!--
日本語: 該当するものにチェックを入れてください
English: Check the relevant items
-->
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
<!--
日本語: 関連する Issue があれば記載してください
English: Link related issues (use "Fixes #123" to auto-close)
-->
- Fixes #206
- refs #199

## What changed?
<!--
日本語: 主な変更点を箇条書きで書いてください
English: List the main changes in bullet points
-->
- `apps/example-vue/src/composables/useSerialClient.ts` を 386 行 → 96 行に圧縮し、`createSerialSession` を `ReplaySubject<SerialSession>` + `switchMap` で薄くラップする構成に刷新。`state$` / `receive$` / `errors$` を `Ref` にそのまま反映し、`text$` の購読・`startReading` / `stopReading` など read loop 管理を削除。
- `apps/example-vue/src/app/App.vue` から `connectionState` 集約オブジェクトを撤廃。`state: Ref<SerialSessionState>` と `errorMessage: Ref<string | null>` を直接購読し、`connected` / `connecting` / `disconnecting` / `status` は `computed` で導出。`status` は Angular example と同じく `unsupported` / `error` を含む 6 状態に対応。
- v2 では `connect$` が内部でポート選択を行うため、UI 側の「ポートを選択」ボタンと `requestPort` API を削除。
- `useSerialClient.test.ts` / `App.test.ts` を `BehaviorSubject<SerialSessionState>` / `Subject<string>` / `Subject<SerialError>` を備えた `createSerialSession` モックに差し替え、23 件のユニットテストに再構成。

## API / Compatibility
<!--
日本語: 公開 API や互換性への影響があれば明記してください
English: Describe any impact on public APIs or compatibility
-->
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

ライブラリ (`packages/web-serial-rxjs`) の公開 API には一切変更なし。変更範囲は `apps/example-vue` のみで、Vue example 内部の composable シグネチャのみ変わる（`connectionState` / `requestPort` / Promise ベース API が削除され、`state` / `errorMessage` / Observable ベース API になる）。

## How to test
<!--
日本語: 動作確認の手順を具体的に書いてください
English: Describe how reviewers can test this change
-->
1. `pnpm nx run example-vue:test` を実行し、`App.test.ts` (10) + `useSerialClient.test.ts` (13) の計 23 件が緑であること。
2. `pnpm nx run example-vue:lint` が緑であること。
3. `pnpm nx run example-vue:build` が成功すること。
4. （任意・実機）`pnpm nx serve example-vue` を Chromium 系ブラウザで開き、接続 / 送信 / 受信 / 切断および USB 抜線時の `errors$` → `state='error'` 遷移が UI に反映されることを目視確認。

## Environment (if relevant)
<!--
日本語: バグ修正・挙動変更の場合は記載してください
English: Required for bug fixes or behavior changes
-->
- Browser: Chrome (Chromium 系)
- OS: macOS
- web-serial-rxjs version (for verification): monorepo の最新 (v2 `SerialSession` 実装済み)
- RxJS version: monorepo の pinned version

## Checklist
<!--
日本語: PR 作成前の確認事項です
English: Please confirm before submitting
-->
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)