### PR TITLE
docs: SerialSession v2 ドキュメント整理と examples の行区切り受信に統一 (#225 #229)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -135,6 +135,8 @@ session.send$('hello\r\n').subscribe();
 - **[Vanilla TypeScript](apps/example-vanilla-ts/)** - RxJS を使用した TypeScript の例
 - **[Vue](apps/example-vue/)** - Composition API を使用した Vue 3 の例
 
+各サンプルは **connect・受信（`receive$` から派生した行区切り）・send・disconnect** の最小動作確認用です。行フレーミングや応用パターンの詳細は [高度な使用方法](docs/ADVANCED_USAGE.ja.md) に集約しています。
+
 各例には、セットアップと使用方法の説明を含む README が含まれています。
 
 ## プロジェクトアイコンについて

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Examples are available for the following environments:
 - **[Vanilla TypeScript](apps/example-vanilla-ts/)** - TypeScript example with RxJS
 - **[Vue](apps/example-vue/)** - Vue 3 example using Composition API
 
+Each sample is a **minimal smoke test** for **connect**, **receive** (newline-delimited lines derived from `receive$`), **send**, and **disconnect**. Deeper patterns live in [Advanced Usage](docs/ADVANCED_USAGE.md).
+
 Each example includes a README with setup and usage instructions.
 
 ## Project Icon

--- a/apps/example-angular/README.md
+++ b/apps/example-angular/README.md
@@ -4,6 +4,8 @@ This is an Angular example application demonstrating how to use the `@gurezo/web
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../README.md#serialsession-v2-at-a-glance).
 
+**Scope**: Minimal smoke test—connect, line-delimited receive (`lines$` derived from `receive$`), send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+
 ## Features
 
 - Browser support detection
@@ -77,7 +79,7 @@ This example uses Angular Services and RxJS observables to handle serial port co
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array` through the service's `sendAsync` method.
 
-5. **Data Receiving**: Data received from the serial port is decoded as UTF-8 and displayed in real-time in the textarea. The received data is managed as an Observable in the service.
+5. **Data Receiving**: UTF-8 chunks are framed into newline-delimited lines (`lines$` in the service) and shown in the textarea.
 
 ## Code Structure
 

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -36,10 +36,11 @@ export class App {
         }
       });
 
