### PR TITLE
docs(web-serial-rxjs): npm のパッケージ README にプロジェクトアイコンを表示する

### DIFF
--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -1,5 +1,9 @@
 # @gurezo/web-serial-rxjs
 
+<p align="center">
+  <img src="./web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
+</p>
+
 Web Serial API を最小限の Session 指向 RxJS 表面でラップする TypeScript ライブラリです。v2 では単一の `SerialSession` を公開し、`state$` / `isConnected$` / `receive$` / `lines$` / `errors$` を購読するだけで UI を駆動できます。read loop や送信キューの自前実装は不要です。
 
 ## ブラウザサポート

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -1,5 +1,9 @@
 # @gurezo/web-serial-rxjs
 
+<p align="center">
+  <img src="./web-serial-rxjs-icon.png" alt="@gurezo/web-serial-rxjs project icon" width="512" />
+</p>
+
 A TypeScript library that wraps the Web Serial API with a minimal, session-oriented RxJS surface. The v2 API exposes a single `SerialSession` so applications can drive their UI from `state$` + `isConnected$` + `receive$` + `lines$` + `errors$`, without rebuilding read loops or send queues themselves.
 
 ## Browser support


### PR DESCRIPTION
## Summary
`@gurezo/web-serial-rxjs` の npm ページに表示される README 先頭に、publish に同梱されている `web-serial-rxjs-icon.png` を表示する。Issue #255 の解消。

## Type of change
- [x] Documentation

## Related issues
- Fixes #255

## What changed?
- パッケージの `README.md` / `README.ja.md` 冒頭にアイコン用の画像参照を追加した
- 画像はパッケージルートの `web-serial-rxjs-icon.png`（既存の `files` エントリ）を参照

## API / Compatibility
- [ ] Public API changes
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. ローカルで `packages/web-serial-rxjs/README.md` をマークダウンプレビューし、同階層の `web-serial-rxjs-icon.png` が表示されることを確認
2. 次回 publish 後、または `npm pack` で展開し npm の README レンダリングでアイコンが出ることを確認

## Checklist
- [x] I updated docs/README if needed（パッケージ README のみ）

Made with [Cursor](https://cursor.com)