### PR TITLE
chore(web-serial-rxjs): パッケージバージョンを 2.0.2 に更新

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.ja.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.ja.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs バージョン
-      description: "例: @gurezo/web-serial-rxjs@2.0.1"
+      description: "例: @gurezo/web-serial-rxjs@2.0.2"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs version
-      description: "Example: @gurezo/web-serial-rxjs@2.0.1"
+      description: "Example: @gurezo/web-serial-rxjs@2.0.2"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Issue #256 に対応し、公開 npm パッケージ `@gurezo/web-serial-rxjs` のバージョンを 2.0.1 から 2.0.2 に更新しました。#255 で反映した README 変更などをパッチリリースとして出すための準備です。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #256
- Related #255

## What changed?

- `packages/web-serial-rxjs/package.json` の `version` を `2.0.2` に更新
- バグ報告 Issue テンプレ（英日）のバージョン例を `2.0.2` に更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `packages/web-serial-rxjs/package.json` の `version` が `2.0.2` であることを確認する
2. `pnpm test` を実行し、既存テストが通ることを確認する
3. （任意）`pnpm exec nx build web-serial-rxjs` でビルドが成功することを確認する

## Environment (if relevant)

- Browser: （該当なし）
- OS: 
- web-serial-rxjs version (for verification): 2.0.2（マージ・タグ `v2.0.2` プッシュ後）
- RxJS version:

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
