### PR TITLE
feat(web-serial-rxjs): 接続中のポート情報（portInfo$ / getPortInfo / getCurrentPort）を追加

### DIFF
--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -42,6 +42,7 @@ const createMockSession = (): MockSession => {
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -53,6 +54,9 @@ const createMockSession = (): MockSession => {
     receive$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
+    portInfo$: portInfoSubject.asObservable(),
+    getPortInfo: () => portInfoSubject.getValue(),
+    getCurrentPort: () => null,
   };
 
   return {

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -37,6 +37,7 @@ const createMockSession = (): MockSession => {
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -48,6 +49,9 @@ const createMockSession = (): MockSession => {
     receive$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
+    portInfo$: portInfoSubject.asObservable(),
+    getPortInfo: () => portInfoSubject.getValue(),
+    getCurrentPort: () => null,
   };
 
   return {

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -38,6 +38,7 @@ const createMockSession = (
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => supported);
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -49,6 +50,9 @@ const createMockSession = (
     receive$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
+    portInfo$: portInfoSubject.asObservable(),
+    getPortInfo: () => portInfoSubject.getValue(),
+    getCurrentPort: () => null,
   };
 
   return {

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -43,6 +43,7 @@ const createMockSession = (supported = true): MockSession => {
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => supported);
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -54,6 +55,9 @@ const createMockSession = (supported = true): MockSession => {
     receive$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
+    portInfo$: portInfoSubject.asObservable(),
+    getPortInfo: () => portInfoSubject.getValue(),
+    getCurrentPort: () => null,
   };
 
   return {

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -45,6 +45,7 @@ const createMockSession = (): MockSession => {
   });
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -56,6 +57,9 @@ const createMockSession = (): MockSession => {
     receive$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
+    portInfo$: portInfoSubject.asObservable(),
+    getPortInfo: () => portInfoSubject.getValue(),
+    getCurrentPort: () => null,
   };
 
   return {

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -36,6 +36,7 @@ const createMockSession = (): MockSession => {
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -47,6 +48,9 @@ const createMockSession = (): MockSession => {
     receive$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
+    portInfo$: portInfoSubject.asObservable(),
+    getPortInfo: () => portInfoSubject.getValue(),
+    getCurrentPort: () => null,
   };
 
   return {

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -12,6 +12,10 @@ Web Serial API は **Chromium 系**のブラウザ（**Chrome** 89+、**Edge** 8
 
 `connect$` の前の feature detection には `SerialSession.isBrowserSupported()`（同期的に `boolean`）を使います。
 
+## 接続中のポート情報（デバイス識別）
+
+`connect$` 成功後は `getPortInfo()` または `portInfo$` で `SerialPort.getInfo()` と同じスナップショット（例: 利用可能な場合の USB ベンダ/プロダクト ID）を取得できます。未接続時は `null` です。`getCurrentPort()` は接続中のみ内部の `SerialPort` を返します。`close()` は直接呼ばず、ライフサイクルは `disconnect$` に任せてください。
+
 ## インストール
 
 ```bash

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -12,6 +12,10 @@ The Web Serial API is only available in **Chromium-based** browsers: **Chrome** 
 
 `SerialSession.isBrowserSupported()` returns a synchronous `boolean` for feature detection before `connect$`.
 
+## Port info (device identification)
+
+After a successful `connect$`, use `getPortInfo()` or subscribe to `portInfo$` for the `SerialPort.getInfo()` snapshot (e.g. USB vendor/product IDs when the device exposes them). Both yield `null` when disconnected. `getCurrentPort()` returns the underlying `SerialPort` while connected; do not call `close()` on it—use `disconnect$` for lifecycle.
+
 ## Installation
 
 ```bash

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -1,4 +1,10 @@
-import { distinctUntilChanged, map, Observable, Subject } from 'rxjs';
+import {
+  BehaviorSubject,
+  distinctUntilChanged,
+  map,
+  Observable,
+  Subject,
+} from 'rxjs';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import { buildRequestOptions } from './internal/build-request-options';
@@ -104,8 +110,16 @@ export function createSerialSession(
     distinctUntilChanged(),
   );
 
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
+  const portInfo$ = portInfoSubject.asObservable();
+
   let activePort: SerialPort | null = null;
   let activePump: ReadPump | null = null;
+
+  const setActivePort = (port: SerialPort | null): void => {
+    activePort = port;
+    portInfoSubject.next(port ? port.getInfo() : null);
+  };
 
   const teardownPump = async (): Promise<void> => {
     const pump = activePump;
@@ -155,7 +169,7 @@ export function createSerialSession(
       machine.toError();
       sendQueue.clear();
       const portToClose = activePort;
-      activePort = null;
+      setActivePort(null);
       void teardownPump().then(() => closePortSafely(portToClose));
     }
     return serialError;
@@ -240,7 +254,6 @@ export function createSerialSession(
             if (selectedPort) {
               await closePortSafely(selectedPort);
             }
-            activePort = null;
             const serialError = reportError(error, 'fatal', {
               fallbackCode: SerialErrorCode.PORT_OPEN_FAILED,
               messagePrefix: 'Failed to open port',
@@ -256,7 +269,7 @@ export function createSerialSession(
             return;
           }
 
-          activePort = selectedPort;
+          setActivePort(selectedPort);
           lineBuffer.clear();
           activePump = createReadPump(selectedPort, {
             onChunk: (text) => {
@@ -325,7 +338,7 @@ export function createSerialSession(
               try {
                 await portToClose.close();
               } catch (error) {
-                activePort = null;
+                setActivePort(null);
                 const serialError = reportError(error, 'fatal', {
                   fallbackCode: SerialErrorCode.CONNECTION_LOST,
                   messagePrefix: 'Failed to close port',
@@ -334,7 +347,7 @@ export function createSerialSession(
                 return;
               }
             }
-            activePort = null;
+            setActivePort(null);
             machine.toIdle();
             subscriber.next();
             subscriber.complete();
@@ -366,6 +379,13 @@ export function createSerialSession(
     },
     state$: machine.state$,
     isConnected$,
+    portInfo$,
+    getPortInfo(): SerialPortInfo | null {
+      return portInfoSubject.getValue();
+    },
+    getCurrentPort(): SerialPort | null {
+      return activePort;
+    },
     errors$,
     receive$,
     lines$,

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -77,6 +77,32 @@ export interface SerialSession {
   readonly isConnected$: Observable<boolean>;
 
   /**
+   * The active port’s {@link SerialPort.getInfo} snapshot, or `null` when no
+   * port is open (including {@link SerialSessionState.Idle},
+   * {@link SerialSessionState.Error}, and {@link SerialSessionState.Unsupported}).
+   *
+   * Emits the current value on subscribe. Use with {@link state$} to know when
+   * the value is valid for your UI.
+   */
+  readonly portInfo$: Observable<SerialPortInfo | null>;
+
+  /**
+   * Synchronous read of the last {@link portInfo$} value.
+   *
+   * @returns The same as {@link SerialPort.getInfo} for the open port, or
+   *   `null` when not connected.
+   */
+  getPortInfo(): SerialPortInfo | null;
+
+  /**
+   * The underlying `SerialPort` while connected, or `null` otherwise.
+   *
+   * Avoid calling `port.close()` or replacing streams yourself; that conflicts
+   * with session lifecycle. Prefer {@link getPortInfo} for identification.
+   */
+  getCurrentPort(): SerialPort | null;
+
+  /**
    * Primary error channel.
    *
    * All {@link SerialError} instances produced by the session (connect /

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -1,4 +1,5 @@
 import {
+  filter,
   firstValueFrom,
   lastValueFrom,
   take,
@@ -13,11 +14,17 @@ import { SerialSessionState } from '../../src/session/serial-session-state';
 
 const S = SerialSessionState;
 
+const stubPortInfo: SerialPortInfo = {
+  usbVendorId: 0x1a86,
+  usbProductId: 0x7523,
+};
+
 type MockPort = {
   readable: ReadableStream<Uint8Array> | null;
   writable: WritableStream<Uint8Array> | null;
   open: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
+  getInfo: ReturnType<typeof vi.fn>;
 };
 
 type StreamHandle = {
@@ -44,6 +51,7 @@ const makeMockPort = (
   writable,
   open: vi.fn().mockResolvedValue(undefined),
   close,
+  getInfo: vi.fn().mockReturnValue(stubPortInfo),
 });
 
 type WritableHarness = {
@@ -121,8 +129,11 @@ describe('createSerialSession', () => {
       expect(typeof session.connect$).toBe('function');
       expect(typeof session.disconnect$).toBe('function');
       expect(typeof session.send$).toBe('function');
+      expect(typeof session.getPortInfo).toBe('function');
+      expect(typeof session.getCurrentPort).toBe('function');
       expect(session.state$).toBeDefined();
       expect(session.isConnected$).toBeDefined();
+      expect(session.portInfo$).toBeDefined();
       expect(session.errors$).toBeDefined();
       expect(session.receive$).toBeDefined();
       expect(session.lines$).toBeDefined();
@@ -343,6 +354,70 @@ describe('createSerialSession', () => {
         S.Idle,
       ]);
       expect(close).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('portInfo$ and getPortInfo', () => {
+    it('replays null before connect', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
+      (globalThis as any).navigator = { serial: {} };
+
+      const session = createSerialSession();
+
+      expect(session.getPortInfo()).toBeNull();
+      expect(session.getCurrentPort()).toBeNull();
+      expect(await firstValueFrom(session.portInfo$)).toBeNull();
+    });
+
+    it('exposes SerialPort.getInfo after connect and clears on disconnect', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const infoDuringConnect = firstValueFrom(
+        session.portInfo$.pipe(take(2), toArray()),
+      );
+
+      await firstValueFrom(session.connect$());
+
+      expect(port.getInfo).toHaveBeenCalled();
+      expect(session.getPortInfo()).toEqual(stubPortInfo);
+      expect(session.getCurrentPort()).toBe(port as unknown as SerialPort);
+
+      const infos = await infoDuringConnect;
+      expect(infos[0]).toBeNull();
+      expect(infos[1]).toEqual(stubPortInfo);
+
+      const nullAfterDisconnect = firstValueFrom(
+        session.portInfo$.pipe(
+          filter((p): p is null => p === null),
+          take(1),
+        ),
+      );
+      await firstValueFrom(session.disconnect$());
+
+      expect(session.getPortInfo()).toBeNull();
+      expect(session.getCurrentPort()).toBeNull();
+      expect(await nullAfterDisconnect).toBeNull();
+    });
+
+    it('clears port info when the read pump errors fatally', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+      expect(session.getPortInfo()).toEqual(stubPortInfo);
+
+      const errorPromise = firstValueFrom(session.errors$);
+      controller.error(new Error('device unplugged'));
+      await errorPromise;
+
+      expect(session.getPortInfo()).toBeNull();
+      expect(session.getCurrentPort()).toBeNull();
+      expect(await firstValueFrom(session.portInfo$)).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
接続中デバイスの識別のため、`SerialPort.getInfo()` に相当する情報を `SerialSession` から取得できるようにしました。`navigator.serial.getPorts()` との手動突合を減らし、#263 / #264 の「ポート公開」部分を満たします。受信ストリームの replay（#265）は含みません。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #264
- Related to #263
- 注: #265（受信 replay）は別 PR の予定

## What changed?
- `portInfo$` / `getPortInfo()` で接続中の `SerialPortInfo` を取得可能にした（未接続時は `null`）
- 高度な利用向けに `getCurrentPort()` で接続中の `SerialPort` を取得可能にした（JSDoc で `close` は使わない旨を明記）
- ライフサイクル（切断・ Read pump 致命エラー）でポート情報を `null` に戻す
- パッケージ・例アプリのテストモック、README 英日を追記

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialSession` に上記3つを**追加**（既存挙動は維持）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. リポジトリルートで `pnpm run test` を実行
2. Chromium 系ブラウザで、サンプルアプリを開き、シリアル接続後に `session.getPortInfo()` や `portInfo$` でベンダ/プロダクト ID が得られることを確認（実機の USB シリアル想定）

## Environment (if relevant)
- Browser: Chrome / Edge 等
- OS: 任意
- web-serial-rxjs version (for verification): このブランチ
- RxJS version: ピア依存 `^7.8.0`

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)