### PR TITLE
chore(release): @gurezo/web-serial-rxjs を v2.0.3 にバージョンアップ

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.ja.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.ja.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs バージョン
-      description: "例: @gurezo/web-serial-rxjs@2.0.2"
+      description: "例: @gurezo/web-serial-rxjs@2.0.3"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs version
-      description: "Example: @gurezo/web-serial-rxjs@2.0.2"
+      description: "Example: @gurezo/web-serial-rxjs@2.0.3"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

`@gurezo/web-serial-rxjs` の npm パッケージバージョンを v2.0.2 から v2.0.3 に更新します。Issue #260 / 関連 #259 に対応します。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #260

## What changed?

- `packages/web-serial-rxjs/package.json` の `version` を `2.0.3` に変更
- バグ報告 Issue テンプレの例示バージョンを `2.0.3` に合わせて更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm install`（必要な場合）
2. `pnpm test`
3. `pnpm exec nx build web-serial-rxjs`

## Environment (if relevant)

- N/A（バージョン文字列の更新のみ）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)