### PR TITLE
fix(web-serial-rxjs): GitHub Pages のドキュメントリンクを TypeDoc / GitHub 表示に修正

### DIFF
--- a/docs/OVERVIEW.ja.md
+++ b/docs/OVERVIEW.ja.md
@@ -4,7 +4,7 @@
   <img src="../assets/icon/web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
 </p>
 
-このページは v2 公開 API の**考え方**をまとめたものです。各 `SerialSession` 面の役割、`SerialSessionState` と `state$` の対応、`receive$` と `lines$` の使い分け。オプション、エラーコード、型の詳細は [API リファレンス](./API_REFERENCE.ja.md) を参照してください。
+このページは v2 公開 API の**考え方**をまとめたものです。各 `SerialSession` 面の役割、`SerialSessionState` と `state$` の対応、`receive$` と `lines$` の使い分け。オプション、エラーコード、型の詳細は [API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html) を参照してください。
 
 ## 目次
 
@@ -34,7 +34,7 @@
 
 ## SerialSession（v2）の全体像
 
-`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**標準の改行区切り**は組み込み `lines$`、独自区切りが必要なときだけ `receive$` 上に RxJS で組み立てます（[高度な使用方法](./ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
+`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**標準の改行区切り**は組み込み `lines$`、独自区切りが必要なときだけ `receive$` 上に RxJS で組み立てます（[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
 
 | 公開面 | 役割 |
 | --- | --- |
@@ -51,7 +51,7 @@
 
 ### SerialSessionState（早見表）
 
-`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](./API_REFERENCE.ja.md#serialsessionstate) を参照してください。
+`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](https://gurezo.github.io/web-serial-rxjs/variables/SerialSessionState.html) および [GitHub 上の表・図](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md#serialsessionstate) を参照してください。
 
 | 定数 | 値 | 意味 |
 | --- | --- | --- |
@@ -62,11 +62,11 @@
 | `SerialSessionState.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
 | `SerialSessionState.Error` | `'error'` | 接続まわりの致命エラー。`disconnect$` か新しいセッションで復帰。 |
 
-**`receive$` と `lines$`:** 改行区切りの定番利用では **`lines$`** を優先。**`receive$`** はチャンクの到着タイミングをそのまま扱う場合や、独自区切り・自前バッファが必要なとき向け（[行単位のフレーミング](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
+**`receive$` と `lines$`:** 改行区切りの定番利用では **`lines$`** を優先。**`receive$`** はチャンクの到着タイミングをそのまま扱う場合や、独自区切り・自前バッファが必要なとき向け（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
 
 **`isConnected$`（UI 用）** — 読み取り専用の `Observable<boolean>` です。`state$` を `SerialSessionState.Connected` と毎回比較しなくても接続有無の UI 分岐に使えます。独自ルールが必要な場合は、従来どおり `state$` から `map` で派生しても構いません。
 
-**`lines$`（行区切り）** — 組み込みです。独自区切りが欲しい場合のみ `receive$` でフレーミングします（[行単位のフレーミング](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
+**`lines$`（行区切り）** — 組み込みです。独自区切りが欲しい場合のみ `receive$` でフレーミングします（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
 
 ### 最小サンプル
 
@@ -91,15 +91,15 @@ session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();
 ```
 
-実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](./QUICK_START.ja.md) を参照してください。
+実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md) を参照してください。
 
 ## ドキュメント索引
 
 | ドキュメント | 用途 |
 | --- | --- |
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ全体の目次、サンプル索引、貢献の導線。 |
-| **[クイックスタート](./QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
-| **[高度な使用方法](./ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
-| **[API リファレンス](./API_REFERENCE.ja.md)** | オプション、`SerialSessionState`、`SerialError` の詳細。 |
-| **[v1 → v2 マイグレーション](./MIGRATION_V2.ja.md)**（[English](./MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
-| **[Phase 5（アーカイブ）](./archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |
+| **[クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
+| **[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
+| **[API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細（TypeDoc）。表・図は [GitHub](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md) も参照。 |
+| **[v1 → v2 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md)**（[English](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
+| **[Phase 5（アーカイブ）](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -4,7 +4,7 @@
   <img src="../assets/icon/web-serial-rxjs-icon.png" alt="web-serial-rxjs project icon" width="512" />
 </p>
 
-This page is the **mental model** for the v2 public API: what each `SerialSession` surface does, how `SerialSessionState` maps to `state$`, and how to choose between `receive$` and `lines$`. For options, error codes, and formal type details, see [API Reference](./API_REFERENCE.md).
+This page is the **mental model** for the v2 public API: what each `SerialSession` surface does, how `SerialSessionState` maps to `state$`, and how to choose between `receive$` and `lines$`. For options, error codes, and formal type details, see [API Reference](modules.html).
 
 ## Table of Contents
 
@@ -34,7 +34,7 @@ This library is framework-agnostic and can be used with:
 
 ## SerialSession (v2) at a glance
 
-`createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; when you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](./ADVANCED_USAGE.md)).
+`createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; when you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 
 | Surface | Role |
 | --- | --- |
@@ -51,7 +51,7 @@ This library is framework-agnostic and can be used with:
 
 ### SerialSessionState (quick reference)
 
-`state$` uses the string union below. Prefer the **const object** (e.g. `SerialSessionState.Connected` → `'connected'`) in code. Full lifecycle diagram, transitions, and edge cases: [API Reference – SerialSessionState](./API_REFERENCE.md#serialsessionstate).
+`state$` uses the string union below. Prefer the **const object** (e.g. `SerialSessionState.Connected` → `'connected'`) in code. Full lifecycle diagram, transitions, and edge cases: [API Reference – SerialSessionState](variables/SerialSessionState.html).
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
@@ -62,11 +62,11 @@ This library is framework-agnostic and can be used with:
 | `SerialSessionState.Unsupported` | `'unsupported'` | Web Serial was not available when the session was created. |
 | `SerialSessionState.Error` | `'error'` | Fatal I/O or lifecycle failure; call `disconnect$` or build a new session. |
 
-**`receive$` vs `lines$`:** prefer **`lines$`** for typical newline-framed text; use **`receive$`** when you need raw chunk timing, a custom delimiter, or a rolling buffer you control (recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
+**`receive$` vs `lines$`:** prefer **`lines$`** for typical newline-framed text; use **`receive$`** when you need raw chunk timing, a custom delimiter, or a rolling buffer you control (recipes in [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing)).
 
 **`isConnected$` (for simple UIs)** — a read-only `Observable<boolean>`. Use it for “port open?” toggles without comparing `state$` to `SerialSessionState.Connected` yourself. You can still derive your own boolean from `state$` with `map` if you need different rules.
 
-**`lines$` (newline framing)** — built in; for non-standard delimiters, frame on `receive$` (recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
+**`lines$` (newline framing)** — built in; for non-standard delimiters, frame on `receive$` (recipes in [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing)).
 
 ### Minimal example
 
@@ -91,15 +91,15 @@ session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();
 ```
 
-In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscribe({ error })` (errors are also on `errors$`). A fuller walkthrough is in [Quick Start](./QUICK_START.md).
+In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscribe({ error })` (errors are also on `errors$`). A fuller walkthrough is in [Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md).
 
 ## Documentation index
 
 | Doc | Use it for |
 | --- | --- |
 | **Repository [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md)** | Monorepo overview, examples index, and contribution links. |
-| **[Quick Start](./QUICK_START.md)** | Shortest path to a working open port and subscriptions. |
-| **[Advanced Usage](./ADVANCED_USAGE.md)** | Line framing, request/response-style flows, and recovery. |
-| **[API Reference](./API_REFERENCE.md)** | Options, `SerialSessionState`, and `SerialError` details. |
-| **[v1 → v2 Migration Guide](./MIGRATION_V2.md)** | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
-| **[Phase 5 archive (legacy v1 doc)](./archive/MIGRATION_PHASE5.md)** | Historical v1 context only. |
+| **[Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md)** | Shortest path to a working open port and subscriptions. |
+| **[Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)** | Line framing, request/response-style flows, and recovery. |
+| **[API Reference](modules.html)** | Options, `SerialSessionState`, and `SerialError` details (generated TypeDoc); narrative tables also on [GitHub](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.md). |
+| **[v1 → v2 Migration Guide](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md)** | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
+| **[Phase 5 archive (legacy v1 doc)](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.md)** | Historical v1 context only. |

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <p align="center">
   <img src="media/web-serial-rxjs-icon.png" alt="web-serial-rxjs project icon" width="512" />
 </p>
-<p>This page is the <strong>mental model</strong> for the v2 public API: what each <code>SerialSession</code> surface does, how <code>SerialSessionState</code> maps to <code>state$</code>, and how to choose between <code>receive$</code> and <code>lines$</code>. For options, error codes, and formal type details, see <a href="media/API_REFERENCE.md">API Reference</a>.</p>
+<p>This page is the <strong>mental model</strong> for the v2 public API: what each <code>SerialSession</code> surface does, how <code>SerialSessionState</code> maps to <code>state$</code>, and how to choose between <code>receive$</code> and <code>lines$</code>. For options, error codes, and formal type details, see <a href="modules.html">API Reference</a>.</p>
 <h2 id="table-of-contents" class="tsd-anchor-link">Table of Contents<a href="#table-of-contents" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h2>
 <ul>
 <li><a href="#features">Features</a></li>
@@ -29,7 +29,7 @@
 <li>Vanilla JavaScript / TypeScript</li>
 </ul>
 <h2 id="serialsession-v2-at-a-glance" class="tsd-anchor-link">SerialSession (v2) at a glance<a href="#serialsession-v2-at-a-glance" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h2>
-<p><code>createSerialSession</code> returns a single <strong>SerialSession</strong>. All interaction goes through the fields below. The public API is intentionally small; when you need <strong>custom</strong> framing, compose plain RxJS on <code>receive$</code> (see <a href="media/ADVANCED_USAGE.md">Advanced Usage</a>).</p>
+<p><code>createSerialSession</code> returns a single <strong>SerialSession</strong>. All interaction goes through the fields below. The public API is intentionally small; when you need <strong>custom</strong> framing, compose plain RxJS on <code>receive$</code> (see <a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md">Advanced Usage</a>).</p>
 <table>
 <thead>
 <tr>
@@ -81,7 +81,7 @@
 </tbody>
 </table>
 <h3 id="serialsessionstate-quick-reference" class="tsd-anchor-link">SerialSessionState (quick reference)<a href="#serialsessionstate-quick-reference" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h3>
-<p><code>state$</code> uses the string union below. Prefer the <strong>const object</strong> (e.g. <code>SerialSessionState.Connected</code> → <code>'connected'</code>) in code. Full lifecycle diagram, transitions, and edge cases: <a href="media/API_REFERENCE.md#serialsessionstate">API Reference – SerialSessionState</a>.</p>
+<p><code>state$</code> uses the string union below. Prefer the <strong>const object</strong> (e.g. <code>SerialSessionState.Connected</code> → <code>'connected'</code>) in code. Full lifecycle diagram, transitions, and edge cases: <a href="variables/SerialSessionState.html">API Reference – SerialSessionState</a>.</p>
 <table>
 <thead>
 <tr>
@@ -123,14 +123,14 @@
 </tr>
 </tbody>
 </table>
-<p><strong><code>receive$</code> vs <code>lines$</code>:</strong> prefer <strong><code>lines$</code></strong> for typical newline-framed text; use <strong><code>receive$</code></strong> when you need raw chunk timing, a custom delimiter, or a rolling buffer you control (recipes in <a href="media/ADVANCED_USAGE.md#line-framing">Advanced Usage</a>).</p>
+<p><strong><code>receive$</code> vs <code>lines$</code>:</strong> prefer <strong><code>lines$</code></strong> for typical newline-framed text; use <strong><code>receive$</code></strong> when you need raw chunk timing, a custom delimiter, or a rolling buffer you control (recipes in <a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing">Advanced Usage</a>).</p>
 <p><strong><code>isConnected$</code> (for simple UIs)</strong> — a read-only <code>Observable&lt;boolean&gt;</code>. Use it for “port open?” toggles without comparing <code>state$</code> to <code>SerialSessionState.Connected</code> yourself. You can still derive your own boolean from <code>state$</code> with <code>map</code> if you need different rules.</p>
-<p><strong><code>lines$</code> (newline framing)</strong> — built in; for non-standard delimiters, frame on <code>receive$</code> (recipes in <a href="media/ADVANCED_USAGE.md#line-framing">Advanced Usage</a>).</p>
+<p><strong><code>lines$</code> (newline framing)</strong> — built in; for non-standard delimiters, frame on <code>receive$</code> (recipes in <a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing">Advanced Usage</a>).</p>
 <h3 id="minimal-example" class="tsd-anchor-link">Minimal example<a href="#minimal-example" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h3>
 <pre><code class="typescript"><span class="hl-0">import</span><span class="hl-1"> { </span><span class="hl-2">createSerialSession</span><span class="hl-1">, </span><span class="hl-2">SerialSessionState</span><span class="hl-1"> } </span><span class="hl-0">from</span><span class="hl-1"> </span><span class="hl-3">&#39;@gurezo/web-serial-rxjs&#39;</span><span class="hl-1">;</span><br/><span class="hl-0">import</span><span class="hl-1"> { </span><span class="hl-2">filter</span><span class="hl-1"> } </span><span class="hl-0">from</span><span class="hl-1"> </span><span class="hl-3">&#39;rxjs&#39;</span><span class="hl-1">;</span><br/><br/><span class="hl-4">const</span><span class="hl-1"> </span><span class="hl-5">session</span><span class="hl-1"> = </span><span class="hl-6">createSerialSession</span><span class="hl-1">({ </span><span class="hl-2">baudRate:</span><span class="hl-1"> </span><span class="hl-7">115200</span><span class="hl-1"> });</span><br/><br/><span class="hl-0">if</span><span class="hl-1"> (!</span><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">isBrowserSupported</span><span class="hl-1">()) {</span><br/><span class="hl-1">  </span><span class="hl-0">throw</span><span class="hl-1"> </span><span class="hl-4">new</span><span class="hl-1"> </span><span class="hl-6">Error</span><span class="hl-1">(</span><span class="hl-3">&#39;Web Serial is not available in this browser&#39;</span><span class="hl-1">);</span><br/><span class="hl-1">}</span><br/><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">lines$</span><span class="hl-1">.</span><span class="hl-6">subscribe</span><span class="hl-1">(</span><span class="hl-2">console</span><span class="hl-1">.</span><span class="hl-2">log</span><span class="hl-1">);</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">errors$</span><span class="hl-1">.</span><span class="hl-6">subscribe</span><span class="hl-1">(</span><span class="hl-2">console</span><span class="hl-1">.</span><span class="hl-2">error</span><span class="hl-1">);</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">state$</span><br/><span class="hl-1">  .</span><span class="hl-6">pipe</span><span class="hl-1">(</span><span class="hl-6">filter</span><span class="hl-1">((</span><span class="hl-2">s</span><span class="hl-1">) </span><span class="hl-4">=&gt;</span><span class="hl-1"> </span><span class="hl-2">s</span><span class="hl-1"> === </span><span class="hl-2">SerialSessionState</span><span class="hl-1">.</span><span class="hl-2">Connected</span><span class="hl-1">))</span><br/><span class="hl-1">  .</span><span class="hl-6">subscribe</span><span class="hl-1">(() </span><span class="hl-4">=&gt;</span><span class="hl-1"> {</span><br/><span class="hl-1">    </span><span class="hl-8">/* e.g. enable UI that must wait until the port is open */</span><br/><span class="hl-1">  });</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">connect$</span><span class="hl-1">().</span><span class="hl-6">subscribe</span><span class="hl-1">();</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">send$</span><span class="hl-1">(</span><span class="hl-3">&#39;hello</span><span class="hl-9">\r\n</span><span class="hl-3">&#39;</span><span class="hl-1">).</span><span class="hl-6">subscribe</span><span class="hl-1">();</span>
 </code><button type="button">Copy</button></pre>
 
-<p>In real apps, handle <code>connect$().subscribe({ next, error })</code> and <code>send$().subscribe({ error })</code> (errors are also on <code>errors$</code>). A fuller walkthrough is in <a href="media/QUICK_START.md">Quick Start</a>.</p>
+<p>In real apps, handle <code>connect$().subscribe({ next, error })</code> and <code>send$().subscribe({ error })</code> (errors are also on <code>errors$</code>). A fuller walkthrough is in <a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md">Quick Start</a>.</p>
 <h2 id="documentation-index" class="tsd-anchor-link">Documentation index<a href="#documentation-index" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h2>
 <table>
 <thead>
@@ -145,23 +145,23 @@
 <td>Monorepo overview, examples index, and contribution links.</td>
 </tr>
 <tr>
-<td><strong><a href="media/QUICK_START.md">Quick Start</a></strong></td>
+<td><strong><a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md">Quick Start</a></strong></td>
 <td>Shortest path to a working open port and subscriptions.</td>
 </tr>
 <tr>
-<td><strong><a href="media/ADVANCED_USAGE.md">Advanced Usage</a></strong></td>
+<td><strong><a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md">Advanced Usage</a></strong></td>
 <td>Line framing, request/response-style flows, and recovery.</td>
 </tr>
 <tr>
-<td><strong><a href="media/API_REFERENCE.md">API Reference</a></strong></td>
-<td>Options, <code>SerialSessionState</code>, and <code>SerialError</code> details.</td>
+<td><strong><a href="modules.html">API Reference</a></strong></td>
+<td>Options, <code>SerialSessionState</code>, and <code>SerialError</code> details (generated TypeDoc); narrative tables also on <a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.md">GitHub</a>.</td>
 </tr>
 <tr>
-<td><strong><a href="media/MIGRATION_V2.md">v1 → v2 Migration Guide</a></strong></td>
+<td><strong><a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md">v1 → v2 Migration Guide</a></strong></td>
 <td>Replacing the removed v1 <code>SerialClient</code> / <code>ShellClient</code> API.</td>
 </tr>
 <tr>
-<td><strong><a href="media/MIGRATION_PHASE5.md">Phase 5 archive (legacy v1 doc)</a></strong></td>
+<td><strong><a href="https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.md">Phase 5 archive (legacy v1 doc)</a></strong></td>
 <td>Historical v1 context only.</td>
 </tr>
 </tbody>

--- a/docs/media/OVERVIEW.ja.md
+++ b/docs/media/OVERVIEW.ja.md
@@ -4,7 +4,7 @@
   <img src="../../assets/icon/web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
 </p>
 
-このページは v2 公開 API の**考え方**をまとめたものです。各 `SerialSession` 面の役割、`SerialSessionState` と `state$` の対応、`receive$` と `lines$` の使い分け。オプション、エラーコード、型の詳細は [API リファレンス](./API_REFERENCE.ja.md) を参照してください。
+このページは v2 公開 API の**考え方**をまとめたものです。各 `SerialSession` 面の役割、`SerialSessionState` と `state$` の対応、`receive$` と `lines$` の使い分け。オプション、エラーコード、型の詳細は [API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html) を参照してください。
 
 ## 目次
 
@@ -34,7 +34,7 @@
 
 ## SerialSession（v2）の全体像
 
-`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**標準の改行区切り**は組み込み `lines$`、独自区切りが必要なときだけ `receive$` 上に RxJS で組み立てます（[高度な使用方法](./ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
+`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**標準の改行区切り**は組み込み `lines$`、独自区切りが必要なときだけ `receive$` 上に RxJS で組み立てます（[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
 
 | 公開面 | 役割 |
 | --- | --- |
@@ -51,7 +51,7 @@
 
 ### SerialSessionState（早見表）
 
-`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](./API_REFERENCE.ja.md#serialsessionstate) を参照してください。
+`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](https://gurezo.github.io/web-serial-rxjs/variables/SerialSessionState.html) および [GitHub 上の表・図](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md#serialsessionstate) を参照してください。
 
 | 定数 | 値 | 意味 |
 | --- | --- | --- |
@@ -62,11 +62,11 @@
 | `SerialSessionState.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
 | `SerialSessionState.Error` | `'error'` | 接続まわりの致命エラー。`disconnect$` か新しいセッションで復帰。 |
 
-**`receive$` と `lines$`:** 改行区切りの定番利用では **`lines$`** を優先。**`receive$`** はチャンクの到着タイミングをそのまま扱う場合や、独自区切り・自前バッファが必要なとき向け（[行単位のフレーミング](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
+**`receive$` と `lines$`:** 改行区切りの定番利用では **`lines$`** を優先。**`receive$`** はチャンクの到着タイミングをそのまま扱う場合や、独自区切り・自前バッファが必要なとき向け（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
 
 **`isConnected$`（UI 用）** — 読み取り専用の `Observable<boolean>` です。`state$` を `SerialSessionState.Connected` と毎回比較しなくても接続有無の UI 分岐に使えます。独自ルールが必要な場合は、従来どおり `state$` から `map` で派生しても構いません。
 
-**`lines$`（行区切り）** — 組み込みです。独自区切りが欲しい場合のみ `receive$` でフレーミングします（[行単位のフレーミング](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
+**`lines$`（行区切り）** — 組み込みです。独自区切りが欲しい場合のみ `receive$` でフレーミングします（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
 
 ### 最小サンプル
 
@@ -91,15 +91,15 @@ session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();
 ```
 
-実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](./QUICK_START.ja.md) を参照してください。
+実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md) を参照してください。
 
 ## ドキュメント索引
 
 | ドキュメント | 用途 |
 | --- | --- |
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ全体の目次、サンプル索引、貢献の導線。 |
-| **[クイックスタート](./QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
-| **[高度な使用方法](./ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
-| **[API リファレンス](./API_REFERENCE.ja.md)** | オプション、`SerialSessionState`、`SerialError` の詳細。 |
-| **[v1 → v2 マイグレーション](./MIGRATION_V2.ja.md)**（[English](./MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
-| **[Phase 5（アーカイブ）](./archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |
+| **[クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
+| **[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
+| **[API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細（TypeDoc）。表・図は [GitHub](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md) も参照。 |
+| **[v1 → v2 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md)**（[English](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
+| **[Phase 5（アーカイブ）](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "nx run-many --target=test --all --exclude=@gurezo/web-serial-rxjs/workspace",
     "docs:generate": "typedoc --options packages/web-serial-rxjs/typedoc.json",
     "docs:clean": "rm -rf docs",
-    "docs": "pnpm run docs:clean && pnpm run docs:generate && cp packages/web-serial-rxjs/docs/*.md docs/ && cp -R packages/web-serial-rxjs/docs/archive docs/ && mkdir -p docs/media && cp packages/web-serial-rxjs/docs/*.ja.md docs/media/ && node tools/fix-docs-media-links.mjs",
+    "docs": "pnpm run docs:clean && pnpm run docs:generate && cp packages/web-serial-rxjs/docs/*.md docs/ && cp -R packages/web-serial-rxjs/docs/archive docs/ && mkdir -p docs/media && cp packages/web-serial-rxjs/docs/*.ja.md docs/media/ && cp packages/web-serial-rxjs/docs/QUICK_START.md packages/web-serial-rxjs/docs/ADVANCED_USAGE.md packages/web-serial-rxjs/docs/API_REFERENCE.md packages/web-serial-rxjs/docs/MIGRATION_V2.md docs/media/ && cp packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.md docs/media/ && node tools/fix-docs-media-links.mjs",
     "publish:test": "pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs",
     "publish": "pnpm publish --filter @gurezo/web-serial-rxjs"
   },

--- a/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
@@ -4,7 +4,7 @@
   <img src="../../../assets/icon/web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
 </p>
 
-このページは v2 公開 API の**考え方**をまとめたものです。各 `SerialSession` 面の役割、`SerialSessionState` と `state$` の対応、`receive$` と `lines$` の使い分け。オプション、エラーコード、型の詳細は [API リファレンス](./API_REFERENCE.ja.md) を参照してください。
+このページは v2 公開 API の**考え方**をまとめたものです。各 `SerialSession` 面の役割、`SerialSessionState` と `state$` の対応、`receive$` と `lines$` の使い分け。オプション、エラーコード、型の詳細は [API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html) を参照してください。
 
 ## 目次
 
@@ -34,7 +34,7 @@
 
 ## SerialSession（v2）の全体像
 
-`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**標準の改行区切り**は組み込み `lines$`、独自区切りが必要なときだけ `receive$` 上に RxJS で組み立てます（[高度な使用方法](./ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
+`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**標準の改行区切り**は組み込み `lines$`、独自区切りが必要なときだけ `receive$` 上に RxJS で組み立てます（[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
 
 | 公開面 | 役割 |
 | --- | --- |
@@ -51,7 +51,7 @@
 
 ### SerialSessionState（早見表）
 
-`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](./API_REFERENCE.ja.md#serialsessionstate) を参照してください。
+`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](https://gurezo.github.io/web-serial-rxjs/variables/SerialSessionState.html) および [GitHub 上の表・図](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md#serialsessionstate) を参照してください。
 
 | 定数 | 値 | 意味 |
 | --- | --- | --- |
@@ -62,11 +62,11 @@
 | `SerialSessionState.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
 | `SerialSessionState.Error` | `'error'` | 接続まわりの致命エラー。`disconnect$` か新しいセッションで復帰。 |
 
-**`receive$` と `lines$`:** 改行区切りの定番利用では **`lines$`** を優先。**`receive$`** はチャンクの到着タイミングをそのまま扱う場合や、独自区切り・自前バッファが必要なとき向け（[行単位のフレーミング](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
+**`receive$` と `lines$`:** 改行区切りの定番利用では **`lines$`** を優先。**`receive$`** はチャンクの到着タイミングをそのまま扱う場合や、独自区切り・自前バッファが必要なとき向け（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
 
 **`isConnected$`（UI 用）** — 読み取り専用の `Observable<boolean>` です。`state$` を `SerialSessionState.Connected` と毎回比較しなくても接続有無の UI 分岐に使えます。独自ルールが必要な場合は、従来どおり `state$` から `map` で派生しても構いません。
 
-**`lines$`（行区切り）** — 組み込みです。独自区切りが欲しい場合のみ `receive$` でフレーミングします（[行単位のフレーミング](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。
+**`lines$`（行区切り）** — 組み込みです。独自区切りが欲しい場合のみ `receive$` でフレーミングします（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
 
 ### 最小サンプル
 
@@ -91,15 +91,15 @@ session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();
 ```
 
-実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](./QUICK_START.ja.md) を参照してください。
+実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md) を参照してください。
 
 ## ドキュメント索引
 
 | ドキュメント | 用途 |
 | --- | --- |
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ全体の目次、サンプル索引、貢献の導線。 |
-| **[クイックスタート](./QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
-| **[高度な使用方法](./ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
-| **[API リファレンス](./API_REFERENCE.ja.md)** | オプション、`SerialSessionState`、`SerialError` の詳細。 |
-| **[v1 → v2 マイグレーション](./MIGRATION_V2.ja.md)**（[English](./MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
-| **[Phase 5（アーカイブ）](./archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |
+| **[クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
+| **[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
+| **[API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細（TypeDoc）。表・図は [GitHub](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md) も参照。 |
+| **[v1 → v2 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md)**（[English](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
+| **[Phase 5（アーカイブ）](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |

--- a/packages/web-serial-rxjs/docs/OVERVIEW.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.md
@@ -4,7 +4,7 @@
   <img src="../../../assets/icon/web-serial-rxjs-icon.png" alt="web-serial-rxjs project icon" width="512" />
 </p>
 
-This page is the **mental model** for the v2 public API: what each `SerialSession` surface does, how `SerialSessionState` maps to `state$`, and how to choose between `receive$` and `lines$`. For options, error codes, and formal type details, see [API Reference](./API_REFERENCE.md).
+This page is the **mental model** for the v2 public API: what each `SerialSession` surface does, how `SerialSessionState` maps to `state$`, and how to choose between `receive$` and `lines$`. For options, error codes, and formal type details, see [API Reference](modules.html).
 
 ## Table of Contents
 
@@ -34,7 +34,7 @@ This library is framework-agnostic and can be used with:
 
 ## SerialSession (v2) at a glance
 
-`createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; when you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](./ADVANCED_USAGE.md)).
+`createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; when you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 
 | Surface | Role |
 | --- | --- |
@@ -51,7 +51,7 @@ This library is framework-agnostic and can be used with:
 
 ### SerialSessionState (quick reference)
 
-`state$` uses the string union below. Prefer the **const object** (e.g. `SerialSessionState.Connected` → `'connected'`) in code. Full lifecycle diagram, transitions, and edge cases: [API Reference – SerialSessionState](./API_REFERENCE.md#serialsessionstate).
+`state$` uses the string union below. Prefer the **const object** (e.g. `SerialSessionState.Connected` → `'connected'`) in code. Full lifecycle diagram, transitions, and edge cases: [API Reference – SerialSessionState](variables/SerialSessionState.html).
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
@@ -62,11 +62,11 @@ This library is framework-agnostic and can be used with:
 | `SerialSessionState.Unsupported` | `'unsupported'` | Web Serial was not available when the session was created. |
 | `SerialSessionState.Error` | `'error'` | Fatal I/O or lifecycle failure; call `disconnect$` or build a new session. |
 
-**`receive$` vs `lines$`:** prefer **`lines$`** for typical newline-framed text; use **`receive$`** when you need raw chunk timing, a custom delimiter, or a rolling buffer you control (recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
+**`receive$` vs `lines$`:** prefer **`lines$`** for typical newline-framed text; use **`receive$`** when you need raw chunk timing, a custom delimiter, or a rolling buffer you control (recipes in [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing)).
 
 **`isConnected$` (for simple UIs)** — a read-only `Observable<boolean>`. Use it for “port open?” toggles without comparing `state$` to `SerialSessionState.Connected` yourself. You can still derive your own boolean from `state$` with `map` if you need different rules.
 
-**`lines$` (newline framing)** — built in; for non-standard delimiters, frame on `receive$` (recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
+**`lines$` (newline framing)** — built in; for non-standard delimiters, frame on `receive$` (recipes in [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing)).
 
 ### Minimal example
 
@@ -91,15 +91,15 @@ session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();
 ```
 
-In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscribe({ error })` (errors are also on `errors$`). A fuller walkthrough is in [Quick Start](./QUICK_START.md).
+In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscribe({ error })` (errors are also on `errors$`). A fuller walkthrough is in [Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md).
 
 ## Documentation index
 
 | Doc | Use it for |
 | --- | --- |
 | **Repository [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md)** | Monorepo overview, examples index, and contribution links. |
-| **[Quick Start](./QUICK_START.md)** | Shortest path to a working open port and subscriptions. |
-| **[Advanced Usage](./ADVANCED_USAGE.md)** | Line framing, request/response-style flows, and recovery. |
-| **[API Reference](./API_REFERENCE.md)** | Options, `SerialSessionState`, and `SerialError` details. |
-| **[v1 → v2 Migration Guide](./MIGRATION_V2.md)** | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
-| **[Phase 5 archive (legacy v1 doc)](./archive/MIGRATION_PHASE5.md)** | Historical v1 context only. |
+| **[Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md)** | Shortest path to a working open port and subscriptions. |
+| **[Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)** | Line framing, request/response-style flows, and recovery. |
+| **[API Reference](modules.html)** | Options, `SerialSessionState`, and `SerialError` details (generated TypeDoc); narrative tables also on [GitHub](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.md). |
+| **[v1 → v2 Migration Guide](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md)** | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
+| **[Phase 5 archive (legacy v1 doc)](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.md)** | Historical v1 context only. |


### PR DESCRIPTION
## Summary

GitHub Pages（`gurezo.github.io/web-serial-rxjs/`）のトップから `media/*.md` へ遷移すると生の Markdown が表示される問題を解消するため、`OVERVIEW.md` / `OVERVIEW.ja.md` のリンク先を TypeDoc 生成 HTML（`modules.html`、`variables/SerialSessionState.html` 等）および GitHub 上でレンダリングされる blob URL に振り直した。`pnpm run docs` 実行時に `docs/media/` へ英語ガイドをコピーする手順を `package.json` に追加し、再生成でファイルが欠落しないようにした。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #271

## What changed?

- `packages/web-serial-rxjs/docs/OVERVIEW.md`: API 参照を TypeDoc、手順系を GitHub blob、索引テーブルに GitHub 上の API_REFERENCE への補助リンクを追加
- `packages/web-serial-rxjs/docs/OVERVIEW.ja.md`: 同方針（TypeDoc は `gurezo.github.io` 絶対 URL、`docs/media` 配置時も有効）
- `package.json`（`docs` スクリプト）: `QUICK_START` / `ADVANCED_USAGE` / `API_REFERENCE` / `MIGRATION_V2` / `MIGRATION_PHASE5` の英語版を `docs/media/` にコピー
- `docs/`: `pnpm run docs` による再生成

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm run docs` を実行する
2. `docs/index.html` を開き、API Reference / SerialSessionState / Quick Start 等のリンクが HTML または GitHub の Markdown 表示になることを確認する
3. デプロイ後、`https://gurezo.github.io/web-serial-rxjs/` で同様に確認する

## Environment (if relevant)

- Browser: Firefox（Issue 再現環境）/ 任意の Chromium 系
- OS: macOS
- web-serial-rxjs version (for verification): v2.1.0 相当
- RxJS version: v7.8.x

## Checklist

- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

### Commits

- `fix(web-serial-rxjs): correct GitHub Pages links in OVERVIEW`
- `fix(web-serial-rxjs): correct GitHub Pages links in OVERVIEW.ja`
- `fix(workspace): copy English guides into docs/media when building docs`
- `chore(workspace): regenerate TypeDoc site for GitHub Pages`

Made with [Cursor](https://cursor.com)