-    this.serialService.receive$
+    this.serialService.lines$
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((chunk) => {
-        this.receivedData.update((prev) => prev + chunk);
+      .subscribe((lines) => {
+        const block = lines.map((l) => `${l}\n`).join('');
+        this.receivedData.update((prev) => prev + block);
       });
 
     this.serialService.errors$
@@ -91,6 +92,7 @@ export class App {
   }
 
   handleConnect(): void {
+    this.receivedData.set('');
     this.errorMessage.set(null);
     this.serialService.connect$(this.baudRate).subscribe({
       error: (error: unknown) => {

--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -152,11 +152,11 @@ describe('SerialClientService', () => {
     await expect(firstValueFrom(service.connect$())).rejects.toBe(boom);
   });
 
-  it('should forward incoming receive$ chunks', async () => {
+  it('should emit newline-delimited lines on lines$', async () => {
     const mock = latestMock();
-    const pending = firstValueFrom(service.receive$);
-    mock.receiveSubject.next('chunk-1');
-    await expect(pending).resolves.toBe('chunk-1');
+    const pending = firstValueFrom(service.lines$);
+    mock.receiveSubject.next('chunk-1\n');
+    await expect(pending).resolves.toEqual(['chunk-1']);
   });
 
   it('should forward errors$ emissions', async () => {

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -5,18 +5,9 @@ import {
   SerialSession,
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import { Observable, ReplaySubject, switchMap } from 'rxjs';
+import { Observable, ReplaySubject, switchMap, filter, map, scan } from 'rxjs';
 
-/**
- * v2 SerialSession を薄くラップした Angular Service。
- *
- * 状態 (`state$`)・受信 (`receive$`)・エラー (`errors$`) はライブラリ側の
- * ストリームをそのまま公開する。旧実装にあった `BehaviorSubject` ベースの
- * 接続状態再合成・`text$` 手動購読・read loop 管理は一切持たない。
- *
- * @see https://github.com/gurezo/web-serial-rxjs/issues/199
- * @see https://github.com/gurezo/web-serial-rxjs/issues/205
- */
+/** v2 SerialSession を薄くラップ。受信は行単位の `lines$` に派生。 */
 @Injectable({ providedIn: 'root' })
 export class SerialClientService implements OnDestroy {
   private readonly sessions$ = new ReplaySubject<SerialSession>(1);
@@ -24,7 +15,8 @@ export class SerialClientService implements OnDestroy {
   private currentBaudRate: number;
 
   readonly state$: Observable<SerialSessionState>;
-  readonly receive$: Observable<string>;
+  /** `receive$` を `\n` で分割した行のバッチ（QUICK_START と同パターン）。 */
+  readonly lines$: Observable<string[]>;
   readonly errors$: Observable<SerialError>;
 
   constructor() {
@@ -35,8 +27,21 @@ export class SerialClientService implements OnDestroy {
     this.sessions$.next(this.currentSession);
 
     this.state$ = this.sessions$.pipe(switchMap((session) => session.state$));
-    this.receive$ = this.sessions$.pipe(
-      switchMap((session) => session.receive$),
+    this.lines$ = this.sessions$.pipe(
+      switchMap((session) =>
+        session.receive$.pipe(
+          scan(
+            (acc, chunk: string) => {
+              const combined = acc.buffer + chunk;
+              const parts = combined.split('\n');
+              return { buffer: parts.pop() ?? '', lines: parts };
+            },
+            { buffer: '', lines: [] as string[] },
+          ),
+          filter((x) => x.lines.length > 0),
+          map((x) => x.lines),
+        ),
+      ),
     );
     this.errors$ = this.sessions$.pipe(switchMap((session) => session.errors$));
   }

--- a/apps/example-react/README.md
+++ b/apps/example-react/README.md
@@ -1,8 +1,10 @@
 # React Example
 
-This is a React example application demonstrating how to use the `@gurezo/web-serial-rxjs` library with the v2 `SerialSession` API to interact with serial ports through the Web Serial API. The example exposes a thin custom hook (`useSerialSession`) that mirrors the Vue composable and the Angular service: it just reflects the library's `state$` / `receive$` / `errors$` streams into React state without reconstructing any connection state of its own.
+This is a minimal React example for the v2 `SerialSession` API (Web Serial). The `useSerialSession` hook maps `state$` / `errors$` into React state and derives **newline-delimited lines** from `receive$` (same pattern as [Quick Start](../../docs/QUICK_START.md)).
 
-**Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../README.md#serialsession-v2-at-a-glance) before reading this app.
+**Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../README.md#serialsession-v2-at-a-glance).
+
+**Scope**: Connect, line-delimited receive, send, and disconnect only. For richer recipes, see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -10,15 +12,9 @@ This is a React example application demonstrating how to use the `@gurezo/web-se
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
-- Receive decoded text from the read pump
+- Receive newline-delimited lines (derived from `receive$`)
 - Unified error channel via `errors$`
 - Full TypeScript type safety
-
-## Completion criteria (Issue #208)
-
-- `useSerialSession` hook is under 100 lines.
-- The hook is implemented with `useEffect` + `subscribe` only — no BehaviorSubject reassembly, no read-loop management, no state-kind mapping.
-- `App.tsx` drives its UI purely from the hook's returned React state (`state`, `receivedData`, `errorMessage`).
 
 ## Requirements
 

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -180,19 +180,19 @@ describe('App', () => {
     expect(latestMock().send$).toHaveBeenCalledWith('hello\n');
   });
 
-  it('receive$ の値が受信データ欄に蓄積される', async () => {
+  it('行区切り受信が受信データ欄に蓄積される', async () => {
     render(<App />);
 
     act(() => {
-      latestMock().receiveSubject.next('foo');
-      latestMock().receiveSubject.next('bar');
+      latestMock().receiveSubject.next('foo\n');
+      latestMock().receiveSubject.next('bar\n');
     });
 
     await waitFor(() => {
       const textarea = screen.getByLabelText(
         '受信データ',
       ) as HTMLTextAreaElement;
-      expect(textarea.value).toBe('foobar');
+      expect(textarea.value).toBe('foo\nbar\n');
     });
   });
 
@@ -211,12 +211,12 @@ describe('App', () => {
     const user = userEvent.setup();
     render(<App />);
 
-    act(() => latestMock().receiveSubject.next('data'));
+    act(() => latestMock().receiveSubject.next('data\n'));
     await waitFor(() => {
       const textarea = screen.getByLabelText(
         '受信データ',
       ) as HTMLTextAreaElement;
-      expect(textarea.value).toBe('data');
+      expect(textarea.value).toBe('data\n');
     });
 
     await user.click(screen.getByText('クリア'));

--- a/apps/example-react/src/App.tsx
+++ b/apps/example-react/src/App.tsx
@@ -31,10 +31,12 @@ export function App() {
           ? { type: 'success', message: 'シリアルポートに接続しました。' }
           : { type: 'info', message: 'シリアルポートに接続していません。' };
 
-  const handleConnect = () =>
+  const handleConnect = () => {
+    clearReceivedData();
     connect$(baudRate).subscribe({
       error: (e: unknown) => console.error('接続エラー:', e),
     });
+  };
   const handleDisconnect = () =>
     disconnect$().subscribe({
       error: (e: unknown) => console.error('切断エラー:', e),

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -108,13 +108,13 @@ describe('useSerialSession', () => {
     expect(result.current.state).toBe('connected');
   });
 
-  it('receive$ の emission が receivedData に累積する', () => {
+  it('receive$ から派生した行が receivedData に累積する', () => {
     const { result } = renderHook(() => useSerialSession());
     act(() => {
-      latestMock().receiveSubject.next('foo');
-      latestMock().receiveSubject.next('bar');
+      latestMock().receiveSubject.next('foo\n');
+      latestMock().receiveSubject.next('bar\n');
     });
-    expect(result.current.receivedData).toBe('foobar');
+    expect(result.current.receivedData).toBe('foo\nbar\n');
   });
 
   it('errors$ の値が errorMessage に反映される', () => {
@@ -137,8 +137,8 @@ describe('useSerialSession', () => {
 
   it('clearReceivedData で receivedData が空になる', () => {
     const { result } = renderHook(() => useSerialSession());
-    act(() => latestMock().receiveSubject.next('data'));
-    expect(result.current.receivedData).toBe('data');
+    act(() => latestMock().receiveSubject.next('data\n'));
+    expect(result.current.receivedData).toBe('data\n');
     act(() => result.current.clearReceivedData());
     expect(result.current.receivedData).toBe('');
   });

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -5,14 +5,17 @@ import {
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
 import { useEffect, useRef, useState } from 'react';
-import { Observable, ReplaySubject, Subscription, switchMap } from 'rxjs';
+import {
+  Observable,
+  ReplaySubject,
+  Subscription,
+  switchMap,
+  filter,
+  map,
+  scan,
+} from 'rxjs';
 
-/**
- * v2 `SerialSession` を薄くラップした React カスタムフック。
- * state / receive / errors をそのまま React state に反映するだけで、
- * BehaviorSubject 的な接続状態再合成や read loop 管理は持たない。
- * @see https://github.com/gurezo/web-serial-rxjs/issues/199 | #208
- */
+/** v2 `SerialSession` を薄くラップ。受信は `receive$` から行単位に派生（QUICK_START と同パターン）。 */
 export interface UseSerialSessionReturn {
   browserSupported: boolean;
   state: SerialSessionState;
@@ -54,8 +57,25 @@ export function useSerialSession(
     );
     sub.add(
       sessions$
-        .pipe(switchMap((s) => s.receive$))
-        .subscribe((c) => setReceivedData((prev) => prev + c)),
+        .pipe(
+          switchMap((s) =>
+            s.receive$.pipe(
+              scan(
+                (acc, chunk: string) => {
+                  const combined = acc.buffer + chunk;
+                  const parts = combined.split('\n');
+                  return { buffer: parts.pop() ?? '', lines: parts };
+                },
+                { buffer: '', lines: [] as string[] },
+              ),
+              filter((x) => x.lines.length > 0),
+              map((x) => x.lines),
+            ),
+          ),
+        )
+        .subscribe((lines) =>
+          setReceivedData((prev) => prev + lines.map((l) => `${l}\n`).join('')),
+        ),
     );
     sub.add(
       sessions$
@@ -77,6 +97,7 @@ export function useSerialSession(
       const next = createSerialSession({ baudRate });
       sessionRef.current = next;
       sessionsRef.current?.next(next);
+      setReceivedData('');
     }
     return (sessionRef.current as SerialSession).connect$();
   };

--- a/apps/example-svelte/README.md
+++ b/apps/example-svelte/README.md
@@ -1,8 +1,10 @@
 # Svelte Example
 
-This is a Svelte example application demonstrating how to use the `@gurezo/web-serial-rxjs` library with the v2 `SerialSession` API to interact with serial ports through the Web Serial API. The example exposes a thin Svelte helper (`useSerialSession`) that mirrors the React hook, the Vue composable, and the Angular service: it just wraps the library's `state$` / `receive$` / `errors$` streams into Svelte `readable` stores without reconstructing any connection state of its own.
+This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSession` wraps `state$` / `errors$` into `readable` stores and derives **newline-delimited lines** from `receive$` (same pattern as [Quick Start](../../docs/QUICK_START.md)).
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../README.md#serialsession-v2-at-a-glance).
+
+**Scope**: Connect, line-delimited receive, send, disconnect only. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -10,15 +12,9 @@ This is a Svelte example application demonstrating how to use the `@gurezo/web-s
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
-- Receive decoded text from the read pump
+- Receive newline-delimited lines (derived from `receive$`)
 - Unified error channel via `errors$`
 - Full TypeScript type safety
-
-## Completion criteria (Issue #209)
-
-- The Svelte example is composed of `readable` stores only — no `writable` BehaviorSubject reassembly, no read-loop management, no `state.kind` remapping.
-- `App.svelte` drives its UI purely from the store subscriptions returned by `useSerialSession` via `$store` syntax.
-- No imperative Web Serial plumbing (open / read / write / close) lives in the app.
 
 ## Requirements
 

--- a/apps/example-svelte/src/App.svelte
+++ b/apps/example-svelte/src/App.svelte
@@ -51,6 +51,7 @@
   $: disconnecting = $state === 'disconnecting';
 
   const handleConnect = () => {
+    clearReceivedData();
     connect$(baudRate).subscribe({
       error: (error: unknown) => console.error('接続エラー:', error),
     });

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -127,12 +127,12 @@ describe('useSerialSession', () => {
     unsub();
   });
 
-  it('receive$ の emission が receivedData に累積する', () => {
+  it('receive$ から派生した行が receivedData に累積する', () => {
     const s = useSerialSession();
     const unsub = s.receivedData.subscribe(() => void 0);
-    latestMock().receiveSubject.next('foo');
-    latestMock().receiveSubject.next('bar');
-    expect(get(s.receivedData)).toBe('foobar');
+    latestMock().receiveSubject.next('foo\n');
+    latestMock().receiveSubject.next('bar\n');
+    expect(get(s.receivedData)).toBe('foo\nbar\n');
     unsub();
   });
 
@@ -157,8 +157,8 @@ describe('useSerialSession', () => {
   it('clearReceivedData で receivedData が空になる', () => {
     const s = useSerialSession();
     const unsub = s.receivedData.subscribe(() => void 0);
-    latestMock().receiveSubject.next('data');
-    expect(get(s.receivedData)).toBe('data');
+    latestMock().receiveSubject.next('data\n');
+    expect(get(s.receivedData)).toBe('data\n');
     s.clearReceivedData();
     expect(get(s.receivedData)).toBe('');
     unsub();

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -4,18 +4,19 @@ import {
   type SerialSession,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import { type Observable, ReplaySubject, Subscription, switchMap } from 'rxjs';
+import {
+  type Observable,
+  ReplaySubject,
+  Subscription,
+  switchMap,
+  filter,
+  map,
+  scan,
+} from 'rxjs';
 import { onDestroy } from 'svelte';
 import { readable, type Readable } from 'svelte/store';
 
-/**
- * v2 `SerialSession` を Svelte store に薄く写すだけのヘルパー。
- * `state$` / `receive$` / `errors$` をそのまま `readable` にラップし、
- * BehaviorSubject 的な接続状態再合成や read loop 管理は持たない。
- *
- * @see https://github.com/gurezo/web-serial-rxjs/issues/199
- * @see https://github.com/gurezo/web-serial-rxjs/issues/209
- */
+/** v2 `SerialSession` を Svelte store に薄く写す。受信は行単位に派生。 */
 export interface UseSerialSessionReturn {
   browserSupported: Readable<boolean>;
   state: Readable<SerialSessionState>;
@@ -51,9 +52,24 @@ export function useSerialSession(
   const receivedData = readable<string>('', (set) => {
     setReceived = set;
     const sub = sessions$
-      .pipe(switchMap((s) => s.receive$))
-      .subscribe((chunk) => {
-        receivedAcc += chunk;
+      .pipe(
+        switchMap((s) =>
+          s.receive$.pipe(
+            scan(
+              (acc, chunk: string) => {
+                const combined = acc.buffer + chunk;
+                const parts = combined.split('\n');
+                return { buffer: parts.pop() ?? '', lines: parts };
+              },
+              { buffer: '', lines: [] as string[] },
+            ),
+            filter((x) => x.lines.length > 0),
+            map((x) => x.lines),
+          ),
+        ),
+      )
+      .subscribe((lines) => {
+        receivedAcc += lines.map((l) => `${l}\n`).join('');
         set(receivedAcc);
       });
     return () => {

--- a/apps/example-vanilla-js/README.md
+++ b/apps/example-vanilla-js/README.md
@@ -4,6 +4,8 @@ This is a vanilla JavaScript example application demonstrating how to use the `@
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../README.md#serialsession-v2-at-a-glance).
 
+**Scope**: Minimal smoke test—connect, line-delimited receive (from `receive$`), send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+
 ## Features
 
 - Browser support detection

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
 import { fromEvent } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, map, scan } from 'rxjs/operators';
 
 const UNSUPPORTED_MSG =
   'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。';
@@ -50,10 +50,23 @@ export class App {
       baudRateSelect.disabled = connected || busy;
       setStatus(status, ...STATUS[state]);
     });
-    this.session.receive$.subscribe((text) => {
-      receiveOutput.value += text;
-      receiveOutput.scrollTop = receiveOutput.scrollHeight;
-    });
+    this.session.receive$
+      .pipe(
+        scan(
+          (acc, chunk) => {
+            const combined = acc.buffer + chunk;
+            const parts = combined.split('\n');
+            return { buffer: parts.pop() ?? '', lines: parts };
+          },
+          { buffer: '', lines: [] },
+        ),
+        filter((x) => x.lines.length > 0),
+        map((x) => x.lines),
+      )
+      .subscribe((lines) => {
+        receiveOutput.value += lines.map((l) => `${l}\n`).join('');
+        receiveOutput.scrollTop = receiveOutput.scrollHeight;
+      });
     this.session.errors$.subscribe((error) => {
       setStatus(status, 'error', `エラー: ${error.message}`);
       console.error('Serial port error:', error);
@@ -64,6 +77,7 @@ export class App {
         this.baudRate = baudRate;
         this.session = createSerialSession({ baudRate });
       }
+      receiveOutput.value = '';
       this.session.connect$().subscribe({ error: () => void 0 });
     });
     fromEvent(disconnectBtn, 'click').subscribe(() =>

--- a/apps/example-vanilla-ts/README.md
+++ b/apps/example-vanilla-ts/README.md
@@ -4,6 +4,8 @@ This is a vanilla TypeScript example application demonstrating how to use the `@
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../README.md#serialsession-v2-at-a-glance).
 
+**Scope**: Minimal smoke test—connect, line-delimited receive (from `receive$`), send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+
 ## Features
 
 - Browser support detection

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -4,7 +4,7 @@ import {
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
 import { fromEvent } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, map, scan } from 'rxjs/operators';
 
 type StatusType = 'info' | 'success' | 'error';
 
@@ -58,10 +58,23 @@ export class App {
       baudRateSelect.disabled = connected || busy;
       setStatus(status, ...STATUS[state]);
     });
-    this.session.receive$.subscribe((text) => {
-      receiveOutput.value += text;
-      receiveOutput.scrollTop = receiveOutput.scrollHeight;
-    });
+    this.session.receive$
+      .pipe(
+        scan(
+          (acc, chunk: string) => {
+            const combined = acc.buffer + chunk;
+            const parts = combined.split('\n');
+            return { buffer: parts.pop() ?? '', lines: parts };
+          },
+          { buffer: '', lines: [] as string[] },
+        ),
+        filter((x) => x.lines.length > 0),
+        map((x) => x.lines),
+      )
+      .subscribe((lines) => {
+        receiveOutput.value += lines.map((l) => `${l}\n`).join('');
+        receiveOutput.scrollTop = receiveOutput.scrollHeight;
+      });
     this.session.errors$.subscribe((error) => {
       setStatus(status, 'error', `エラー: ${error.message}`);
       console.error('Serial port error:', error);
@@ -72,6 +85,7 @@ export class App {
         this.baudRate = baudRate;
         this.session = createSerialSession({ baudRate });
       }
+      receiveOutput.value = '';
       this.session.connect$().subscribe({ error: () => void 0 });
     });
     fromEvent(disconnectBtn, 'click').subscribe(() =>

--- a/apps/example-vue/README.md
+++ b/apps/example-vue/README.md
@@ -4,6 +4,8 @@ This is a Vue example application demonstrating how to use the `@gurezo/web-seri
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../README.md#serialsession-v2-at-a-glance).
 
+**Scope**: Minimal smoke test—connect, line-delimited receive (from `receive$`), send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+
 ## Features
 
 - Browser support detection

--- a/apps/example-vue/src/app/App.vue
+++ b/apps/example-vue/src/app/App.vue
@@ -47,6 +47,7 @@ const status = computed<{ type: StatusType; message: string }>(() => {
 });
 
 const handleConnect = () => {
+  clearReceivedData();
   connect$(baudRate.value).subscribe({
     error: (error: unknown) => {
       console.error('接続エラー:', error);

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -176,14 +176,14 @@ describe('useSerialClient', () => {
     expect(latestMock().send$).toHaveBeenCalledWith('hello');
   });
 
-  it('should append incoming receive$ chunks to receivedData', () => {
+  it('should append newline-delimited lines to receivedData', () => {
     const { api } = mountHarness();
     const mock = latestMock();
 
-    mock.receiveSubject.next('chunk-1');
-    mock.receiveSubject.next('chunk-2');
+    mock.receiveSubject.next('chunk-1\n');
+    mock.receiveSubject.next('chunk-2\n');
 
-    expect(api.receivedData.value).toBe('chunk-1chunk-2');
+    expect(api.receivedData.value).toBe('chunk-1\nchunk-2\n');
   });
 
   it('should set errorMessage from errors$ emissions', () => {
@@ -209,9 +209,9 @@ describe('useSerialClient', () => {
   it('should clear received data', () => {
     const { api } = mountHarness();
     const mock = latestMock();
-    mock.receiveSubject.next('chunk-1');
+    mock.receiveSubject.next('chunk-1\n');
 
-    expect(api.receivedData.value).toBe('chunk-1');
+    expect(api.receivedData.value).toBe('chunk-1\n');
     api.clearReceivedData();
     expect(api.receivedData.value).toBe('');
   });

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -4,19 +4,17 @@ import {
   type SerialSession,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import { Observable, ReplaySubject, switchMap } from 'rxjs';
+import {
+  Observable,
+  ReplaySubject,
+  switchMap,
+  filter,
+  map,
+  scan,
+} from 'rxjs';
 import { onUnmounted, ref, type Ref } from 'vue';
 
-/**
- * v2 `SerialSession` を薄くラップした Vue Composable。
- *
- * `state$` / `receive$` / `errors$` をそのままリアクティブな `Ref` に反映し、
- * BehaviorSubject 的な接続状態再合成、`text$` の手動購読、read loop 管理は
- * 一切持たない。
- *
- * @see https://github.com/gurezo/web-serial-rxjs/issues/199
- * @see https://github.com/gurezo/web-serial-rxjs/issues/206
- */
+/** v2 `SerialSession` を薄くラップ。受信は `receive$` から行単位に派生。 */
 export interface UseSerialClientReturn {
   browserSupported: Ref<boolean>;
   state: Ref<SerialSessionState>;
@@ -50,9 +48,25 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
       }
     });
   const receiveSub = sessions$
-    .pipe(switchMap((session) => session.receive$))
-    .subscribe((chunk) => {
-      receivedData.value = receivedData.value + chunk;
+    .pipe(
+      switchMap((session) =>
+        session.receive$.pipe(
+          scan(
+            (acc, chunk: string) => {
+              const combined = acc.buffer + chunk;
+              const parts = combined.split('\n');
+              return { buffer: parts.pop() ?? '', lines: parts };
+            },
+            { buffer: '', lines: [] as string[] },
+          ),
+          filter((x) => x.lines.length > 0),
+          map((x) => x.lines),
+        ),
+      ),
+    )
+    .subscribe((lines) => {
+      receivedData.value =
+        receivedData.value + lines.map((l) => `${l}\n`).join('');
     });
   const errorsSub = sessions$
     .pipe(switchMap((session) => session.errors$))
@@ -65,6 +79,7 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
       currentBaudRate = baudRate;
       currentSession = createSerialSession({ baudRate });
       sessions$.next(currentSession);
+      receivedData.value = '';
     }
     return currentSession.connect$();
   };

--- a/docs/media/ADVANCED_USAGE.md
+++ b/docs/media/ADVANCED_USAGE.md
@@ -1,8 +1,10 @@
 # Advanced Usage
 
-The v2 `SerialSession` intentionally exposes a small surface. Most "advanced" workflows are expressed by composing plain RxJS operators over `receive$` and `send$`.
+The v2 `SerialSession` intentionally exposes a small surface. Most "advanced" workflows are expressed by composing plain RxJS operators over `receive$` and `send$`. If you are new to the API, read the [README](../../README.md#serialsession-v2-at-a-glance) and [Quick Start](./QUICK_START.md) first; this page focuses on **recipes** (line framing, derived streams, and recovery) that the README defers on purpose.
 
-## Line Framing
+This page maps directly to [issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228): **`lines$`**, **`connected$`**, **`sendLine`**, **`readUntil`**, and **`waitForState`** are all patterns you build on top of the existing API—no extra library exports. For a real-world serial-console style app, see [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) (Web Serial over USB OTG); the same recipes apply when you reimplement its read/write loop with `SerialSession`.
+
+## Line Framing (`lines$` from `receive$`)
 
 `receive$` emits UTF-8 decoded chunks as they arrive from the underlying `TextDecoder`. Combine it with `scan` to frame by newline:
 
@@ -29,6 +31,34 @@ const lines$ = session.receive$.pipe(
 lines$.subscribe((lines) => lines.forEach((line) => console.log('line:', line)));
 ```
 
+Many embedded shells use `\r\n` line endings. You can split on `/\r?\n/` instead of `'\n'`, or normalize chunks before splitting.
+
+## Connected boolean (UI) (`connected$` from `state$`)
+
+There is no `connected$` on `SerialSession`. For a simple "is the port open?" flag for buttons or templates, derive from `state$`:
+
+```typescript
+import { map } from 'rxjs';
+
+const connected$ = session.state$.pipe(map((s) => s === 'connected'));
+```
+
+Prefer driving full UI from `state$` when you need spinners and multiple phases (see [State-driven UI](#state-driven-ui) below).
+
+## Send line (`sendLine` / `sendLine$` pattern)
+
+Interactive shells often expect a full line terminated by CRLF. Wrap `send$` in a small helper instead of adding API to the library:
+
+```typescript
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+sendLine('ls -al').subscribe({
+  error: (error) => console.error('send failed:', error),
+});
+```
+
+Use `\n` only when the remote explicitly expects LF-only (some UART protocols). The session encodes strings as UTF-8 the same way in both cases.
+
 ## Ordered Writes
 
 `send$` is already serialised by an internal FIFO queue, so concurrent subscribers are delivered in call order:
@@ -44,21 +74,80 @@ from(commands)
   });
 ```
 
-If you need one-shot request / response pairs, compose `send$` with a bounded read of `receive$`:
+## readUntil pattern (`readUntil$` / prompt-style reads)
+
+`receive$` delivers **chunks**, not logical messages. A **read-until** pattern accumulates text until a predicate (delimiter, regex, prompt) matches. Because `receive$` is hot and does not replay past chunks to late subscribers, **start waiting on `receive$` before you `send$`** if the device may respond immediately.
 
 ```typescript
-import { firstValueFrom, scan, filter, map, timeout } from 'rxjs';
+import { firstValueFrom, scan, filter, map, take, timeout } from 'rxjs';
 
+async function readUntil(
+  predicate: (buffer: string) => boolean,
+  options: { timeoutMs?: number } = {},
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? 5000;
+  const match$ = session.receive$.pipe(
+    scan((buffer, chunk) => buffer + chunk, ''),
+    filter(predicate),
+    map((buffer) => buffer),
+    take(1),
+    timeout(timeoutMs),
+  );
+  return firstValueFrom(match$);
+}
+
+const sendLine = (line: string) => session.send$(`${line}\r\n`);
+
+// Example: wait for a login prompt, then send credentials (illustrative only)
+await readUntil((buf) => /login:\s*$/im.test(buf));
+await firstValueFrom(sendLine('pi'));
+await readUntil((buf) => /password:\s*$/im.test(buf));
+await firstValueFrom(sendLine('raspberry'));
+```
+
+One-shot **command + prompt** pairs use the same accumulation pipeline; subscribe first, then send:
+
+```typescript
 async function query(cmd: string, prompt = /device>\s$/): Promise<string> {
   const response$ = session.receive$.pipe(
     scan((buffer, chunk) => buffer + chunk, ''),
     filter((buffer) => prompt.test(buffer)),
     map((buffer) => buffer),
+    take(1),
     timeout(5000),
   );
+  const responsePromise = firstValueFrom(response$);
   await firstValueFrom(session.send$(cmd));
-  return firstValueFrom(response$);
+  return responsePromise;
 }
+```
+
+## waitForState
+
+Sometimes you need to **await** a specific `SerialSessionState` (for example `'connected'` after UI-driven `connect$`, or `'idle'` after `disconnect$`) instead of wiring everything through `subscribe`. Use `state$` with `filter`, `take(1)`, and an optional timeout:
+
+```typescript
+import { filter, take, firstValueFrom, timeout } from 'rxjs';
+import type { SerialSessionState } from '@gurezo/web-serial-rxjs';
+
+async function waitForState(
+  target: SerialSessionState,
+  options: { timeoutMs?: number } = {},
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  await firstValueFrom(
+    session.state$.pipe(
+      filter((s) => s === target),
+      take(1),
+      timeout(timeoutMs),
+    ),
+  );
+}
+
+// Example: after connect$ completes, you are already 'connected'; this is for
+// coordination with other async code or stricter timeout handling.
+await firstValueFrom(session.connect$());
+await waitForState('connected', { timeoutMs: 5000 });
 ```
 
 ## State-Driven UI

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -135,6 +135,8 @@ session.send$('hello\r\n').subscribe();
 - **[Vanilla TypeScript](https://github.com/gurezo/web-serial-rxjs/tree/main/apps/example-vanilla-ts)** - RxJS を使用した TypeScript の例
 - **[Vue](https://github.com/gurezo/web-serial-rxjs/tree/main/apps/example-vue)** - Composition API を使用した Vue 3 の例
 
+各サンプルは **connect・受信（`receive$` から派生した行区切り）・send・disconnect** の最小動作確認用です。応用は [高度な使用方法](docs/ADVANCED_USAGE.ja.md) を参照してください。
+
 各例には、セットアップと使用方法の説明を含む README が含まれています。
 
 ## プロジェクトアイコンについて

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -136,6 +136,8 @@ Examples are available for the following environments:
 - **[Vanilla TypeScript](https://github.com/gurezo/web-serial-rxjs/tree/main/apps/example-vanilla-ts)** - TypeScript example with RxJS
 - **[Vue](https://github.com/gurezo/web-serial-rxjs/tree/main/apps/example-vue)** - Vue 3 example using Composition API
 
+Each sample is a **minimal smoke test** for **connect**, **receive** (newline-delimited lines derived from `receive$`), **send**, and **disconnect**. See [Advanced Usage](docs/ADVANCED_USAGE.md) for richer patterns.
+
 Each example includes a README with setup and usage instructions.
 
 ## Project Icon


### PR DESCRIPTION
## Summary

Issue #225 に沿って Typedoc 用 `docs/media/ADVANCED_USAGE.md` をパッケージ版と揃え、モノレポ／パッケージ README に「サンプルは最小動作確認」と応用は Advanced へ集約する旨を追記しました。Issue #229 に沿って各 example を `receive$` からの行区切り（QUICK_START と同パターン）に統一し、接続時の受信クリアや README のスコープ説明を整理しました。

## Type of change

- [x] Documentation
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #225
- Fixes #229

## What changed?

- `docs/media/ADVANCED_USAGE.md` をパッケージの Advanced ドキュメントと同期
- ルート／`packages/web-serial-rxjs` の README（日英）にサンプル役割の一文を追加
- 全 example: 行区切り受信、`lines$`（Angular）、テスト・各 README の更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test

1. `nx run-many -t test --projects=example-react,example-vue,example-svelte,example-angular,example-vanilla-ts,example-vanilla-js`
2. 任意の example を Chromium で起動し、接続・送信・受信（改行区切り）・切断を確認

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed