### PR TITLE
refactor(example-vanilla-ts, example-vanilla-js): SerialSession API へ移行 (#210)

### DIFF
--- a/apps/example-vanilla-js/index.html
+++ b/apps/example-vanilla-js/index.html
@@ -30,9 +30,6 @@
             <button id="disconnect-btn" class="btn btn-secondary" disabled>
               切断
             </button>
-            <button id="request-port-btn" class="btn btn-outline">
-              ポート選択
-            </button>
           </div>
           <div id="connection-status" class="status-message"></div>
         </section>

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,328 +1,91 @@
-// Static imports are correct for application code.
-// Test files use vi.mock which causes false positives for lazy-load detection.
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import {
-  createSerialClient,
-  isBrowserSupported,
-  SerialError,
-} from '@gurezo/web-serial-rxjs';
+import { createSerialSession } from '@gurezo/web-serial-rxjs';
 import { fromEvent } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 
-/**
- * Main application class for the vanilla JavaScript example
- */
+const UNSUPPORTED_MSG =
+  'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。';
+const STATUS = {
+  idle: ['info', 'シリアルポートから切断しました。'],
+  connecting: ['info', '接続中です...'],
+  connected: ['success', 'シリアルポートに接続しました。'],
+  disconnecting: ['info', '切断中です...'],
+  unsupported: ['error', UNSUPPORTED_MSG],
+  error: ['error', 'エラーが発生しました。errors$ を確認してください。'],
+};
+
+const $ = (id) => {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`${id} element not found`);
+  return el;
+};
+const setStatus = (el, type, msg) => {
+  el.textContent = msg;
+  el.className = `status-message ${type}`;
+};
+
 export class App {
   constructor() {
-    this.client = null;
-    this.readSubscription = null;
-    this.stateSubscription = null;
-
-    // Initialize UI elements
-    this.initializeElements();
-    // Check browser support
-    this.checkBrowserSupport();
-    // Setup event handlers
-    this.setupEventHandlers();
-  }
-
-  /**
-   * Initialize DOM elements
-   */
-  initializeElements() {
-    // Browser support
-    this.browserSupportStatus = document.getElementById(
-      'browser-support-status',
+    const connectBtn = $('connect-btn');
+    const disconnectBtn = $('disconnect-btn');
+    const status = $('connection-status');
+    const baudRateSelect = $('baud-rate');
+    const sendInput = $('send-input');
+    const sendBtn = $('send-btn');
+    const receiveOutput = $('receive-output');
+    this.baudRate = parseInt(baudRateSelect.value, 10);
+    this.session = createSerialSession({ baudRate: this.baudRate });
+    const supported = this.session.isBrowserSupported();
+    setStatus(
+      $('browser-support-status'),
+      supported ? 'success' : 'error',
+      supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
-
-    // Connection
-    this.connectBtn = document.getElementById('connect-btn');
-    this.disconnectBtn = document.getElementById('disconnect-btn');
-    this.requestPortBtn = document.getElementById('request-port-btn');
-    this.connectionStatus = document.getElementById('connection-status');
-
-    // Configuration
-    this.baudRateSelect = document.getElementById('baud-rate');
-
-    // Send data
-    this.sendInput = document.getElementById('send-input');
-    this.sendBtn = document.getElementById('send-btn');
-
-    // Receive data
-    this.receiveOutput = document.getElementById('receive-output');
-    this.clearReceiveBtn = document.getElementById('clear-receive-btn');
-  }
-
-  /**
-   * Check browser support
-   */
-  checkBrowserSupport() {
-    const supported = isBrowserSupported();
-
-    if (supported) {
-      this.showStatus(
-        this.browserSupportStatus,
-        'success',
-        'ブラウザは Web Serial API をサポートしています。',
-      );
-      // Enable connection button if browser is supported
-      this.connectBtn.disabled = false;
-      this.requestPortBtn.disabled = false;
-    } else {
-      this.showStatus(
-        this.browserSupportStatus,
-        'error',
-        'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
-      );
-    }
-  }
-
-  /**
-   * Setup event handlers using RxJS
-   */
-  setupEventHandlers() {
-    // Connect button
-    fromEvent(this.connectBtn, 'click').subscribe(() => {
-      this.handleConnect();
+    this.session.state$.subscribe((state) => {
+      const connected = state === 'connected';
+      const busy = state === 'connecting' || state === 'disconnecting';
+      connectBtn.disabled = !supported || connected || busy;
+      disconnectBtn.disabled = !connected;
+      sendInput.disabled = sendBtn.disabled = !connected;
+      baudRateSelect.disabled = connected || busy;
+      setStatus(status, ...STATUS[state]);
     });
-
-    // Disconnect button
-    fromEvent(this.disconnectBtn, 'click').subscribe(() => {
-      this.handleDisconnect();
+    this.session.receive$.subscribe((text) => {
+      receiveOutput.value += text;
+      receiveOutput.scrollTop = receiveOutput.scrollHeight;
     });
-
-    // Request port button
-    fromEvent(this.requestPortBtn, 'click').subscribe(() => {
-      this.handleRequestPort();
+    this.session.errors$.subscribe((error) => {
+      setStatus(status, 'error', `エラー: ${error.message}`);
+      console.error('Serial port error:', error);
     });
-
-    // Send button
-    fromEvent(this.sendBtn, 'click').subscribe(() => {
-      this.handleSend();
-    });
-
-    // Send on Enter key
-    fromEvent(this.sendInput, 'keydown')
-      .pipe(
-        filter((event) => event.key === 'Enter' && !event.shiftKey),
-        map((event) => {
-          event.preventDefault();
-          return event;
-        }),
-      )
-      .subscribe(() => {
-        this.handleSend();
-      });
-
-    // Clear receive output
-    fromEvent(this.clearReceiveBtn, 'click').subscribe(() => {
-      this.receiveOutput.value = '';
-    });
-  }
-
-  /**
-   * Handle connect action
-   */
-  handleConnect() {
-    if (!this.client) {
-      const baudRate = parseInt(this.baudRateSelect.value, 10);
-      this.client = createSerialClient({ baudRate });
-    }
-
-    this.updateConnectionUI(false);
-
-    this.client.connect().subscribe({
-      next: () => {
-        this.showStatus(this.connectionStatus, 'success', '接続処理を開始しました。');
-        this.subscribeState();
-        this.startReading();
-      },
-      error: (error) => {
-        this.updateConnectionUI(false);
-        this.handleError(error, this.connectionStatus);
-      },
-    });
-  }
-
-  /**
-   * Handle disconnect action
-   */
-  handleDisconnect() {
-    if (!this.client || !this.client.connected) {
-      return;
-    }
-
-    this.stopReading();
-
-    this.client.disconnect().subscribe({
-      next: () => {
-        this.stopStateSubscription();
-        this.updateConnectionUI(false);
-      },
-      error: (error) => {
-        this.handleError(error, this.connectionStatus);
-        // Even if there's an error, update UI to reflect disconnected state
-        this.updateConnectionUI(false);
-      },
-    });
-  }
-
-  /**
-   * Handle request port action
-   */
-  handleRequestPort() {
-    if (!this.client) {
-      const baudRate = parseInt(this.baudRateSelect.value, 10);
-      this.client = createSerialClient({ baudRate });
-    }
-
-    this.client.requestPort().subscribe({
-      next: (port) => {
-        this.showStatus(
-          this.connectionStatus,
-          'success',
-          `ポートが選択されました: ${port.getInfo?.()?.usbVendorId || 'N/A'}`,
-        );
-      },
-      error: (error) => {
-        this.handleError(error, this.connectionStatus);
-      },
-    });
-  }
-
-  /**
-   * Handle send data action
-   */
-  handleSend() {
-    if (!this.client || !this.client.connected) {
-      this.showStatus(
-        this.connectionStatus,
-        'warning',
-        '接続されていません。先にシリアルポートに接続してください。',
-      );
-      return;
-    }
-
-    const text = this.sendInput.value.trim();
-    if (!text) {
-      return;
-    }
-
-    this.client.send$(`${text}\n`).subscribe({
-      next: () => {
-        // Clear input after successful send
-        this.sendInput.value = '';
-      },
-      error: (error) => {
-        this.handleError(error, this.connectionStatus);
-      },
-    });
-  }
-
-  /**
-   * Start reading from serial port
-   */
-  startReading() {
-    if (!this.client || !this.client.connected) {
-      return;
-    }
-
-    // Stop any existing read subscription
-    this.stopReading();
-
-    const readStream$ = this.client.text$;
-
-    this.readSubscription = readStream$.subscribe({
-      next: (text) => {
-        // Append to receive output
-        this.receiveOutput.value += text;
-
-        // Auto-scroll to bottom
-        this.receiveOutput.scrollTop = this.receiveOutput.scrollHeight;
-      },
-      error: (error) => {
-        this.handleError(error, this.connectionStatus);
-        // Disconnect on read error
-        this.handleDisconnect();
-      },
-    });
-  }
-
-  subscribeState() {
-    if (!this.client) {
-      return;
-    }
-    this.stopStateSubscription();
-
-    this.stateSubscription = this.client.state$.subscribe((state) => {
-      this.updateConnectionUI(state.kind === 'connected');
-      if (state.kind === 'connecting') {
-        this.showStatus(this.connectionStatus, 'info', '接続中です...');
-      } else if (state.kind === 'disconnecting') {
-        this.showStatus(this.connectionStatus, 'info', '切断中です...');
-      } else if (state.kind === 'connected') {
-        this.showStatus(this.connectionStatus, 'success', 'シリアルポートに接続しました。');
-      } else if (state.kind === 'idle') {
-        this.showStatus(this.connectionStatus, 'info', 'シリアルポートから切断しました。');
-      } else if (state.kind === 'unsupported') {
-        this.showStatus(this.connectionStatus, 'error', state.support.reason);
-      } else if (state.kind === 'error') {
-        this.showStatus(this.connectionStatus, 'error', `エラー: ${state.error.message}`);
+    fromEvent(connectBtn, 'click').subscribe(() => {
+      const baudRate = parseInt(baudRateSelect.value, 10);
+      if (baudRate !== this.baudRate) {
+        this.baudRate = baudRate;
+        this.session = createSerialSession({ baudRate });
       }
+      this.session.connect$().subscribe({ error: () => void 0 });
     });
-  }
-
-  stopStateSubscription() {
-    if (this.stateSubscription) {
-      this.stateSubscription.unsubscribe();
-      this.stateSubscription = null;
-    }
-  }
-
-  /**
-   * Stop reading from serial port
-   */
-  stopReading() {
-    if (this.readSubscription) {
-      this.readSubscription.unsubscribe();
-      this.readSubscription = null;
-    }
-  }
-
-  /**
-   * Update connection UI state
-   */
-  updateConnectionUI(connected) {
-    this.connectBtn.disabled = connected;
-    this.disconnectBtn.disabled = !connected;
-    this.sendInput.disabled = !connected;
-    this.sendBtn.disabled = !connected;
-    this.baudRateSelect.disabled = connected;
-  }
-
-  /**
-   * Show status message
-   */
-  showStatus(element, type, message) {
-    element.textContent = message;
-    element.className = `status-message ${type}`;
-  }
-
-  /**
-   * Handle errors
-   */
-  handleError(error, statusElement) {
-    let message = 'エラーが発生しました。';
-
-    if (error instanceof SerialError) {
-      message = `エラー: ${error.message}`;
-    } else if (error instanceof Error) {
-      message = `エラー: ${error.message}`;
-    } else {
-      message = `エラー: ${String(error)}`;
-    }
-
-    this.showStatus(statusElement, 'error', message);
-    console.error('Serial port error:', error);
+    fromEvent(disconnectBtn, 'click').subscribe(() =>
+      this.session.disconnect$().subscribe({ error: () => void 0 }),
+    );
+    const send = () => {
+      const text = sendInput.value.trim();
+      if (!text) return;
+      this.session.send$(`${text}\n`).subscribe({
+        next: () => (sendInput.value = ''),
+        error: () => void 0,
+      });
+    };
+    fromEvent(sendBtn, 'click').subscribe(send);
+    fromEvent(sendInput, 'keydown')
+      .pipe(filter((e) => e.key === 'Enter' && !e.shiftKey))
+      .subscribe((e) => {
+        e.preventDefault();
+        send();
+      });
+    fromEvent($('clear-receive-btn'), 'click').subscribe(
+      () => (receiveOutput.value = ''),
+    );
   }
 }

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -1,61 +1,22 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { BehaviorSubject, Subject, of } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './app.js';
 
-// Mock the web-serial-rxjs library
 vi.mock('@gurezo/web-serial-rxjs', () => {
-  const mockClient = {
-    connected: false,
-    currentPort: null,
-    connect: vi.fn(() => ({
-      subscribe: vi.fn((observer) => {
-        setTimeout(() => {
-          mockClient.connected = true;
-          observer.next();
-          observer.complete();
-        }, 0);
-      }),
-    })),
-    disconnect: vi.fn(() => ({
-      subscribe: vi.fn((observer) => {
-        setTimeout(() => {
-          mockClient.connected = false;
-          observer.next();
-          observer.complete();
-        }, 0);
-      }),
-    })),
-    requestPort: vi.fn(() => ({
-      subscribe: vi.fn((observer) => {
-        setTimeout(() => {
-          observer.next({});
-          observer.complete();
-        }, 0);
-      }),
-    })),
-    text$: {
-      subscribe: vi.fn(() => ({
-        unsubscribe: vi.fn(),
-      })),
-    },
-    send$: vi.fn(() => ({
-      subscribe: vi.fn((observer) => {
-        setTimeout(() => {
-          observer.next();
-          observer.complete();
-        }, 0);
-      }),
-    })),
-  };
-
-  return {
-    createSerialClient: vi.fn(() => mockClient),
+  const state$ = new BehaviorSubject('idle');
+  const receive$ = new Subject();
+  const errors$ = new Subject();
+  const mockSession = {
     isBrowserSupported: vi.fn(() => true),
-    SerialError: class MockSerialError extends Error {
-      constructor(message) {
-        super(message);
-        this.name = 'SerialError';
-      }
-    },
+    connect$: vi.fn(() => of(undefined)),
+    disconnect$: vi.fn(() => of(undefined)),
+    send$: vi.fn(() => of(undefined)),
+    state$,
+    receive$,
+    errors$,
+  };
+  return {
+    createSerialSession: vi.fn(() => mockSession),
   };
 });
 
@@ -64,13 +25,11 @@ describe('App', () => {
   let container;
 
   beforeEach(() => {
-    // Create a mock DOM structure
     container = document.createElement('div');
     container.innerHTML = `
       <div id="browser-support-status"></div>
       <button id="connect-btn"></button>
       <button id="disconnect-btn"></button>
-      <button id="request-port-btn"></button>
       <div id="connection-status"></div>
       <select id="baud-rate">
         <option value="9600">9600</option>
@@ -85,12 +44,11 @@ describe('App', () => {
   });
 
   afterEach(() => {
-    if (app && app.readSubscription) {
-      app.readSubscription.unsubscribe();
-    }
     if (container && container.parentNode) {
       container.parentNode.removeChild(container);
     }
+    app = null;
+    container = null;
   });
 
   it('should create an App instance', () => {
@@ -98,32 +56,24 @@ describe('App', () => {
     expect(app).toBeInstanceOf(App);
   });
 
-  it('should initialize DOM elements', () => {
+  it('should create a SerialSession via createSerialSession on init', async () => {
+    const { createSerialSession } = await import('@gurezo/web-serial-rxjs');
     app = new App();
-    expect(app.connectBtn).toBeDefined();
-    expect(app.disconnectBtn).toBeDefined();
-    expect(app.sendInput).toBeDefined();
-    expect(app.receiveOutput).toBeDefined();
+    expect(createSerialSession).toHaveBeenCalled();
   });
 
-  it('should check browser support on initialization', async () => {
-    const { isBrowserSupported } =
-      await import('@gurezo/web-serial-rxjs');
+  it('should render browser support status based on session.isBrowserSupported', () => {
     app = new App();
-    // Give time for the async initialization to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(isBrowserSupported).toHaveBeenCalled();
+    const el = document.getElementById('browser-support-status');
+    expect(el.textContent).toContain('Web Serial API');
+    expect(el.className).toContain('success');
   });
 
-  it('should enable connect button when browser is supported', () => {
+  it('should render DOM elements required by the app', () => {
     app = new App();
-    // Wait for async initialization
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        // The button should be enabled if browser is supported
-        // (Note: In real tests, this depends on the mock return value)
-        resolve();
-      }, 100);
-    });
+    expect(document.getElementById('connect-btn')).not.toBeNull();
+    expect(document.getElementById('disconnect-btn')).not.toBeNull();
+    expect(document.getElementById('send-input')).not.toBeNull();
+    expect(document.getElementById('receive-output')).not.toBeNull();
   });
 });

--- a/apps/example-vanilla-ts/index.html
+++ b/apps/example-vanilla-ts/index.html
@@ -30,9 +30,6 @@
             <button id="disconnect-btn" class="btn btn-secondary" disabled>
               切断
             </button>
-            <button id="request-port-btn" class="btn btn-outline">
-              ポート選択
-            </button>
           </div>
           <div id="connection-status" class="status-message"></div>
         </section>

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -1,97 +1,23 @@
-import type { SerialClient } from '@gurezo/web-serial-rxjs';
-import type { Observable, Subscription } from 'rxjs';
+import type { SerialError, SerialSession } from '@gurezo/web-serial-rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './app.js';
 
-// Mock the web-serial-rxjs library
 vi.mock('@gurezo/web-serial-rxjs', () => {
-  let isConnected = false;
-  const mockClient = {
-    get connected() {
-      return isConnected;
-    },
-    currentPort: null,
-    connect: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          setTimeout(() => {
-            isConnected = true;
-            observer.next?.();
-            observer.complete?.();
-          }, 0);
-        },
-      ),
-    })) as unknown as () => Observable<void>,
-    disconnect: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          setTimeout(() => {
-            isConnected = false;
-            observer.next?.();
-            observer.complete?.();
-          }, 0);
-        },
-      ),
-    })) as unknown as () => Observable<void>,
-    requestPort: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: (port: SerialPort) => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          setTimeout(() => {
-            observer.next?.({} as SerialPort);
-            observer.complete?.();
-          }, 0);
-        },
-      ),
-    })) as unknown as () => Observable<SerialPort>,
-    text$: {
-      subscribe: vi.fn(() => ({
-        unsubscribe: vi.fn(),
-      })) as unknown as (observer: {
-        next?: (text: string) => void;
-        error?: (error: unknown) => void;
-        complete?: () => void;
-      }) => Subscription,
-    } as unknown as Observable<string>,
-    send$: vi.fn(() => ({
-      subscribe: vi.fn(
-        (observer: {
-          next?: () => void;
-          error?: (error: unknown) => void;
-          complete?: () => void;
-        }) => {
-          setTimeout(() => {
-            observer.next?.();
-            observer.complete?.();
-          }, 0);
-        },
-      ),
-    })) as unknown as (data: string) => Observable<void>,
-    getPorts: vi.fn(() => ({
-      subscribe: vi.fn(),
-    })) as unknown as () => Observable<SerialPort[]>,
-  } as SerialClient;
-
-  return {
-    createSerialClient: vi.fn(() => mockClient),
+  const state$ = new BehaviorSubject<string>('idle');
+  const receive$ = new Subject<string>();
+  const errors$ = new Subject<SerialError>();
+  const mockSession = {
     isBrowserSupported: vi.fn(() => true),
-    SerialError: class MockSerialError extends Error {
-      constructor(message: string) {
-        super(message);
-        this.name = 'SerialError';
-      }
-    },
+    connect$: vi.fn(() => of(undefined)),
+    disconnect$: vi.fn(() => of(undefined)),
+    send$: vi.fn(() => of(undefined)),
+    state$,
+    receive$,
+    errors$,
+  };
+  return {
+    createSerialSession: vi.fn(() => mockSession as unknown as SerialSession),
   };
 });
 
@@ -100,13 +26,11 @@ describe('App', () => {
   let container: HTMLDivElement | null = null;
 
   beforeEach(() => {
-    // Create a mock DOM structure
     container = document.createElement('div');
     container.innerHTML = `
       <div id="browser-support-status"></div>
       <button id="connect-btn"></button>
       <button id="disconnect-btn"></button>
-      <button id="request-port-btn"></button>
       <div id="connection-status"></div>
       <select id="baud-rate">
         <option value="9600">9600</option>
@@ -121,7 +45,6 @@ describe('App', () => {
   });
 
   afterEach(() => {
-    // Cleanup: App instance will handle its own cleanup
     if (container && container.parentNode) {
       container.parentNode.removeChild(container);
     }
@@ -134,36 +57,24 @@ describe('App', () => {
     expect(app).toBeInstanceOf(App);
   });
 
-  it('should initialize DOM elements', () => {
+  it('should create a SerialSession via createSerialSession on init', async () => {
+    const { createSerialSession } = await import('@gurezo/web-serial-rxjs');
     app = new App();
-    // Verify that the app was created successfully
-    // DOM elements are private, so we just verify the app instance exists
-    expect(app).toBeDefined();
-    // Verify that required DOM elements exist in the document
-    expect(document.getElementById('connect-btn')).toBeDefined();
-    expect(document.getElementById('disconnect-btn')).toBeDefined();
-    expect(document.getElementById('send-input')).toBeDefined();
-    expect(document.getElementById('receive-output')).toBeDefined();
+    expect(createSerialSession).toHaveBeenCalled();
   });
 
-  it('should check browser support on initialization', async () => {
-    const { isBrowserSupported } =
-      await import('@gurezo/web-serial-rxjs');
+  it('should render browser support status based on session.isBrowserSupported', () => {
     app = new App();
-    // Give time for the async initialization to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(isBrowserSupported).toHaveBeenCalled();
+    const el = document.getElementById('browser-support-status');
+    expect(el?.textContent).toContain('Web Serial API');
+    expect(el?.className).toContain('success');
   });
 
-  it('should enable connect button when browser is supported', () => {
+  it('should render DOM elements required by the app', () => {
     app = new App();
-    // Wait for async initialization
-    return new Promise<void>((resolve) => {
-      setTimeout(() => {
-        // The button should be enabled if browser is supported
-        // (Note: In real tests, this depends on the mock return value)
-        resolve();
-      }, 100);
-    });
+    expect(document.getElementById('connect-btn')).not.toBeNull();
+    expect(document.getElementById('disconnect-btn')).not.toBeNull();
+    expect(document.getElementById('send-input')).not.toBeNull();
+    expect(document.getElementById('receive-output')).not.toBeNull();
   });
 });

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,406 +1,99 @@
-// Static imports are correct for application code.
-// Test files use vi.mock which causes false positives for lazy-load detection.
 import {
-  createSerialClient,
-  isBrowserSupported,
-  SerialClient,
-  SerialError,
+  createSerialSession,
+  type SerialSession,
+  type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import type { Subscription } from 'rxjs';
 import { fromEvent } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { filter } from 'rxjs/operators';
 
-/**
- * Main application class for the vanilla TypeScript example
- */
+type StatusType = 'info' | 'success' | 'error';
+
+const UNSUPPORTED_MSG =
+  'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。';
+const STATUS: Record<SerialSessionState, [StatusType, string]> = {
+  idle: ['info', 'シリアルポートから切断しました。'],
+  connecting: ['info', '接続中です...'],
+  connected: ['success', 'シリアルポートに接続しました。'],
+  disconnecting: ['info', '切断中です...'],
+  unsupported: ['error', UNSUPPORTED_MSG],
+  error: ['error', 'エラーが発生しました。errors$ を確認してください。'],
+};
+
+const $ = <T extends HTMLElement>(id: string): T => {
+  const el = document.getElementById(id);
+  if (!el) throw new Error(`${id} element not found`);
+  return el as T;
+};
+const setStatus = (el: HTMLElement, type: StatusType, msg: string): void => {
+  el.textContent = msg;
+  el.className = `status-message ${type}`;
+};
+
 export class App {
-  private client: SerialClient | null = null;
-  private readSubscription: Subscription | null = null;
-  private stateSubscription: Subscription | null = null;
-
-  // Browser support
-  private browserSupportStatus!: HTMLElement;
-
-  // Connection
-  private connectBtn!: HTMLButtonElement;
-  private disconnectBtn!: HTMLButtonElement;
-  private requestPortBtn!: HTMLButtonElement;
-  private connectionStatus!: HTMLElement;
-
-  // Configuration
-  private baudRateSelect!: HTMLSelectElement;
-
-  // Send data
-  private sendInput!: HTMLInputElement;
-  private sendBtn!: HTMLButtonElement;
-
-  // Receive data
-  private receiveOutput!: HTMLTextAreaElement;
-  private clearReceiveBtn!: HTMLButtonElement;
+  private session: SerialSession;
+  private baudRate: number;
 
   constructor() {
-    // Initialize UI elements
-    this.initializeElements();
-    // Check browser support
-    this.checkBrowserSupport();
-    // Setup event handlers
-    this.setupEventHandlers();
-  }
-
-  /**
-   * Initialize DOM elements
-   */
-  private initializeElements(): void {
-    // Browser support
-    const browserSupportStatus = document.getElementById(
-      'browser-support-status',
+    const connectBtn = $<HTMLButtonElement>('connect-btn');
+    const disconnectBtn = $<HTMLButtonElement>('disconnect-btn');
+    const status = $<HTMLElement>('connection-status');
+    const baudRateSelect = $<HTMLSelectElement>('baud-rate');
+    const sendInput = $<HTMLInputElement>('send-input');
+    const sendBtn = $<HTMLButtonElement>('send-btn');
+    const receiveOutput = $<HTMLTextAreaElement>('receive-output');
+    this.baudRate = parseInt(baudRateSelect.value, 10);
+    this.session = createSerialSession({ baudRate: this.baudRate });
+    const supported = this.session.isBrowserSupported();
+    setStatus(
+      $<HTMLElement>('browser-support-status'),
+      supported ? 'success' : 'error',
+      supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
-    if (!browserSupportStatus) {
-      throw new Error('browser-support-status element not found');
-    }
-    this.browserSupportStatus = browserSupportStatus;
-
-    // Connection
-    const connectBtn = document.getElementById('connect-btn');
-    if (!connectBtn || !(connectBtn instanceof HTMLButtonElement)) {
-      throw new Error('connect-btn element not found');
-    }
-    this.connectBtn = connectBtn;
-
-    const disconnectBtn = document.getElementById('disconnect-btn');
-    if (!disconnectBtn || !(disconnectBtn instanceof HTMLButtonElement)) {
-      throw new Error('disconnect-btn element not found');
-    }
-    this.disconnectBtn = disconnectBtn;
-
-    const requestPortBtn = document.getElementById('request-port-btn');
-    if (!requestPortBtn || !(requestPortBtn instanceof HTMLButtonElement)) {
-      throw new Error('request-port-btn element not found');
-    }
-    this.requestPortBtn = requestPortBtn;
-
-    const connectionStatus = document.getElementById('connection-status');
-    if (!connectionStatus) {
-      throw new Error('connection-status element not found');
-    }
-    this.connectionStatus = connectionStatus;
-
-    // Configuration
-    const baudRateSelect = document.getElementById('baud-rate');
-    if (!baudRateSelect || !(baudRateSelect instanceof HTMLSelectElement)) {
-      throw new Error('baud-rate element not found');
-    }
-    this.baudRateSelect = baudRateSelect;
-
-    // Send data
-    const sendInput = document.getElementById('send-input');
-    if (!sendInput || !(sendInput instanceof HTMLInputElement)) {
-      throw new Error('send-input element not found');
-    }
-    this.sendInput = sendInput;
-
-    const sendBtn = document.getElementById('send-btn');
-    if (!sendBtn || !(sendBtn instanceof HTMLButtonElement)) {
-      throw new Error('send-btn element not found');
-    }
-    this.sendBtn = sendBtn;
-
-    // Receive data
-    const receiveOutput = document.getElementById('receive-output');
-    if (!receiveOutput || !(receiveOutput instanceof HTMLTextAreaElement)) {
-      throw new Error('receive-output element not found');
-    }
-    this.receiveOutput = receiveOutput;
-
-    const clearReceiveBtn = document.getElementById('clear-receive-btn');
-    if (!clearReceiveBtn || !(clearReceiveBtn instanceof HTMLButtonElement)) {
-      throw new Error('clear-receive-btn element not found');
-    }
-    this.clearReceiveBtn = clearReceiveBtn;
-  }
-
-  /**
-   * Check browser support
-   */
-  private checkBrowserSupport(): void {
-    const supported = isBrowserSupported();
-
-    if (supported) {
-      this.showStatus(
-        this.browserSupportStatus,
-        'success',
-        'ブラウザは Web Serial API をサポートしています。',
-      );
-      // Enable connection button if browser is supported
-      this.connectBtn.disabled = false;
-      this.requestPortBtn.disabled = false;
-    } else {
-      this.showStatus(
-        this.browserSupportStatus,
-        'error',
-        'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
-      );
-    }
-  }
-
-  /**
-   * Setup event handlers using RxJS
-   */
-  private setupEventHandlers(): void {
-    // Connect button
-    fromEvent(this.connectBtn, 'click').subscribe(() => {
-      this.handleConnect();
+    this.session.state$.subscribe((state) => {
+      const connected = state === 'connected';
+      const busy = state === 'connecting' || state === 'disconnecting';
+      connectBtn.disabled = !supported || connected || busy;
+      disconnectBtn.disabled = !connected;
+      sendInput.disabled = sendBtn.disabled = !connected;
+      baudRateSelect.disabled = connected || busy;
+      setStatus(status, ...STATUS[state]);
     });
-
-    // Disconnect button
-    fromEvent(this.disconnectBtn, 'click').subscribe(() => {
-      this.handleDisconnect();
+    this.session.receive$.subscribe((text) => {
+      receiveOutput.value += text;
+      receiveOutput.scrollTop = receiveOutput.scrollHeight;
     });
-
-    // Request port button
-    fromEvent(this.requestPortBtn, 'click').subscribe(() => {
-      this.handleRequestPort();
+    this.session.errors$.subscribe((error) => {
+      setStatus(status, 'error', `エラー: ${error.message}`);
+      console.error('Serial port error:', error);
     });
-
-    // Send button
-    fromEvent(this.sendBtn, 'click').subscribe(() => {
-      this.handleSend();
-    });
-
-    // Send on Enter key
-    fromEvent<KeyboardEvent>(this.sendInput, 'keydown')
-      .pipe(
-        filter((event) => event.key === 'Enter' && !event.shiftKey),
-        map((event) => {
-          event.preventDefault();
-          return event;
-        }),
-      )
-      .subscribe(() => {
-        this.handleSend();
-      });
-
-    // Clear receive output
-    fromEvent(this.clearReceiveBtn, 'click').subscribe(() => {
-      this.receiveOutput.value = '';
-    });
-  }
-
-  /**
-   * Handle connect action
-   */
-  private handleConnect(): void {
-    if (!this.client) {
-      const baudRate = parseInt(this.baudRateSelect.value, 10);
-      this.client = createSerialClient({ baudRate });
-    }
-
-    this.updateConnectionUI(false);
-
-    this.client.connect().subscribe({
-      next: () => {
-        this.showStatus(this.connectionStatus, 'success', '接続処理を開始しました。');
-        this.subscribeState();
-        this.startReading();
-      },
-      error: (error: unknown) => {
-        this.updateConnectionUI(false);
-        this.handleError(error, this.connectionStatus);
-      },
-    });
-  }
-
-  /**
-   * Handle disconnect action
-   */
-  private handleDisconnect(): void {
-    if (!this.client || !this.client.connected) {
-      return;
-    }
-
-    this.stopReading();
-
-    this.client.disconnect().subscribe({
-      next: () => {
-        this.stopStateSubscription();
-        this.updateConnectionUI(false);
-      },
-      error: (error: unknown) => {
-        this.handleError(error, this.connectionStatus);
-        // Even if there's an error, update UI to reflect disconnected state
-        this.updateConnectionUI(false);
-      },
-    });
-  }
-
-  /**
-   * Handle request port action
-   */
-  private handleRequestPort(): void {
-    if (!this.client) {
-      const baudRate = parseInt(this.baudRateSelect.value, 10);
-      this.client = createSerialClient({ baudRate });
-    }
-
-    this.client.requestPort().subscribe({
-      next: (port) => {
-        const portInfo = port.getInfo?.();
-        const vendorId = portInfo?.usbVendorId || 'N/A';
-        this.showStatus(
-          this.connectionStatus,
-          'success',
-          `ポートが選択されました: ${vendorId}`,
-        );
-      },
-      error: (error: unknown) => {
-        this.handleError(error, this.connectionStatus);
-      },
-    });
-  }
-
-  /**
-   * Handle send data action
-   */
-  private handleSend(): void {
-    if (!this.client || !this.client.connected) {
-      this.showStatus(
-        this.connectionStatus,
-        'warning',
-        '接続されていません。先にシリアルポートに接続してください。',
-      );
-      return;
-    }
-
-    const text = this.sendInput.value.trim();
-    if (!text) {
-      return;
-    }
-
-    this.client.send$(`${text}\n`).subscribe({
-      next: () => {
-        // Clear input after successful send
-        this.sendInput.value = '';
-      },
-      error: (error: unknown) => {
-        this.handleError(error, this.connectionStatus);
-      },
-    });
-  }
-
-  /**
-   * Start reading from serial port
-   */
-  private startReading(): void {
-    if (!this.client || !this.client.connected) {
-      return;
-    }
-
-    // Stop any existing read subscription
-    this.stopReading();
-
-    const readStream$ = this.client.text$;
-
-    this.readSubscription = readStream$.subscribe({
-      next: (text: string) => {
-        // Append to receive output
-        this.receiveOutput.value += text;
-
-        // Auto-scroll to bottom
-        this.receiveOutput.scrollTop = this.receiveOutput.scrollHeight;
-      },
-      error: (error: unknown) => {
-        this.handleError(error, this.connectionStatus);
-        // Disconnect on read error
-        this.handleDisconnect();
-      },
-    });
-  }
-
-  private subscribeState(): void {
-    if (!this.client) {
-      return;
-    }
-    this.stopStateSubscription();
-
-    this.stateSubscription = this.client.state$.subscribe((state) => {
-      this.updateConnectionUI(state.kind === 'connected');
-      if (state.kind === 'connecting') {
-        this.showStatus(this.connectionStatus, 'info', '接続中です...');
-      } else if (state.kind === 'disconnecting') {
-        this.showStatus(this.connectionStatus, 'info', '切断中です...');
-      } else if (state.kind === 'connected') {
-        this.showStatus(this.connectionStatus, 'success', 'シリアルポートに接続しました。');
-      } else if (state.kind === 'idle') {
-        this.showStatus(this.connectionStatus, 'info', 'シリアルポートから切断しました。');
-      } else if (state.kind === 'unsupported') {
-        this.showStatus(
-          this.connectionStatus,
-          'error',
-          state.support.supported
-            ? 'Unsupported state was reported.'
-            : state.support.reason,
-        );
-      } else if (state.kind === 'error') {
-        this.showStatus(this.connectionStatus, 'error', `エラー: ${state.error.message}`);
+    fromEvent(connectBtn, 'click').subscribe(() => {
+      const baudRate = parseInt(baudRateSelect.value, 10);
+      if (baudRate !== this.baudRate) {
+        this.baudRate = baudRate;
+        this.session = createSerialSession({ baudRate });
       }
+      this.session.connect$().subscribe({ error: () => void 0 });
     });
-  }
-
-  private stopStateSubscription(): void {
-    if (this.stateSubscription) {
-      this.stateSubscription.unsubscribe();
-      this.stateSubscription = null;
-    }
-  }
-
-  /**
-   * Stop reading from serial port
-   */
-  private stopReading(): void {
-    if (this.readSubscription) {
-      this.readSubscription.unsubscribe();
-      this.readSubscription = null;
-    }
-  }
-
-  /**
-   * Update connection UI state
-   */
-  private updateConnectionUI(connected: boolean): void {
-    this.connectBtn.disabled = connected;
-    this.disconnectBtn.disabled = !connected;
-    this.sendInput.disabled = !connected;
-    this.sendBtn.disabled = !connected;
-    this.baudRateSelect.disabled = connected;
-  }
-
-  /**
-   * Show status message
-   */
-  private showStatus(
-    element: HTMLElement,
-    type: 'info' | 'success' | 'error' | 'warning',
-    message: string,
-  ): void {
-    element.textContent = message;
-    element.className = `status-message ${type}`;
-  }
-
-  /**
-   * Handle errors
-   */
-  private handleError(error: unknown, statusElement: HTMLElement): void {
-    let message = 'エラーが発生しました。';
-
-    if (error instanceof SerialError) {
-      message = `エラー: ${error.message}`;
-    } else if (error instanceof Error) {
-      message = `エラー: ${error.message}`;
-    } else {
-      message = `エラー: ${String(error)}`;
-    }
-
-    this.showStatus(statusElement, 'error', message);
-    console.error('Serial port error:', error);
+    fromEvent(disconnectBtn, 'click').subscribe(() =>
+      this.session.disconnect$().subscribe({ error: () => void 0 }),
+    );
+    const send = () => {
+      const text = sendInput.value.trim();
+      if (!text) return;
+      this.session.send$(`${text}\n`).subscribe({
+        next: () => (sendInput.value = ''),
+        error: () => void 0,
+      });
+    };
+    fromEvent(sendBtn, 'click').subscribe(send);
+    fromEvent<KeyboardEvent>(sendInput, 'keydown')
+      .pipe(filter((e) => e.key === 'Enter' && !e.shiftKey))
+      .subscribe((e) => {
+        e.preventDefault();
+        send();
+      });
+    fromEvent($<HTMLButtonElement>('clear-receive-btn'), 'click').subscribe(
+      () => (receiveOutput.value = ''),
+    );
   }
 }


### PR DESCRIPTION
## Summary

- `apps/example-vanilla-ts` / `apps/example-vanilla-js` を v2 `createSerialSession` ベースに書き換え、read loop / state 再構築ロジックをアプリ側から排除
- 両 example の本体コードを 100 行未満に収め、Issue #210 の完了条件を満たす
- 本 PR のスコープは vanilla example の 2 アプリのみ。legacy API 削除（#199）、ライブラリ側ドキュメント更新（#207）、その他の README 更新は別 PR で対応する

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #210
- Refs #199
- Refs #207

## What changed?

- `apps/example-vanilla-ts/src/app.ts` を `createSerialSession` + `state$` / `receive$` / `errors$` 直接購読に書き換え（99 行・read loop / state 再構築を削除）
- `apps/example-vanilla-js/src/app.js` も同様に書き換え（91 行）
- 両 example のテスト（`app.test.ts` / `app.test.js`）を SerialSession モック仕様に更新
- `index.html` から v2 API に存在しない「ポート選択」ボタンを削除

### 本 PR のスコープ外（別 Issue/PR で対応）

- `packages/web-serial-rxjs` の legacy API（`createSerialClient` / `createShellClient` 等）削除 → #199 の別 PR で対応
- `packages/web-serial-rxjs/README*.md` / `packages/web-serial-rxjs/docs/*.md` / root `docs/*.md` の更新 → #207 で対応
- root `README.md` / `README.ja.md` と `apps/example-angular` / `apps/example-vue` 等の README 更新 → #207 で対応

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

（本 PR は example アプリの内部実装を v2 SerialSession API へ移行するのみで、ライブラリ側の公開 API には変更を加えない）

## How to test

1. `pnpm install`
2. `nx test example-vanilla-ts` / `nx test example-vanilla-js` が pass することを確認
3. `nx lint example-vanilla-ts` / `nx lint example-vanilla-js` が clean であることを確認
4. `nx build example-vanilla-ts` / `nx build example-vanilla-js` が成功することを確認
5. `pnpm --filter example-vanilla-ts dev` を起動し、Chromium 系ブラウザで接続 → 受信 → 送信 → 切断、および USB 抜線時の `errors$` と `state$='error'` 遷移を確認

## Environment (if relevant)

- Browser: Chrome 最新版
- OS: macOS
- web-serial-rxjs version (for verification): 本 PR の HEAD（`main` 時点の公開 API をそのまま利用）
- RxJS version: ワークスペースの固定版

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed（ドキュメント更新は #207 で対応）
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)
