### PR TITLE
chore(release): @gurezo/web-serial-rxjs を v2.0.1 に更新

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.ja.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.ja.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs バージョン
-      description: "例: @gurezo/web-serial-rxjs@2.0.0"
+      description: "例: @gurezo/web-serial-rxjs@2.0.1"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs version
-      description: "Example: @gurezo/web-serial-rxjs@2.0.0"
+      description: "Example: @gurezo/web-serial-rxjs@2.0.1"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
npm パッケージ `@gurezo/web-serial-rxjs` のバージョンを 2.0.0 から 2.0.1 に上げ、Issue #253 の内容どおり、次のリリース（タグ `v2.0.1`）と `package.json` の整合を取る。関連文脈は #249, #251。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #253
- 関連: #249, #251

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を 2.0.1 に更新
- バグレポート Issue テンプレ（EN/JA）の例示バージョンを 2.0.1 に合わせて更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

パッチ上げのため、公開 API や挙動の変更はない。

## How to test
1. `pnpm install --frozen-lockfile`
2. `pnpm exec nx build web-serial-rxjs`
3. `pnpm test`
4. 任意: `pnpm run publish:test`（ドライラン）

## Environment (if relevant)
該当なし（バージョン番号の更新のみ）。

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.) — 該当なし

Made with [Cursor](https://cursor.com)