### PR TITLE
chore(web-serial-rxjs): @gurezo/web-serial-rxjs を 2.1.0 に上げる

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.ja.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.ja.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs バージョン
-      description: "例: @gurezo/web-serial-rxjs@2.0.3"
+      description: "例: @gurezo/web-serial-rxjs@2.1.0"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     id: package_version
     attributes:
       label: web-serial-rxjs version
-      description: "Example: @gurezo/web-serial-rxjs@2.0.3"
+      description: "Example: @gurezo/web-serial-rxjs@2.1.0"
       placeholder: "@gurezo/web-serial-rxjs@x.y.z"
     validations:
       required: true

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

npm パッケージ `@gurezo/web-serial-rxjs` のバージョンを 2.0.3 から 2.1.0 に更新しました。Issue #263–#265 に関連するリリース準備のための変更です。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #268
- Related #263
- Related #264
- Related #265

## What changed?

- `packages/web-serial-rxjs/package.json` の `version` を `2.1.0` に変更
- バグ報告用 Issue テンプレ（英日）のバージョン例示を 2.1.0 に更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm test` を実行し、通過することを確認する
2. `pnpm exec nx build web-serial-rxjs` でビルドが成功することを確認する
3. （可能なら）Chromium 系ブラウザで例アプリの動作を軽く確認する

## Environment (if relevant)

- web-serial-rxjs version (for verification): 2.1.0（マージ・タグ後）
- RxJS version: ^7.8.0（peer）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)
