### PR TITLE
feat: createTerminalBuffer を追加（terminal 表示用の receive$ ヘルパー）

### DIFF
--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -14,6 +14,7 @@
  * state, read loops, or write queues themselves.
  *
  * - {@link createSerialSession} - factory for a {@link SerialSession}
+ * - {@link createTerminalBuffer} - terminal-style display text from {@link SerialSession.receive$}
  * - {@link SerialSession} - the runtime interface
  * - {@link SerialSessionOptions} - connection options
  * - {@link SerialSessionState} - `state$` payload values (const + type)
@@ -58,3 +59,6 @@ export type {
 
 export { SerialError } from './errors/serial-error';
 export { SerialErrorCode } from './errors/serial-error-code';
+
+export { createTerminalBuffer } from './terminal/create-terminal-buffer';
+export type { TerminalBuffer } from './terminal/create-terminal-buffer';

--- a/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
+++ b/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
@@ -1,0 +1,81 @@
+import { type Observable, map, scan, shareReplay } from 'rxjs';
+
+/** @internal Folded state between {@link createTerminalBuffer} emissions. */
+export interface TerminalBufferState {
+  completed: string;
+  currentLine: string;
+}
+
+/**
+ * Applies one raw decoder chunk to terminal display state.
+ * Handles `\r\n` and lone `\n` as line endings, and lone `\r` as
+ * carriage return (clear current line for redraw). Does not interpret ANSI escapes.
+ *
+ * @internal Exported for unit tests.
+ */
+export function applyTerminalChunk(
+  state: TerminalBufferState,
+  chunk: string,
+): TerminalBufferState {
+  let { completed, currentLine } = state;
+  const len = chunk.length;
+
+  for (let i = 0; i < len; i++) {
+    const c = chunk[i]!;
+    if (c === '\r') {
+      const next = i + 1 < len ? chunk[i + 1]! : '';
+      if (next === '\n') {
+        completed += currentLine + '\n';
+        currentLine = '';
+        i++;
+      } else {
+        currentLine = '';
+      }
+    } else if (c === '\n') {
+      completed += currentLine + '\n';
+      currentLine = '';
+    } else {
+      currentLine += c;
+    }
+  }
+
+  return { completed, currentLine };
+}
+
+/** @internal */
+export function terminalDisplayText(state: TerminalBufferState): string {
+  return state.completed + state.currentLine;
+}
+
+export interface TerminalBuffer {
+  /**
+   * Cumulative text suitable for terminal-style display: completed lines plus
+   * the current line, with `\r` redraws collapsed per Issue #275.
+   */
+  readonly text$: Observable<string>;
+}
+
+const initialTerminalState: TerminalBufferState = {
+  completed: '',
+  currentLine: '',
+};
+
+/**
+ * Builds a terminal-oriented text stream from {@link SerialSession.receive$} (or any
+ * `Observable<string>` of decoded chunks). Uses internal buffering so callers need not
+ * implement carriage-return collapse themselves.
+ */
+export function createTerminalBuffer(
+  receive$: Observable<string>,
+): TerminalBuffer {
+  const text$ = receive$.pipe(
+    scan(
+      (state, chunk: string) => applyTerminalChunk(state, chunk),
+      initialTerminalState,
+    ),
+    map(terminalDisplayText),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  return { text$ };
+}

--- a/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
+++ b/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
@@ -21,9 +21,9 @@ export function applyTerminalChunk(
   const len = chunk.length;
 
   for (let i = 0; i < len; i++) {
-    const c = chunk[i]!;
+    const c = chunk.charAt(i);
     if (c === '\r') {
-      const next = i + 1 < len ? chunk[i + 1]! : '';
+      const next = i + 1 < len ? chunk.charAt(i + 1) : '';
       if (next === '\n') {
         completed += currentLine + '\n';
         currentLine = '';

--- a/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
+++ b/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { Subject, firstValueFrom } from 'rxjs';
+import {
+  applyTerminalChunk,
+  createTerminalBuffer,
+  terminalDisplayText,
+  type TerminalBufferState,
+} from '../../src/terminal/create-terminal-buffer';
+
+const empty: TerminalBufferState = { completed: '', currentLine: '' };
+
+describe('applyTerminalChunk', () => {
+  it('treats A\\rB as B on one chunk', () => {
+    const s = applyTerminalChunk(empty, 'A\rB');
+    expect(terminalDisplayText(s)).toBe('B');
+  });
+
+  it('treats A\\rB when split across chunks', () => {
+    let s = applyTerminalChunk(empty, 'A');
+    expect(terminalDisplayText(s)).toBe('A');
+    s = applyTerminalChunk(s, '\rB');
+    expect(terminalDisplayText(s)).toBe('B');
+  });
+
+  it('treats CRLF as one line end', () => {
+    const s = applyTerminalChunk(empty, 'a\r\nb');
+    expect(terminalDisplayText(s)).toBe('a\nb');
+  });
+
+  it('treats lone LF as line end', () => {
+    const s = applyTerminalChunk(empty, 'a\nb');
+    expect(terminalDisplayText(s)).toBe('a\nb');
+  });
+
+  it('resolves a\\r then \\nb across chunks', () => {
+    let s = applyTerminalChunk(empty, 'a\r');
+    expect(terminalDisplayText(s)).toBe('');
+    s = applyTerminalChunk(s, '\nb');
+    expect(terminalDisplayText(s)).toBe('\nb');
+  });
+});
+
+describe('createTerminalBuffer', () => {
+  it('emits cumulative display text with carriage-return collapse', () => {
+    const receive$ = new Subject<string>();
+    const { text$ } = createTerminalBuffer(receive$);
+    const out: string[] = [];
+    text$.subscribe((t) => out.push(t));
+    receive$.next('A\rB');
+    expect(out.at(-1)).toBe('B');
+  });
+
+  it('handles mixed newlines in streamed chunks', () => {
+    const receive$ = new Subject<string>();
+    const { text$ } = createTerminalBuffer(receive$);
+    const out: string[] = [];
+    text$.subscribe((t) => out.push(t));
+    receive$.next('line1\n');
+    receive$.next('x\r\ny\r');
+    receive$.next('z\n');
+    expect(out.at(-1)).toBe('line1\nx\nz\n');
+  });
+
+  it('simulates ls-style same-line redraw without horizontal drift', () => {
+    const receive$ = new Subject<string>();
+    const { text$ } = createTerminalBuffer(receive$);
+    let last = '';
+    text$.subscribe((t) => {
+      last = t;
+    });
+    receive$.next('-rw-r--r--  1 alice  staff  123 ./foo\r');
+    receive$.next('-rw-r--r--  1 bob    staff  123 ./foo\n');
+    expect(last).toBe('-rw-r--r--  1 bob    staff  123 ./foo\n');
+    expect(last).not.toContain('alice');
+  });
+
+  it('shares replayed text$ across subscribers', async () => {
+    const receive$ = new Subject<string>();
+    const { text$ } = createTerminalBuffer(receive$);
+    const first: string[] = [];
+    text$.subscribe((t) => first.push(t));
+    receive$.next('only');
+    const late = await firstValueFrom(text$);
+    expect(late).toBe('only');
+    expect(first).toEqual(['only']);
+  });
+});


### PR DESCRIPTION
## Summary

`receive$` の raw チャンクから、`\r` による行の上書きを解釈した累積テキストを `text$` で返す `createTerminalBuffer` を追加した。親 Issue #275 で想定している raw / lines / terminal の三層のうち、子 Issue #276 の範囲（実装・単体テスト）に対応する。

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #276
- Related #275

## What changed?

- `createTerminalBuffer(receive$)` を実装（内部バッファ、`\r` / `\n` / `\r\n` の扱い）
- `text$` に `shareReplay` を適用し、同一バッファへの複数購読で状態が分岐しないようにした
- Vitest で `A\rB`、改行の混在・チャンク分割、`ls` 風の同一行 `\r` 上書き、`firstValueFrom` による遅延購読を検証
- [`packages/web-serial-rxjs/src/index.ts`](packages/web-serial-rxjs/src/index.ts) から `createTerminalBuffer` / `TerminalBuffer` を export

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: `createTerminalBuffer`、`TerminalBuffer` 型を新規 export。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm exec vitest run --config packages/web-serial-rxjs/vite.config.ts`
2. （任意）`pnpm exec nx run web-serial-rxjs:lint`

## Environment (if relevant)

- Browser: N/A（単体テストのみ）
- OS: （記載不要なら削除）
- web-serial-rxjs version (for verification): ブランチ `feat/create-terminal-buffer-276`
- RxJS version: （リポジトリの peer と同じ）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)