### PR TITLE
chore(web-serial-rxjs): @gurezo/web-serial-rxjs を v2.0.0 に更新

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.ja.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.ja.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs バージョン
-      description: "例: @gurezo/web-serial-rxjs@0.1.0"
+      description: "例: @gurezo/web-serial-rxjs@2.0.0"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs version
-      description: "Example: @gurezo/web-serial-rxjs@0.1.0"
+      description: "Example: @gurezo/web-serial-rxjs@2.0.0"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "0.2.0",
+  "version": "2.0.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- npm 公開パッケージのバージョンを v0.2.0 から v2.0.0 に上げ、v2 SerialSession 公開 API（#199 完了）に合わせたメジャー版とする（#244）。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [x] Breaking change

## Related issues

- Fixes #244

## What changed?

- `packages/web-serial-rxjs/package.json` の `version` を `2.0.0` に更新
- Issue テンプレ（英日）のバージョン表記例を `2.0.0` に更新
- `pnpm-lock.yaml` は変更不要（確認済み）

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: v2 再設計は既に main にマージ済み。本 PR は**セマンティックバージョンの npm 上の主番号**を 2 に揃えるための**版番号の更新**（利用者は v1 系 API からの移行は MIGRATION / 破壊的変更扱い）。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: 既存の `MIGRATION_V2` ドキュメントおよび README を参照。npm の `0.2.0` 利用者は v2 へ更新時に破壊的変更に注意。

## How to test

1. `pnpm install`（lock を触らない限り不要）
2. `pnpm test`
3. `pnpm exec nx build web-serial-rxjs`

## Environment (if relevant)

- web-serial-rxjs version (for verification): 2.0.0（`packages/web-serial-rxjs/package.json`）
- Browser: 任意（本変更は主に版番号・リリース用）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser（版番号のみの変更のため任意）
- [ ] I updated docs/README if needed（版番号のみで README の固定記載を変えない）
- [x] 公開 API の意図は #199 完了版に一致（本 PR は版の一致）

Made with [Cursor](https://cursor.com)