### PR TITLE
fix(web-serial-rxjs): npm 上のパッケージ README でアイコンが表示されるよう修正

### DIFF
--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -1,7 +1,7 @@
 # @gurezo/web-serial-rxjs
 
 <p align="center">
-  <img src="./web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
+  <img src="https://raw.githubusercontent.com/gurezo/web-serial-rxjs/main/packages/web-serial-rxjs/web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
 </p>
 
 Web Serial API を最小限の Session 指向 RxJS 表面でラップする TypeScript ライブラリです。v2 では単一の `SerialSession` を公開し、`state$` / `isConnected$` / `receive$` / `lines$` / `errors$` を購読するだけで UI を駆動できます。read loop や送信キューの自前実装は不要です。

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -1,7 +1,7 @@
 # @gurezo/web-serial-rxjs
 
 <p align="center">
-  <img src="./web-serial-rxjs-icon.png" alt="@gurezo/web-serial-rxjs project icon" width="512" />
+  <img src="https://raw.githubusercontent.com/gurezo/web-serial-rxjs/main/packages/web-serial-rxjs/web-serial-rxjs-icon.png" alt="@gurezo/web-serial-rxjs project icon" width="512" />
 </p>
 
 A TypeScript library that wraps the Web Serial API with a minimal, session-oriented RxJS surface. The v2 API exposes a single `SerialSession` so applications can drive their UI from `state$` + `isConnected$` + `receive$` + `lines$` + `errors$`, without rebuilding read loops or send queues themselves.


### PR DESCRIPTION
## Summary

npm パッケージの README タブで、HTML の `img` の相対パスが解決されず alt テキストだけが表示されていたため、`raw.githubusercontent.com` の絶対 URL に変更し、表示を安定させました。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #259

## What changed?

- `packages/web-serial-rxjs/README.md` と `README.ja.md` のアイコン `img` の `src` を、リポジトリ上の main ブランチの raw 絶対 URL（`web-serial-rxjs-icon.png`）に差し替え

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. ブラウザで `https://raw.githubusercontent.com/gurezo/web-serial-rxjs/main/packages/web-serial-rxjs/web-serial-rxjs-icon.png` を開き、PNG が表示されることを確認する。
2. マージ・publish 後、https://www.npmjs.com/package/@gurezo/web-serial-rxjs?activeTab=readme でアイコンが表示されることを確認する（次バージョンの publish 後に反映）。

## Environment (if relevant)

- ドキュメントのみの変更のため未記載

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)