### PR TITLE
docs: ADVANCED_USAGE に Issue #228 の応用レシピを追記 (#228)

### DIFF
--- a/docs/ADVANCED_USAGE.ja.md
+++ b/docs/ADVANCED_USAGE.ja.md
@@ -2,7 +2,9 @@
 
 v2 の `SerialSession` は意図的に小さな公開面に絞られています。応用パターンの大半は、`receive$` と `send$` の上に普通の RxJS オペレータを組み合わせることで表現できます。API の全体像は先に[README](../README.ja.md#serialsessionv2の全体像)と[クイックスタート](./QUICK_START.ja.md)を読み、本ページは README で省いた**行フレーミング・派生ストリーム・リカバリ**のレシピに絞ります。
 
-## 行単位のフレーミング
+本ページは [Issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228) で列挙したパターンに対応します。**`lines$`・`connected$`・`sendLine`・`readUntil`・`waitForState`** はいずれも既存 API の組み合わせであり、ライブラリに追加の export はありません。USB OTG シリアルコンソールの実例として [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) があります。同アプリの読み書きループを `SerialSession` で書き直すときも、ここでのレシピがそのまま使えます。
+
+## 行単位のフレーミング（`receive$` からの `lines$`）
 
 `receive$` は `TextDecoder` 経由で UTF-8 デコード済みのチャンクをそのまま emit します。`scan` と組み合わせて改行でフレーム化します。
 
@@ -29,7 +31,9 @@ const lines$ = session.receive$.pipe(
 lines$.subscribe((lines) => lines.forEach((line) => console.log('行:', line)));
 ```
 
-## 接続中フラグ（`connected$` 相当）
+組み込みシェルによっては行末が `\r\n` です。`'\n'` の代わりに `/\r?\n/` で分割する、または分割前にチャンクを正規化する方法があります。
+
+## 接続中フラグ（`state$` からの `connected$` 相当）
 
 `SerialSession` に `connected$` プロパティはありません。ボタンの有効／無効などに使う真偽値が欲しい場合は `state$` から派生します。
 
@@ -40,6 +44,20 @@ const connected$ = session.state$.pipe(map((s) => s === 'connected'));
 ```
 
 接続中以外の段階（`connecting` など）も扱う UI では、真偽値ではなく下記の [state$ 駆動の UI](#state-駆動の-ui) のように `state$` 全体を使う方が分かりやすいです。
+
+## 1 行送信（`sendLine` / `sendLine$` 相当）
+
+対話シェルでは CRLF 終端の 1 行を期待することが多いです。ライブラリに API を増やさず、`send$` の薄いラッパーにします。
+
+```typescript
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+sendLine('ls -al').subscribe({
+  error: (error) => console.error('送信失敗:', error),
+});
+```
+
+相手が LF のみを期待する UART プロトコルなら `\n` に置き換えます。いずれも文字列は同様に UTF-8 エンコードされます。
 
 ## 順序保証のある送信
 
@@ -56,21 +74,80 @@ from(commands)
   });
 ```
 
-リクエスト／レスポンスのペアが欲しい場合は、`send$` と `receive$` の有限な読み取りを合成します。
+## readUntil パターン（`readUntil$` / プロンプト待ち）
+
+`receive$` は**チャンク**単位であり、メッセージ単位ではありません。**readUntil** はバッファに蓄積したテキストが述語（区切り・正規表現・プロンプト）を満たすまで待ちます。`receive$` はホットで過去チャンクを後から購読しただけでは再現されないため、相手がすぐ応答するなら **`send$` する前に `receive$` 側の待ち受けを開始**してください。
 
 ```typescript
-import { firstValueFrom, scan, filter, map, timeout } from 'rxjs';
+import { firstValueFrom, scan, filter, map, take, timeout } from 'rxjs';
 
+async function readUntil(
+  predicate: (buffer: string) => boolean,
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const match$ = session.receive$.pipe(
+    scan((buffer, chunk) => buffer + chunk, ''),
+    filter(predicate),
+    map((buffer) => buffer),
+    take(1),
+    timeout(timeoutMs),
+  );
+  return firstValueFrom(match$);
+}
+
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+// 例: ログインプロンプトを待ってから資格情報を送る（説明用）
+await readUntil((buf) => /login:\s*$/im.test(buf));
+await firstValueFrom(sendLine('pi'));
+await readUntil((buf) => /password:\s*$/im.test(buf));
+await firstValueFrom(sendLine('raspberry'));
+```
+
+**コマンド送信＋プロンプト待ち**も同じ蓄積パイプラインです。先に購読（`firstValueFrom` で Promise を取得）してから送ります。
+
+```typescript
 async function query(cmd: string, prompt = /device>\s$/): Promise<string> {
   const response$ = session.receive$.pipe(
     scan((buffer, chunk) => buffer + chunk, ''),
     filter((buffer) => prompt.test(buffer)),
     map((buffer) => buffer),
+    take(1),
     timeout(5000),
   );
+  const responsePromise = firstValueFrom(response$);
   await firstValueFrom(session.send$(cmd));
-  return firstValueFrom(response$);
+  return responsePromise;
 }
+```
+
+## waitForState
+
+`connect$` や `disconnect$` のあと、特定の `SerialSessionState`（例: `'connected'` や `'idle'`）が立つまで **await** したい場合があります。`state$` に `filter`・`take(1)`・必要なら `timeout` を載せます。
+
+```typescript
+import { filter, take, firstValueFrom, timeout } from 'rxjs';
+import type { SerialSessionState } from '@gurezo/web-serial-rxjs';
+
+async function waitForState(
+  target: SerialSessionState,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  await firstValueFrom(
+    session.state$.pipe(
+      filter((s) => s === target),
+      take(1),
+      timeout(timeoutMs),
+    ),
+  );
+}
+
+// 例: connect$ 成功後はすでに 'connected' だが、他の非同期処理との整合や
+// タイムアウトを明示したいときに使う
+await firstValueFrom(session.connect$());
+await waitForState('connected', { timeoutMs: 5000 });
 ```
 
 ## state$ 駆動の UI

--- a/docs/ADVANCED_USAGE.md
+++ b/docs/ADVANCED_USAGE.md
@@ -2,7 +2,9 @@
 
 The v2 `SerialSession` intentionally exposes a small surface. Most "advanced" workflows are expressed by composing plain RxJS operators over `receive$` and `send$`. If you are new to the API, read the [README](../README.md#serialsession-v2-at-a-glance) and [Quick Start](./QUICK_START.md) first; this page focuses on **recipes** (line framing, derived streams, and recovery) that the README defers on purpose.
 
-## Line Framing
+This page maps directly to [issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228): **`lines$`**, **`connected$`**, **`sendLine`**, **`readUntil`**, and **`waitForState`** are all patterns you build on top of the existing API—no extra library exports. For a real-world serial-console style app, see [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) (Web Serial over USB OTG); the same recipes apply when you reimplement its read/write loop with `SerialSession`.
+
+## Line Framing (`lines$` from `receive$`)
 
 `receive$` emits UTF-8 decoded chunks as they arrive from the underlying `TextDecoder`. Combine it with `scan` to frame by newline:
 
@@ -29,7 +31,9 @@ const lines$ = session.receive$.pipe(
 lines$.subscribe((lines) => lines.forEach((line) => console.log('line:', line)));
 ```
 
-## Connected boolean (UI)
+Many embedded shells use `\r\n` line endings. You can split on `/\r?\n/` instead of `'\n'`, or normalize chunks before splitting.
+
+## Connected boolean (UI) (`connected$` from `state$`)
 
 There is no `connected$` on `SerialSession`. For a simple "is the port open?" flag for buttons or templates, derive from `state$`:
 
@@ -40,6 +44,20 @@ const connected$ = session.state$.pipe(map((s) => s === 'connected'));
 ```
 
 Prefer driving full UI from `state$` when you need spinners and multiple phases (see [State-driven UI](#state-driven-ui) below).
+
+## Send line (`sendLine` / `sendLine$` pattern)
+
+Interactive shells often expect a full line terminated by CRLF. Wrap `send$` in a small helper instead of adding API to the library:
+
+```typescript
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+sendLine('ls -al').subscribe({
+  error: (error) => console.error('send failed:', error),
+});
+```
+
+Use `\n` only when the remote explicitly expects LF-only (some UART protocols). The session encodes strings as UTF-8 the same way in both cases.
 
 ## Ordered Writes
 
@@ -56,21 +74,80 @@ from(commands)
   });
 ```
 
-If you need one-shot request / response pairs, compose `send$` with a bounded read of `receive$`:
+## readUntil pattern (`readUntil$` / prompt-style reads)
+
+`receive$` delivers **chunks**, not logical messages. A **read-until** pattern accumulates text until a predicate (delimiter, regex, prompt) matches. Because `receive$` is hot and does not replay past chunks to late subscribers, **start waiting on `receive$` before you `send$`** if the device may respond immediately.
 
 ```typescript
-import { firstValueFrom, scan, filter, map, timeout } from 'rxjs';
+import { firstValueFrom, scan, filter, map, take, timeout } from 'rxjs';
 
+async function readUntil(
+  predicate: (buffer: string) => boolean,
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const match$ = session.receive$.pipe(
+    scan((buffer, chunk) => buffer + chunk, ''),
+    filter(predicate),
+    map((buffer) => buffer),
+    take(1),
+    timeout(timeoutMs),
+  );
+  return firstValueFrom(match$);
+}
+
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+// Example: wait for a login prompt, then send credentials (illustrative only)
+await readUntil((buf) => /login:\s*$/im.test(buf));
+await firstValueFrom(sendLine('pi'));
+await readUntil((buf) => /password:\s*$/im.test(buf));
+await firstValueFrom(sendLine('raspberry'));
+```
+
+One-shot **command + prompt** pairs use the same accumulation pipeline; subscribe first, then send:
+
+```typescript
 async function query(cmd: string, prompt = /device>\s$/): Promise<string> {
   const response$ = session.receive$.pipe(
     scan((buffer, chunk) => buffer + chunk, ''),
     filter((buffer) => prompt.test(buffer)),
     map((buffer) => buffer),
+    take(1),
     timeout(5000),
   );
+  const responsePromise = firstValueFrom(response$);
   await firstValueFrom(session.send$(cmd));
-  return firstValueFrom(response$);
+  return responsePromise;
 }
+```
+
+## waitForState
+
+Sometimes you need to **await** a specific `SerialSessionState` (for example `'connected'` after UI-driven `connect$`, or `'idle'` after `disconnect$`) instead of wiring everything through `subscribe`. Use `state$` with `filter`, `take(1)`, and an optional timeout:
+
+```typescript
+import { filter, take, firstValueFrom, timeout } from 'rxjs';
+import type { SerialSessionState } from '@gurezo/web-serial-rxjs';
+
+async function waitForState(
+  target: SerialSessionState,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  await firstValueFrom(
+    session.state$.pipe(
+      filter((s) => s === target),
+      take(1),
+      timeout(timeoutMs),
+    ),
+  );
+}
+
+// Example: after connect$ completes, you are already 'connected'; this is for
+// coordination with other async code or stricter timeout handling.
+await firstValueFrom(session.connect$());
+await waitForState('connected', { timeoutMs: 5000 });
 ```
 
 ## State-Driven UI

--- a/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md
+++ b/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md
@@ -2,7 +2,9 @@
 
 v2 の `SerialSession` は意図的に小さな公開面に絞られています。応用パターンの大半は、`receive$` と `send$` の上に普通の RxJS オペレータを組み合わせることで表現できます。API の全体像は先に[README](../../../README.ja.md#serialsessionv2の全体像)と[クイックスタート](./QUICK_START.ja.md)を読み、本ページは README で省いた**行フレーミング・派生ストリーム・リカバリ**のレシピに絞ります。
 
-## 行単位のフレーミング
+本ページは [Issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228) で列挙したパターンに対応します。**`lines$`・`connected$`・`sendLine`・`readUntil`・`waitForState`** はいずれも既存 API の組み合わせであり、ライブラリに追加の export はありません。USB OTG シリアルコンソールの実例として [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) があります。同アプリの読み書きループを `SerialSession` で書き直すときも、ここでのレシピがそのまま使えます。
+
+## 行単位のフレーミング（`receive$` からの `lines$`）
 
 `receive$` は `TextDecoder` 経由で UTF-8 デコード済みのチャンクをそのまま emit します。`scan` と組み合わせて改行でフレーム化します。
 
@@ -29,7 +31,9 @@ const lines$ = session.receive$.pipe(
 lines$.subscribe((lines) => lines.forEach((line) => console.log('行:', line)));
 ```
 
-## 接続中フラグ（`connected$` 相当）
+組み込みシェルによっては行末が `\r\n` です。`'\n'` の代わりに `/\r?\n/` で分割する、または分割前にチャンクを正規化する方法があります。
+
+## 接続中フラグ（`state$` からの `connected$` 相当）
 
 `SerialSession` に `connected$` プロパティはありません。ボタンの有効／無効などに使う真偽値が欲しい場合は `state$` から派生します。
 
@@ -40,6 +44,20 @@ const connected$ = session.state$.pipe(map((s) => s === 'connected'));
 ```
 
 接続中以外の段階（`connecting` など）も扱う UI では、真偽値ではなく下記の [state$ 駆動の UI](#state-駆動の-ui) のように `state$` 全体を使う方が分かりやすいです。
+
+## 1 行送信（`sendLine` / `sendLine$` 相当）
+
+対話シェルでは CRLF 終端の 1 行を期待することが多いです。ライブラリに API を増やさず、`send$` の薄いラッパーにします。
+
+```typescript
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+sendLine('ls -al').subscribe({
+  error: (error) => console.error('送信失敗:', error),
+});
+```
+
+相手が LF のみを期待する UART プロトコルなら `\n` に置き換えます。いずれも文字列は同様に UTF-8 エンコードされます。
 
 ## 順序保証のある送信
 
@@ -56,21 +74,80 @@ from(commands)
   });
 ```
 
-リクエスト／レスポンスのペアが欲しい場合は、`send$` と `receive$` の有限な読み取りを合成します。
+## readUntil パターン（`readUntil$` / プロンプト待ち）
+
+`receive$` は**チャンク**単位であり、メッセージ単位ではありません。**readUntil** はバッファに蓄積したテキストが述語（区切り・正規表現・プロンプト）を満たすまで待ちます。`receive$` はホットで過去チャンクを後から購読しただけでは再現されないため、相手がすぐ応答するなら **`send$` する前に `receive$` 側の待ち受けを開始**してください。
 
 ```typescript
-import { firstValueFrom, scan, filter, map, timeout } from 'rxjs';
+import { firstValueFrom, scan, filter, map, take, timeout } from 'rxjs';
 
+async function readUntil(
+  predicate: (buffer: string) => boolean,
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const match$ = session.receive$.pipe(
+    scan((buffer, chunk) => buffer + chunk, ''),
+    filter(predicate),
+    map((buffer) => buffer),
+    take(1),
+    timeout(timeoutMs),
+  );
+  return firstValueFrom(match$);
+}
+
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+// 例: ログインプロンプトを待ってから資格情報を送る（説明用）
+await readUntil((buf) => /login:\s*$/im.test(buf));
+await firstValueFrom(sendLine('pi'));
+await readUntil((buf) => /password:\s*$/im.test(buf));
+await firstValueFrom(sendLine('raspberry'));
+```
+
+**コマンド送信＋プロンプト待ち**も同じ蓄積パイプラインです。先に購読（`firstValueFrom` で Promise を取得）してから送ります。
+
+```typescript
 async function query(cmd: string, prompt = /device>\s$/): Promise<string> {
   const response$ = session.receive$.pipe(
     scan((buffer, chunk) => buffer + chunk, ''),
     filter((buffer) => prompt.test(buffer)),
     map((buffer) => buffer),
+    take(1),
     timeout(5000),
   );
+  const responsePromise = firstValueFrom(response$);
   await firstValueFrom(session.send$(cmd));
-  return firstValueFrom(response$);
+  return responsePromise;
 }
+```
+
+## waitForState
+
+`connect$` や `disconnect$` のあと、特定の `SerialSessionState`（例: `'connected'` や `'idle'`）が立つまで **await** したい場合があります。`state$` に `filter`・`take(1)`・必要なら `timeout` を載せます。
+
+```typescript
+import { filter, take, firstValueFrom, timeout } from 'rxjs';
+import type { SerialSessionState } from '@gurezo/web-serial-rxjs';
+
+async function waitForState(
+  target: SerialSessionState,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  await firstValueFrom(
+    session.state$.pipe(
+      filter((s) => s === target),
+      take(1),
+      timeout(timeoutMs),
+    ),
+  );
+}
+
+// 例: connect$ 成功後はすでに 'connected' だが、他の非同期処理との整合や
+// タイムアウトを明示したいときに使う
+await firstValueFrom(session.connect$());
+await waitForState('connected', { timeoutMs: 5000 });
 ```
 
 ## state$ 駆動の UI

--- a/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md
+++ b/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md
@@ -2,7 +2,9 @@
 
 The v2 `SerialSession` intentionally exposes a small surface. Most "advanced" workflows are expressed by composing plain RxJS operators over `receive$` and `send$`. If you are new to the API, read the [README](../../../README.md#serialsession-v2-at-a-glance) and [Quick Start](./QUICK_START.md) first; this page focuses on **recipes** (line framing, derived streams, and recovery) that the README defers on purpose.
 
-## Line Framing
+This page maps directly to [issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228): **`lines$`**, **`connected$`**, **`sendLine`**, **`readUntil`**, and **`waitForState`** are all patterns you build on top of the existing API—no extra library exports. For a real-world serial-console style app, see [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) (Web Serial over USB OTG); the same recipes apply when you reimplement its read/write loop with `SerialSession`.
+
+## Line Framing (`lines$` from `receive$`)
 
 `receive$` emits UTF-8 decoded chunks as they arrive from the underlying `TextDecoder`. Combine it with `scan` to frame by newline:
 
@@ -29,7 +31,9 @@ const lines$ = session.receive$.pipe(
 lines$.subscribe((lines) => lines.forEach((line) => console.log('line:', line)));
 ```
 
-## Connected boolean (UI)
+Many embedded shells use `\r\n` line endings. You can split on `/\r?\n/` instead of `'\n'`, or normalize chunks before splitting.
+
+## Connected boolean (UI) (`connected$` from `state$`)
 
 There is no `connected$` on `SerialSession`. For a simple "is the port open?" flag for buttons or templates, derive from `state$`:
 
@@ -40,6 +44,20 @@ const connected$ = session.state$.pipe(map((s) => s === 'connected'));
 ```
 
 Prefer driving full UI from `state$` when you need spinners and multiple phases (see [State-driven UI](#state-driven-ui) below).
+
+## Send line (`sendLine` / `sendLine$` pattern)
+
+Interactive shells often expect a full line terminated by CRLF. Wrap `send$` in a small helper instead of adding API to the library:
+
+```typescript
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+sendLine('ls -al').subscribe({
+  error: (error) => console.error('send failed:', error),
+});
+```
+
+Use `\n` only when the remote explicitly expects LF-only (some UART protocols). The session encodes strings as UTF-8 the same way in both cases.
 
 ## Ordered Writes
 
@@ -56,21 +74,80 @@ from(commands)
   });
 ```
 
-If you need one-shot request / response pairs, compose `send$` with a bounded read of `receive$`:
+## readUntil pattern (`readUntil$` / prompt-style reads)
+
+`receive$` delivers **chunks**, not logical messages. A **read-until** pattern accumulates text until a predicate (delimiter, regex, prompt) matches. Because `receive$` is hot and does not replay past chunks to late subscribers, **start waiting on `receive$` before you `send$`** if the device may respond immediately.
 
 ```typescript
-import { firstValueFrom, scan, filter, map, timeout } from 'rxjs';
+import { firstValueFrom, scan, filter, map, take, timeout } from 'rxjs';
 
+async function readUntil(
+  predicate: (buffer: string) => boolean,
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const match$ = session.receive$.pipe(
+    scan((buffer, chunk) => buffer + chunk, ''),
+    filter(predicate),
+    map((buffer) => buffer),
+    take(1),
+    timeout(timeoutMs),
+  );
+  return firstValueFrom(match$);
+}
+
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+// Example: wait for a login prompt, then send credentials (illustrative only)
+await readUntil((buf) => /login:\s*$/im.test(buf));
+await firstValueFrom(sendLine('pi'));
+await readUntil((buf) => /password:\s*$/im.test(buf));
+await firstValueFrom(sendLine('raspberry'));
+```
+
+One-shot **command + prompt** pairs use the same accumulation pipeline; subscribe first, then send:
+
+```typescript
 async function query(cmd: string, prompt = /device>\s$/): Promise<string> {
   const response$ = session.receive$.pipe(
     scan((buffer, chunk) => buffer + chunk, ''),
     filter((buffer) => prompt.test(buffer)),
     map((buffer) => buffer),
+    take(1),
     timeout(5000),
   );
+  const responsePromise = firstValueFrom(response$);
   await firstValueFrom(session.send$(cmd));
-  return firstValueFrom(response$);
+  return responsePromise;
 }
+```
+
+## waitForState
+
+Sometimes you need to **await** a specific `SerialSessionState` (for example `'connected'` after UI-driven `connect$`, or `'idle'` after `disconnect$`) instead of wiring everything through `subscribe`. Use `state$` with `filter`, `take(1)`, and an optional timeout:
+
+```typescript
+import { filter, take, firstValueFrom, timeout } from 'rxjs';
+import type { SerialSessionState } from '@gurezo/web-serial-rxjs';
+
+async function waitForState(
+  target: SerialSessionState,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  await firstValueFrom(
+    session.state$.pipe(
+      filter((s) => s === target),
+      take(1),
+      timeout(timeoutMs),
+    ),
+  );
+}
+
+// Example: after connect$ completes, you are already 'connected'; this is for
+// coordination with other async code or stricter timeout handling.
+await firstValueFrom(session.connect$());
+await waitForState('connected', { timeoutMs: 5000 });
 ```
 
 ## State-Driven UI


### PR DESCRIPTION
## Summary

SerialSession v2 の既存 API のみで、Issue #228 で列挙された `lines$`・`connected$`・`sendLine`・`readUntil`・`waitForState` を ADVANCED_USAGE（英日）に明示化した。CHIRIMEN PiZeroWebSerialConsole のようなシリアルコンソール用途の再現に必要な注意（ホットな `receive$`、送信前の購読開始、CRLF 行）を追記した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Closes #228
- Refs #225

## What changed?

- 冒頭に Issue #228 / PiZeroWebSerialConsole への導線を追加
- 行フレーミング見出しを `lines$` 相当と明示し、`\r\n` 向けの注記を追加
- `connected$` 相当の見出しを補強
- `sendLine`（CRLF 終端の薄いラッパー）セクションを追加
- `readUntil` パターン、`query` の購読順修正（`take(1)` を含む）
- `waitForState`（`state$` + `filter` + `take(1)` + `timeout`）を追加
- `packages/web-serial-rxjs/docs/` とルート `docs/` の ADVANCED_USAGE を同期

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `packages/web-serial-rxjs/docs/ADVANCED_USAGE.md` と `.ja.md`、および `docs/ADVANCED_USAGE*.md` のリンク（README・QUICK_START への相対パス）が意図どおりか確認する
2. コードブロックを任意のサンドボックスにコピーし、型・import が妥当か目視する
3. （任意）Chromium で Web Serial を使うアプリにレシピを組み込み、プロンプト待ちが欠落しないか確認する

## Environment (if relevant)

- Browser: （ドキュメントのみ変更）
- OS: 
- web-serial-rxjs version (for verification):
- RxJS version:

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)