### PR TITLE
docs: クイックスタートを最短動作フローに整理

### DIFF
--- a/docs/QUICK_START.ja.md
+++ b/docs/QUICK_START.ja.md
@@ -1,144 +1,62 @@
 # クイックスタート
 
-**最短で**ポートを開き、購読まで進む手順です。`state$` / `receive$` / `errors$` と各メソッドの一覧は、先に[リポジトリの README](../README.ja.md#serialsessionv2の全体像)を参照してください。
+**最短で**シリアルポートを開き、行単位で受信し、送信・切断するところまで進む手順です。`state$` / `receive$` / `errors$` と各メソッドの一覧は、先に[リポジトリの README](../README.ja.md#serialsessionv2の全体像)を参照してください。
 
-v2 の公開 API は `createSerialSession` が返す単一の `SerialSession` です。`state$` / `receive$` / `errors$` を購読し、`connect$` / `disconnect$` / `send$` でポートを操作します。
+`SerialSession` にビルトインの `lines$` や `connected$` はありません。下記では `receive$` と `state$` から**派生**させます（パターンの説明は[高度な使用方法](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
 
 ```typescript
+import { filter, map, scan } from 'rxjs';
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
 
-const session = createSerialSession({ baudRate: 9600 });
+const session = createSerialSession({ baudRate: 115200 });
 
 if (!session.isBrowserSupported()) {
   console.error('このブラウザは Web Serial API をサポートしていません');
 }
 
-session.state$.subscribe((state) => console.log('状態:', state));
-session.receive$.subscribe((text) => console.log('受信:', text));
-session.errors$.subscribe((error) => console.error('シリアルエラー:', error));
+const connected$ = session.state$.pipe(map((s) => s === 'connected'));
+
+const lines$ = session.receive$.pipe(
+  scan(
+    (acc, chunk) => {
+      const combined = acc.buffer + chunk;
+      const parts = combined.split('\n');
+      return { buffer: parts.pop() ?? '', lines: parts };
+    },
+    { buffer: '', lines: [] as string[] },
+  ),
+  filter((s) => s.lines.length > 0),
+  map((s) => s.lines),
+);
+
+connected$.subscribe((isConnected) => console.log('接続中:', isConnected));
+lines$.subscribe((lines) => lines.forEach((line) => console.log('行:', line)));
+
+// 本番では errors$ を購読して SerialError を扱うことを推奨します
+session.errors$.subscribe((err) => console.error('シリアルエラー:', err));
 
 session.connect$().subscribe({
   next: () => {
-    session.send$('help\n').subscribe({
-      error: (error) => console.error('送信エラー:', error),
+    session.send$('ls\r\n').subscribe({
+      error: (e) => console.error('送信エラー:', e),
     });
   },
-  error: (error) => console.error('接続エラー:', error),
+  error: (e) => console.error('接続エラー:', e),
 });
 ```
 
-## 使用例
+## 切断する
 
-### 基本的な接続
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 115200,
-  dataBits: 8,
-  stopBits: 1,
-  parity: 'none',
-});
-
-session.connect$().subscribe({
-  next: () => console.log('接続しました'),
-  error: (error) => console.error('接続に失敗しました:', error),
-});
-```
-
-### テキストを読み取る
-
-`receive$` はストリーミング `TextDecoder` により UTF-8 デコード済みの文字列を emit します。マルチバイト文字がチャンクをまたいでも正しく結合されます。境界は**任意のチャンク**で、1 行が 1 emit になるとは限りません。改行区切りの行が欲しい場合は `receive$` の上にオペレータを重ねます（完全な例は[高度な使用方法](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）:
+ポートを閉じるときは `disconnect$` を呼びます。
 
 ```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe();
-session.receive$.subscribe((chunk) => console.log('chunk:', chunk));
-```
-
-### 順序を保証した送信
-
-`send$` は内部の FIFO キューにより、並行する呼び出しでも呼び出し順にポートへ書き込まれます。
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-import { from, concatMap } from 'rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe({
-  next: () => {
-    const messages = ['メッセージ 1\n', 'メッセージ 2\n', 'メッセージ 3\n'];
-    from(messages)
-      .pipe(concatMap((msg) => session.send$(msg)))
-      .subscribe({
-        error: (error) => console.error('送信エラー:', error),
-      });
-  },
-});
-```
-
-### エラーハンドリング
-
-接続・読み取り・書き込み・クローズで発生するすべてのエラーは `SerialError` に正規化され、`errors$` に流れます。致命的なエラーは `state$` を `'error'` に遷移させます。
-
-```typescript
-import {
-  createSerialSession,
-  SerialError,
-  SerialErrorCode,
-} from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.errors$.subscribe((error: SerialError) => {
-  switch (error.code) {
-    case SerialErrorCode.BROWSER_NOT_SUPPORTED:
-      console.error('Web Serial API がサポートされていません');
-      break;
-    case SerialErrorCode.PORT_OPEN_FAILED:
-      console.error('ポートのオープンに失敗:', error.message);
-      break;
-    case SerialErrorCode.READ_FAILED:
-    case SerialErrorCode.CONNECTION_LOST:
-      console.error('接続が失われました');
-      break;
-    case SerialErrorCode.WRITE_FAILED:
-      console.error('書き込みに失敗:', error.message);
-      break;
-    default:
-      console.error('シリアルエラー:', error);
-  }
-});
-
-session.connect$().subscribe({
-  error: () => {
-    // errors$ 側でも流れているのでここでは握り潰しても OK
-  },
-});
-```
-
-### ポートフィルタ
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 9600,
-  filters: [{ usbVendorId: 0x1234 }, { usbVendorId: 0x5678 }],
-});
-
-session.connect$().subscribe({
-  error: (error) => console.error('接続エラー:', error),
+session.disconnect$().subscribe({
+  error: (e) => console.error('切断エラー:', e),
 });
 ```
 
 ## 次のステップ
 
-- `SerialSession` の全インターフェイスは [API リファレンス](./API_REFERENCE.ja.md) を参照してください。
-- 行フレーミング、擬似リクエスト／レスポンス、リカバリは [高度な使用方法](./ADVANCED_USAGE.ja.md) を参照してください。
+- 公開メソッドとストリームの一覧は [API リファレンス](./API_REFERENCE.ja.md) を参照してください。
+- チャンク単位の受信、送信の順序制御、エラー分岐の詳細、ポートフィルタなどは [高度な使用方法](./ADVANCED_USAGE.ja.md) を参照してください。
 - v1 からの移行は [v1 → v2 マイグレーション](./MIGRATION_V2.ja.md) を参照してください。

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -1,144 +1,62 @@
 # Quick Start
 
-This is the **shortest path** to an open port and working subscriptions. For a one-page map of `state$` / `receive$` / `errors$` and the imperative methods, start with the [project README](../README.md#serialsession-v2-at-a-glance).
+This is the **shortest path** to opening a serial port, receiving **newline-delimited lines**, sending data, and closing the port. For the full map of `state$`, `receive$`, `errors$`, and the imperative methods, read the [project README](../README.md#serialsession-v2-at-a-glance) first.
 
-The v2 public API is a single `SerialSession` created by `createSerialSession`. Subscribe to `state$`, `receive$`, and `errors$` and drive the port through `connect$`, `disconnect$`, and `send$`.
+`SerialSession` does not expose built-in `lines$` or `connected$`. Below they are **derived** from `receive$` and `state$` (see [Advanced Usage](./ADVANCED_USAGE.md#line-framing) for the pattern).
 
 ```typescript
+import { filter, map, scan } from 'rxjs';
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
 
-const session = createSerialSession({ baudRate: 9600 });
+const session = createSerialSession({ baudRate: 115200 });
 
 if (!session.isBrowserSupported()) {
   console.error('Web Serial API is not supported in this browser');
 }
 
-session.state$.subscribe((state) => console.log('State:', state));
-session.receive$.subscribe((text) => console.log('Received:', text));
-session.errors$.subscribe((error) => console.error('Serial error:', error));
+const connected$ = session.state$.pipe(map((s) => s === 'connected'));
+
+const lines$ = session.receive$.pipe(
+  scan(
+    (acc, chunk) => {
+      const combined = acc.buffer + chunk;
+      const parts = combined.split('\n');
+      return { buffer: parts.pop() ?? '', lines: parts };
+    },
+    { buffer: '', lines: [] as string[] },
+  ),
+  filter((s) => s.lines.length > 0),
+  map((s) => s.lines),
+);
+
+connected$.subscribe((isConnected) => console.log('Connected:', isConnected));
+lines$.subscribe((lines) => lines.forEach((line) => console.log('line:', line)));
+
+// In production apps, subscribe to errors$ and handle SerialError
+session.errors$.subscribe((err) => console.error('Serial error:', err));
 
 session.connect$().subscribe({
   next: () => {
-    session.send$('help\n').subscribe({
-      error: (error) => console.error('Send error:', error),
+    session.send$('ls\r\n').subscribe({
+      error: (e) => console.error('Send error:', e),
     });
   },
-  error: (error) => console.error('Connection error:', error),
+  error: (e) => console.error('Connection error:', e),
 });
 ```
 
-## Usage Examples
+## Disconnect
 
-### Basic Connection
+Call `disconnect$` when you want to close the port.
 
 ```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 115200,
-  dataBits: 8,
-  stopBits: 1,
-  parity: 'none',
-});
-
-session.connect$().subscribe({
-  next: () => console.log('Connected'),
-  error: (error) => console.error('Connection failed:', error),
+session.disconnect$().subscribe({
+  error: (e) => console.error('Disconnect error:', e),
 });
 ```
 
-### Reading Text
+## Next steps
 
-`receive$` emits UTF-8 decoded strings using a streaming `TextDecoder`. Multi-byte characters split across chunks are joined automatically. Subscriptions see **arbitrary chunk boundaries**—not one line per emission. For newline-delimited lines, compose operators over `receive$` (full recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)):
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe();
-session.receive$.subscribe((chunk) => console.log('Chunk:', chunk));
-```
-
-### Ordered Sends
-
-`send$` internally serialises concurrent calls through a FIFO queue so payloads reach the port in call order.
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-import { from, concatMap } from 'rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe({
-  next: () => {
-    const messages = ['Message 1\n', 'Message 2\n', 'Message 3\n'];
-    from(messages)
-      .pipe(concatMap((msg) => session.send$(msg)))
-      .subscribe({
-        error: (error) => console.error('Send error:', error),
-      });
-  },
-});
-```
-
-### Error Handling
-
-Every failure (connect / read / write / close) is normalised to `SerialError` and multiplexed on `errors$`. Fatal failures additionally drive `state$` into `'error'`.
-
-```typescript
-import {
-  createSerialSession,
-  SerialError,
-  SerialErrorCode,
-} from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.errors$.subscribe((error: SerialError) => {
-  switch (error.code) {
-    case SerialErrorCode.BROWSER_NOT_SUPPORTED:
-      console.error('Browser does not support Web Serial API');
-      break;
-    case SerialErrorCode.PORT_OPEN_FAILED:
-      console.error('Failed to open port:', error.message);
-      break;
-    case SerialErrorCode.READ_FAILED:
-    case SerialErrorCode.CONNECTION_LOST:
-      console.error('Connection lost');
-      break;
-    case SerialErrorCode.WRITE_FAILED:
-      console.error('Write failed:', error.message);
-      break;
-    default:
-      console.error('Serial error:', error);
-  }
-});
-
-session.connect$().subscribe({
-  error: () => {
-    // already surfaced via errors$
-  },
-});
-```
-
-### Port Filtering
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 9600,
-  filters: [{ usbVendorId: 0x1234 }, { usbVendorId: 0x5678 }],
-});
-
-session.connect$().subscribe({
-  error: (error) => console.error('Connection error:', error),
-});
-```
-
-## Next Steps
-
-- See [API Reference](./API_REFERENCE.md) for the full `SerialSession` surface.
-- Check out [Advanced Usage](./ADVANCED_USAGE.md) for line framing, request/response-style flows, and recovery.
-- Coming from v1? Read the [v1 → v2 Migration Guide](./MIGRATION_V2.md).
+- See the [API Reference](./API_REFERENCE.md) for the full list of streams and methods.
+- Chunk-mode reception, ordered sends, detailed error handling, port filters, and more recipes are in [Advanced Usage](./ADVANCED_USAGE.md).
+- Migrating from v1 is covered in [Migration v1 → v2](./MIGRATION_V2.md).

--- a/docs/media/QUICK_START.md
+++ b/docs/media/QUICK_START.md
@@ -1,159 +1,62 @@
 # Quick Start
 
-The v2 public API is a single `SerialSession` created by `createSerialSession`. Subscribe to `state$`, `receive$`, and `errors$` and drive the port through `connect$`, `disconnect$`, and `send$`.
+This is the **shortest path** to opening a serial port, receiving **newline-delimited lines**, sending data, and closing the port. For the full map of `state$`, `receive$`, `errors$`, and the imperative methods, read the [project README](../../README.md#serialsession-v2-at-a-glance) first.
+
+`SerialSession` does not expose built-in `lines$` or `connected$`. Below they are **derived** from `receive$` and `state$` (see [Advanced Usage](./ADVANCED_USAGE.md#line-framing) for the pattern).
 
 ```typescript
+import { filter, map, scan } from 'rxjs';
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
 
-const session = createSerialSession({ baudRate: 9600 });
+const session = createSerialSession({ baudRate: 115200 });
 
 if (!session.isBrowserSupported()) {
   console.error('Web Serial API is not supported in this browser');
 }
 
-session.state$.subscribe((state) => console.log('State:', state));
-session.receive$.subscribe((text) => console.log('Received:', text));
-session.errors$.subscribe((error) => console.error('Serial error:', error));
+const connected$ = session.state$.pipe(map((s) => s === 'connected'));
+
+const lines$ = session.receive$.pipe(
+  scan(
+    (acc, chunk) => {
+      const combined = acc.buffer + chunk;
+      const parts = combined.split('\n');
+      return { buffer: parts.pop() ?? '', lines: parts };
+    },
+    { buffer: '', lines: [] as string[] },
+  ),
+  filter((s) => s.lines.length > 0),
+  map((s) => s.lines),
+);
+
+connected$.subscribe((isConnected) => console.log('Connected:', isConnected));
+lines$.subscribe((lines) => lines.forEach((line) => console.log('line:', line)));
+
+// In production apps, subscribe to errors$ and handle SerialError
+session.errors$.subscribe((err) => console.error('Serial error:', err));
 
 session.connect$().subscribe({
   next: () => {
-    session.send$('help\n').subscribe({
-      error: (error) => console.error('Send error:', error),
+    session.send$('ls\r\n').subscribe({
+      error: (e) => console.error('Send error:', e),
     });
   },
-  error: (error) => console.error('Connection error:', error),
+  error: (e) => console.error('Connection error:', e),
 });
 ```
 
-## Usage Examples
+## Disconnect
 
-### Basic Connection
+Call `disconnect$` when you want to close the port.
 
 ```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 115200,
-  dataBits: 8,
-  stopBits: 1,
-  parity: 'none',
-});
-
-session.connect$().subscribe({
-  next: () => console.log('Connected'),
-  error: (error) => console.error('Connection failed:', error),
+session.disconnect$().subscribe({
+  error: (e) => console.error('Disconnect error:', e),
 });
 ```
 
-### Reading Text
+## Next steps
 
-`receive$` emits UTF-8 decoded strings using a streaming `TextDecoder`. Multi-byte characters split across chunks are joined automatically. Use RxJS operators when you need line framing.
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-import { scan, filter, map } from 'rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe();
-
-session.receive$.subscribe((chunk) => console.log('Chunk:', chunk));
-
-session.receive$
-  .pipe(
-    scan(
-      (acc, chunk) => {
-        const combined = acc.buffer + chunk;
-        const parts = combined.split('\n');
-        return { buffer: parts.pop() ?? '', lines: parts };
-      },
-      { buffer: '', lines: [] as string[] },
-    ),
-    filter((s) => s.lines.length > 0),
-    map((s) => s.lines),
-  )
-  .subscribe((lines) => lines.forEach((line) => console.log('Line:', line)));
-```
-
-### Ordered Sends
-
-`send$` internally serialises concurrent calls through a FIFO queue so payloads reach the port in call order.
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-import { from, concatMap } from 'rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe({
-  next: () => {
-    const messages = ['Message 1\n', 'Message 2\n', 'Message 3\n'];
-    from(messages)
-      .pipe(concatMap((msg) => session.send$(msg)))
-      .subscribe({
-        error: (error) => console.error('Send error:', error),
-      });
-  },
-});
-```
-
-### Error Handling
-
-Every failure (connect / read / write / close) is normalised to `SerialError` and multiplexed on `errors$`. Fatal failures additionally drive `state$` into `'error'`.
-
-```typescript
-import {
-  createSerialSession,
-  SerialError,
-  SerialErrorCode,
-} from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.errors$.subscribe((error: SerialError) => {
-  switch (error.code) {
-    case SerialErrorCode.BROWSER_NOT_SUPPORTED:
-      console.error('Browser does not support Web Serial API');
-      break;
-    case SerialErrorCode.PORT_OPEN_FAILED:
-      console.error('Failed to open port:', error.message);
-      break;
-    case SerialErrorCode.READ_FAILED:
-    case SerialErrorCode.CONNECTION_LOST:
-      console.error('Connection lost');
-      break;
-    case SerialErrorCode.WRITE_FAILED:
-      console.error('Write failed:', error.message);
-      break;
-    default:
-      console.error('Serial error:', error);
-  }
-});
-
-session.connect$().subscribe({
-  error: () => {
-    // already surfaced via errors$
-  },
-});
-```
-
-### Port Filtering
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 9600,
-  filters: [{ usbVendorId: 0x1234 }, { usbVendorId: 0x5678 }],
-});
-
-session.connect$().subscribe({
-  error: (error) => console.error('Connection error:', error),
-});
-```
-
-## Next Steps
-
-- See [API Reference](./API_REFERENCE.md) for the full `SerialSession` surface.
-- Check out [Advanced Usage](./ADVANCED_USAGE.md) for more patterns.
-- Coming from v1? Read the [v1 → v2 Migration Guide](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md).
+- See the [API Reference](./API_REFERENCE.md) for the full list of streams and methods.
+- Chunk-mode reception, ordered sends, detailed error handling, port filters, and more recipes are in [Advanced Usage](./ADVANCED_USAGE.md).
+- Migrating from v1 is covered in [Migration v1 → v2](./MIGRATION_V2.md).

--- a/packages/web-serial-rxjs/docs/QUICK_START.ja.md
+++ b/packages/web-serial-rxjs/docs/QUICK_START.ja.md
@@ -1,144 +1,62 @@
 # クイックスタート
 
-**最短で**ポートを開き、購読まで進む手順です。`state$` / `receive$` / `errors$` と各メソッドの一覧は、先に[リポジトリの README](../../../README.ja.md#serialsessionv2の全体像)を参照してください。
+**最短で**シリアルポートを開き、行単位で受信し、送信・切断するところまで進む手順です。`state$` / `receive$` / `errors$` と各メソッドの一覧は、先に[リポジトリの README](../../../README.ja.md#serialsessionv2の全体像)を参照してください。
 
-v2 の公開 API は `createSerialSession` が返す単一の `SerialSession` です。`state$` / `receive$` / `errors$` を購読し、`connect$` / `disconnect$` / `send$` でポートを操作します。
+`SerialSession` にビルトインの `lines$` や `connected$` はありません。下記では `receive$` と `state$` から**派生**させます（パターンの説明は[高度な使用方法](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
 
 ```typescript
+import { filter, map, scan } from 'rxjs';
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
 
-const session = createSerialSession({ baudRate: 9600 });
+const session = createSerialSession({ baudRate: 115200 });
 
 if (!session.isBrowserSupported()) {
   console.error('このブラウザは Web Serial API をサポートしていません');
 }
 
-session.state$.subscribe((state) => console.log('状態:', state));
-session.receive$.subscribe((text) => console.log('受信:', text));
-session.errors$.subscribe((error) => console.error('シリアルエラー:', error));
+const connected$ = session.state$.pipe(map((s) => s === 'connected'));
+
+const lines$ = session.receive$.pipe(
+  scan(
+    (acc, chunk) => {
+      const combined = acc.buffer + chunk;
+      const parts = combined.split('\n');
+      return { buffer: parts.pop() ?? '', lines: parts };
+    },
+    { buffer: '', lines: [] as string[] },
+  ),
+  filter((s) => s.lines.length > 0),
+  map((s) => s.lines),
+);
+
+connected$.subscribe((isConnected) => console.log('接続中:', isConnected));
+lines$.subscribe((lines) => lines.forEach((line) => console.log('行:', line)));
+
+// 本番では errors$ を購読して SerialError を扱うことを推奨します
+session.errors$.subscribe((err) => console.error('シリアルエラー:', err));
 
 session.connect$().subscribe({
   next: () => {
-    session.send$('help\n').subscribe({
-      error: (error) => console.error('送信エラー:', error),
+    session.send$('ls\r\n').subscribe({
+      error: (e) => console.error('送信エラー:', e),
     });
   },
-  error: (error) => console.error('接続エラー:', error),
+  error: (e) => console.error('接続エラー:', e),
 });
 ```
 
-## 使用例
+## 切断する
 
-### 基本的な接続
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 115200,
-  dataBits: 8,
-  stopBits: 1,
-  parity: 'none',
-});
-
-session.connect$().subscribe({
-  next: () => console.log('接続しました'),
-  error: (error) => console.error('接続に失敗しました:', error),
-});
-```
-
-### テキストを読み取る
-
-`receive$` はストリーミング `TextDecoder` により UTF-8 デコード済みの文字列を emit します。マルチバイト文字がチャンクをまたいでも正しく結合されます。境界は**任意のチャンク**で、1 行が 1 emit になるとは限りません。改行区切りの行が欲しい場合は `receive$` の上にオペレータを重ねます（完全な例は[高度な使用方法](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）:
+ポートを閉じるときは `disconnect$` を呼びます。
 
 ```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe();
-session.receive$.subscribe((chunk) => console.log('chunk:', chunk));
-```
-
-### 順序を保証した送信
-
-`send$` は内部の FIFO キューにより、並行する呼び出しでも呼び出し順にポートへ書き込まれます。
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-import { from, concatMap } from 'rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe({
-  next: () => {
-    const messages = ['メッセージ 1\n', 'メッセージ 2\n', 'メッセージ 3\n'];
-    from(messages)
-      .pipe(concatMap((msg) => session.send$(msg)))
-      .subscribe({
-        error: (error) => console.error('送信エラー:', error),
-      });
-  },
-});
-```
-
-### エラーハンドリング
-
-接続・読み取り・書き込み・クローズで発生するすべてのエラーは `SerialError` に正規化され、`errors$` に流れます。致命的なエラーは `state$` を `'error'` に遷移させます。
-
-```typescript
-import {
-  createSerialSession,
-  SerialError,
-  SerialErrorCode,
-} from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.errors$.subscribe((error: SerialError) => {
-  switch (error.code) {
-    case SerialErrorCode.BROWSER_NOT_SUPPORTED:
-      console.error('Web Serial API がサポートされていません');
-      break;
-    case SerialErrorCode.PORT_OPEN_FAILED:
-      console.error('ポートのオープンに失敗:', error.message);
-      break;
-    case SerialErrorCode.READ_FAILED:
-    case SerialErrorCode.CONNECTION_LOST:
-      console.error('接続が失われました');
-      break;
-    case SerialErrorCode.WRITE_FAILED:
-      console.error('書き込みに失敗:', error.message);
-      break;
-    default:
-      console.error('シリアルエラー:', error);
-  }
-});
-
-session.connect$().subscribe({
-  error: () => {
-    // errors$ 側でも流れているのでここでは握り潰しても OK
-  },
-});
-```
-
-### ポートフィルタ
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 9600,
-  filters: [{ usbVendorId: 0x1234 }, { usbVendorId: 0x5678 }],
-});
-
-session.connect$().subscribe({
-  error: (error) => console.error('接続エラー:', error),
+session.disconnect$().subscribe({
+  error: (e) => console.error('切断エラー:', e),
 });
 ```
 
 ## 次のステップ
 
-- `SerialSession` の全インターフェイスは [API リファレンス](./API_REFERENCE.ja.md) を参照してください。
-- 行フレーミング、擬似リクエスト／レスポンス、リカバリは [高度な使用方法](./ADVANCED_USAGE.ja.md) を参照してください。
+- 公開メソッドとストリームの一覧は [API リファレンス](./API_REFERENCE.ja.md) を参照してください。
+- チャンク単位の受信、送信の順序制御、エラー分岐の詳細、ポートフィルタなどは [高度な使用方法](./ADVANCED_USAGE.ja.md) を参照してください。
 - v1 からの移行は [v1 → v2 マイグレーション](./MIGRATION_V2.ja.md) を参照してください。

--- a/packages/web-serial-rxjs/docs/QUICK_START.md
+++ b/packages/web-serial-rxjs/docs/QUICK_START.md
@@ -1,144 +1,62 @@
 # Quick Start
 
-This is the **shortest path** to an open port and working subscriptions. For a one-page map of `state$` / `receive$` / `errors$` and the imperative methods, start with the [project README](../../../README.md#serialsession-v2-at-a-glance).
+This is the **shortest path** to opening a serial port, receiving **newline-delimited lines**, sending data, and closing the port. For the full map of `state$`, `receive$`, `errors$`, and the imperative methods, read the [project README](../../../README.md#serialsession-v2-at-a-glance) first.
 
-The v2 public API is a single `SerialSession` created by `createSerialSession`. Subscribe to `state$`, `receive$`, and `errors$` and drive the port through `connect$`, `disconnect$`, and `send$`.
+`SerialSession` does not expose built-in `lines$` or `connected$`. Below they are **derived** from `receive$` and `state$` (see [Advanced Usage](./ADVANCED_USAGE.md#line-framing) for the pattern).
 
 ```typescript
+import { filter, map, scan } from 'rxjs';
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
 
-const session = createSerialSession({ baudRate: 9600 });
+const session = createSerialSession({ baudRate: 115200 });
 
 if (!session.isBrowserSupported()) {
   console.error('Web Serial API is not supported in this browser');
 }
 
-session.state$.subscribe((state) => console.log('State:', state));
-session.receive$.subscribe((text) => console.log('Received:', text));
-session.errors$.subscribe((error) => console.error('Serial error:', error));
+const connected$ = session.state$.pipe(map((s) => s === 'connected'));
+
+const lines$ = session.receive$.pipe(
+  scan(
+    (acc, chunk) => {
+      const combined = acc.buffer + chunk;
+      const parts = combined.split('\n');
+      return { buffer: parts.pop() ?? '', lines: parts };
+    },
+    { buffer: '', lines: [] as string[] },
+  ),
+  filter((s) => s.lines.length > 0),
+  map((s) => s.lines),
+);
+
+connected$.subscribe((isConnected) => console.log('Connected:', isConnected));
+lines$.subscribe((lines) => lines.forEach((line) => console.log('line:', line)));
+
+// In production apps, subscribe to errors$ and handle SerialError
+session.errors$.subscribe((err) => console.error('Serial error:', err));
 
 session.connect$().subscribe({
   next: () => {
-    session.send$('help\n').subscribe({
-      error: (error) => console.error('Send error:', error),
+    session.send$('ls\r\n').subscribe({
+      error: (e) => console.error('Send error:', e),
     });
   },
-  error: (error) => console.error('Connection error:', error),
+  error: (e) => console.error('Connection error:', e),
 });
 ```
 
-## Usage Examples
+## Disconnect
 
-### Basic Connection
+Call `disconnect$` when you want to close the port.
 
 ```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 115200,
-  dataBits: 8,
-  stopBits: 1,
-  parity: 'none',
-});
-
-session.connect$().subscribe({
-  next: () => console.log('Connected'),
-  error: (error) => console.error('Connection failed:', error),
+session.disconnect$().subscribe({
+  error: (e) => console.error('Disconnect error:', e),
 });
 ```
 
-### Reading Text
+## Next steps
 
-`receive$` emits UTF-8 decoded strings using a streaming `TextDecoder`. Multi-byte characters split across chunks are joined automatically. Subscriptions see **arbitrary chunk boundaries**—not one line per emission. For newline-delimited lines, compose operators over `receive$` (full recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)):
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe();
-session.receive$.subscribe((chunk) => console.log('Chunk:', chunk));
-```
-
-### Ordered Sends
-
-`send$` internally serialises concurrent calls through a FIFO queue so payloads reach the port in call order.
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-import { from, concatMap } from 'rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.connect$().subscribe({
-  next: () => {
-    const messages = ['Message 1\n', 'Message 2\n', 'Message 3\n'];
-    from(messages)
-      .pipe(concatMap((msg) => session.send$(msg)))
-      .subscribe({
-        error: (error) => console.error('Send error:', error),
-      });
-  },
-});
-```
-
-### Error Handling
-
-Every failure (connect / read / write / close) is normalised to `SerialError` and multiplexed on `errors$`. Fatal failures additionally drive `state$` into `'error'`.
-
-```typescript
-import {
-  createSerialSession,
-  SerialError,
-  SerialErrorCode,
-} from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({ baudRate: 9600 });
-
-session.errors$.subscribe((error: SerialError) => {
-  switch (error.code) {
-    case SerialErrorCode.BROWSER_NOT_SUPPORTED:
-      console.error('Browser does not support Web Serial API');
-      break;
-    case SerialErrorCode.PORT_OPEN_FAILED:
-      console.error('Failed to open port:', error.message);
-      break;
-    case SerialErrorCode.READ_FAILED:
-    case SerialErrorCode.CONNECTION_LOST:
-      console.error('Connection lost');
-      break;
-    case SerialErrorCode.WRITE_FAILED:
-      console.error('Write failed:', error.message);
-      break;
-    default:
-      console.error('Serial error:', error);
-  }
-});
-
-session.connect$().subscribe({
-  error: () => {
-    // already surfaced via errors$
-  },
-});
-```
-
-### Port Filtering
-
-```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
-
-const session = createSerialSession({
-  baudRate: 9600,
-  filters: [{ usbVendorId: 0x1234 }, { usbVendorId: 0x5678 }],
-});
-
-session.connect$().subscribe({
-  error: (error) => console.error('Connection error:', error),
-});
-```
-
-## Next Steps
-
-- See [API Reference](./API_REFERENCE.md) for the full `SerialSession` surface.
-- Check out [Advanced Usage](./ADVANCED_USAGE.md) for line framing, request/response-style flows, and recovery.
-- Coming from v1? Read the [v1 → v2 Migration Guide](./MIGRATION_V2.md).
+- See the [API Reference](./API_REFERENCE.md) for the full list of streams and methods.
+- Chunk-mode reception, ordered sends, detailed error handling, port filters, and more recipes are in [Advanced Usage](./ADVANCED_USAGE.md).
+- Migrating from v1 is covered in [Migration v1 → v2](./MIGRATION_V2.md).


### PR DESCRIPTION
## Summary

Issue #227 に沿い、クイックスタートを「コピペで接続〜行受信〜送信〜切断」に特化した最小構成に再構成しました。`lines$` と `connected$` は SerialSession の新 API ではなく、`receive$` / `state$` からの派生として記載し、親 Issue #225 の README / QUICK_START / ADVANCED の役割分担に合わせて詳細な例は ADVANCED へ寄せました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #227

## What changed?

- 先頭に `lines$` / `connected$` 前提の最小サンプルを配置（派生コード込み）
- `receive$` を主役にしない構成に変更
- 長い使用例（エラー分岐の網羅、concatMap、フィルタ詳説など）を削減しリンクに置換
- パッケージ配下・リポジトリルート・`docs/media` の QUICK_START を同期

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. ドキュメント内のコードブロックが TypeScript として整合しているか目視
2. 相対リンクがロケール（en/ja）ごとに切れていないか確認
3. （任意）Chromium でサンプルどおりに接続・送信できるか手元デバイスで確認

## Environment (if relevant)

- Browser: Chrome / Edge / Opera / etc. (version: )
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification):
- RxJS version:

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)