### PR TITLE
feat(examples): 全 example のターミナル表示を createTerminalBuffer に統一 (#278)

### DIFF
--- a/apps/example-angular/README.md
+++ b/apps/example-angular/README.md
@@ -4,7 +4,7 @@ This is an Angular example application demonstrating how to use the `@gurezo/web
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, raw receive via `receive$` for on-screen mirror (interactive shells / `\r` progress), connection UI via `isConnected$`, send, disconnect. Line-only parsing uses `lines$` from the library docs when needed. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, display via `terminalText$` (`createTerminalBuffer(session.receive$).text$` for `\r`-safe shells), optional line logging with `lines$`, UI via `isConnected$`, send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -79,7 +79,7 @@ This example uses Angular Services and RxJS observables to handle serial port co
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port via the service's `send$` method.
 
-5. **Data Receiving**: The service exposes the session's `lines$` (one string per line); the component appends each line to the textarea. The UI uses `isConnected$` for enable/disable. Raw chunks use `receive$` (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+5. **Data Receiving**: The service exposes **`terminalText$`** (`createTerminalBuffer` over `receive$`) for textarea display (carriage-return redraws collapsed). **`lines$`** is for newline-delimited logging or parsers only—not for raw terminal mirrors. Raw chunks use **`receive$`** directly (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 
 ## Code Structure
 

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -41,11 +41,9 @@ export class App {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((v) => this.isConnected.set(v));
 
-    this.serialService.receive$
+    this.serialService.terminalText$
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((chunk) => {
-        this.receivedData.update((prev) => prev + chunk);
-      });
+      .subscribe((text) => this.receivedData.set(text));
 
     this.serialService.errors$
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -93,6 +91,7 @@ export class App {
 
   handleConnect(): void {
     this.receivedData.set('');
+    this.serialService.bumpTerminalBufferEpoch();
     this.errorMessage.set(null);
     this.serialService.connect$(this.baudRate).subscribe({
       error: (error: unknown) => {
@@ -132,6 +131,7 @@ export class App {
   }
 
   clearReceivedData(): void {
+    this.serialService.bumpTerminalBufferEpoch();
     this.receivedData.set('');
   }
 }

--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -183,6 +183,27 @@ describe('SerialClientService', () => {
     await expect(pending).resolves.toBe('chunk-1');
   });
 
+  it('should fold carriage returns in terminalText$', () => {
+    const mock = latestMock();
+    const values: string[] = [];
+    const sub = service.terminalText$.subscribe((t) => values.push(t));
+    mock.receiveSubject.next('A\r');
+    mock.receiveSubject.next('B');
+    expect(values.at(-1)).toBe('B');
+    sub.unsubscribe();
+  });
+
+  it('bumpTerminalBufferEpoch starts a fresh terminal fold for the same session', () => {
+    const mock = latestMock();
+    const values: string[] = [];
+    const sub = service.terminalText$.subscribe((t) => values.push(t));
+    mock.receiveSubject.next('leftover');
+    service.bumpTerminalBufferEpoch();
+    mock.receiveSubject.next('new');
+    expect(values.at(-1)).toBe('new');
+    sub.unsubscribe();
+  });
+
   it('should forward errors$ emissions', async () => {
     const mock = latestMock();
     const pending = firstValueFrom(service.errors$);

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -1,22 +1,33 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import {
   createSerialSession,
+  createTerminalBuffer,
   SerialError,
   SerialSession,
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import { Observable, ReplaySubject, switchMap } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  Observable,
+  ReplaySubject,
+  switchMap,
+} from 'rxjs';
 
-/** v2 SerialSession を薄くラップ。ターミナル表示向けに生受信 `receive$` を公開。 */
+/** v2 SerialSession を薄くラップ。表示は `terminalText$`（`createTerminalBuffer`）、`receive$` は raw。 */
 @Injectable({ providedIn: 'root' })
 export class SerialClientService implements OnDestroy {
   private readonly sessions$ = new ReplaySubject<SerialSession>(1);
+  /** 同一セッションでも表示バッファだけ切り替え（クリア・再接続）するための世代。 */
+  private readonly terminalBufferEpoch$ = new BehaviorSubject(0);
   private currentSession: SerialSession;
   private currentBaudRate: number;
 
   readonly state$: Observable<SerialSessionState>;
-  /** デコード済み生チャンク（ターミナルミラー向け）。 */
+  /** デコード済み raw チャンク。textarea には `terminalText$` を参照。 */
   readonly receive$: Observable<string>;
+  /** `\r` を畳んだターミナル表示用テキスト（Issue #275 `createTerminalBuffer`）。 */
+  readonly terminalText$: Observable<string>;
   readonly isConnected$: Observable<boolean>;
   readonly errors$: Observable<SerialError>;
 
@@ -30,6 +41,12 @@ export class SerialClientService implements OnDestroy {
     this.state$ = this.sessions$.pipe(switchMap((session) => session.state$));
     this.receive$ = this.sessions$.pipe(
       switchMap((session) => session.receive$),
+    );
+    this.terminalText$ = combineLatest([
+      this.sessions$,
+      this.terminalBufferEpoch$,
+    ]).pipe(
+      switchMap(([session]) => createTerminalBuffer(session.receive$).text$),
     );
     this.isConnected$ = this.sessions$.pipe(
       switchMap((session) => session.isConnected$),
@@ -61,5 +78,10 @@ export class SerialClientService implements OnDestroy {
 
   send$(data: string | Uint8Array): Observable<void> {
     return this.currentSession.send$(data);
+  }
+
+  /** `createTerminalBuffer` の累積を捨て、以降の受信のみ表示する（textarea クリア・再接続時）。 */
+  bumpTerminalBufferEpoch(): void {
+    this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
   }
 }

--- a/apps/example-react/README.md
+++ b/apps/example-react/README.md
@@ -1,10 +1,10 @@
 # React Example
 
-This is a minimal React example for the v2 `SerialSession` API (Web Serial). The `useSerialSession` hook maps `state$` / `isConnected$` / `errors$` into React state and appends **raw decoder chunks** from `receive$` for terminal-like output (preserves `\r` redraws).
+This is a minimal React example for the v2 `SerialSession` API (Web Serial). The `useSerialSession` hook maps `state$` / `isConnected$` / `errors$` into React state and binds **`receivedData`** to `createTerminalBuffer(session.receive$).text$` so `\r` redraws (e.g. `ls -la`) stay aligned. Use **`lines$`** only for newline-delimited logs or parsers, not as the primary terminal view.
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Connect, receive via `receive$`, send, and disconnect only. Use built-in `lines$` separately when you need newline-delimited parsing only. For richer recipes, see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Connect, display from `createTerminalBuffer(receive$)`, send, and disconnect. Use built-in `lines$` only when you need newline-delimited parsing or logging—not for interactive terminal mirrors. For richer recipes, see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -12,7 +12,7 @@ This is a minimal React example for the v2 `SerialSession` API (Web Serial). The
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
-- Receive terminal-oriented output via `receive$` (raw chunks)
+- Receive terminal-oriented display text via `createTerminalBuffer(receive$)` (see `receivedData`); raw chunks remain on `receive$`
 - Unified error channel via `errors$`
 - Full TypeScript type safety
 
@@ -64,7 +64,7 @@ The example uses the v2 `SerialSession` API directly:
 2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`. When the baud rate changes between calls, the hook transparently creates a new `SerialSession` so subsequent streams reflect the new port configuration.
 3. **State UI**: The hook subscribes to `session.state$` and `session.isConnected$`. `App.tsx` uses `SerialSessionState` for status text and `isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.
-5. **Receiving**: `session.lines$` emits one complete line at a time; the hook appends each line (with a trailing newline for display) to `receivedData`. Use `receive$` only when you need raw chunks (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+5. **Receiving**: The hook subscribes to **`createTerminalBuffer(session.receive$).text$`** and mirrors the result in `receivedData` (carriage-return safe). Use **`lines$`** for complete-line logging or simple parsers; it drops lone `\r` behavior (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 6. **Errors**: All connect/read/write/close failures are multiplexed through `session.errors$` and surfaced as the hook's `errorMessage` state. No per-call try/catch wrappers are needed.
 
 ## Code Structure

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -126,7 +126,7 @@ describe('useSerialSession', () => {
     expect(result.current.state).toBe(SS.Connected);
   });
 
-  it('receive$ のチャンクが receivedData に累積する', () => {
+  it('receive$ のチャンクは createTerminalBuffer 経由で receivedData に反映される', () => {
     const { result } = renderHook(() => useSerialSession());
     act(() => {
       latestMock().receiveSubject.next('foo');

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,13 +1,14 @@
 import {
   createSerialSession,
+  createTerminalBuffer,
   SerialSessionState,
   type SerialError,
   type SerialSession,
 } from '@gurezo/web-serial-rxjs';
 import { useEffect, useRef, useState } from 'react';
-import { Observable, ReplaySubject, Subscription, switchMap } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, ReplaySubject, Subscription, switchMap } from 'rxjs';
 
-/** v2 `SerialSession` を薄くラップ。ターミナル表示向けに生受信 `receive$` を連結。 */
+/** v2 `SerialSession` を薄くラップ。表示は `createTerminalBuffer(receive$).text$`（再接続時は世代でリセット）。 */
 export interface UseSerialSessionReturn {
   browserSupported: boolean;
   state: SerialSessionState;
@@ -25,6 +26,7 @@ export function useSerialSession(
 ): UseSerialSessionReturn {
   const sessionsRef = useRef<ReplaySubject<SerialSession> | null>(null);
   const sessionRef = useRef<SerialSession | null>(null);
+  const terminalBufferEpoch$ = useRef(new BehaviorSubject(0));
   const baudRateRef = useRef<number>(initialBaudRate);
   if (sessionsRef.current === null) {
     sessionRef.current = createSerialSession({ baudRate: initialBaudRate });
@@ -59,11 +61,12 @@ export function useSerialSession(
         .subscribe((next) => setIsConnected(next)),
     );
     sub.add(
-      sessions$
-        .pipe(switchMap((s) => s.receive$))
-        .subscribe((chunk) =>
-          setReceivedData((prev) => prev + chunk),
-        ),
+      combineLatest([
+        sessions$,
+        terminalBufferEpoch$.current,
+      ])
+        .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+        .subscribe(setReceivedData),
     );
     sub.add(
       sessions$
@@ -79,13 +82,19 @@ export function useSerialSession(
     };
   }, []);
 
+  const bumpTerminalBufferEpoch = (): void => {
+    const b = terminalBufferEpoch$.current;
+    b.next(b.value + 1);
+  };
+
   const connect$ = (baudRate?: number): Observable<void> => {
+    setReceivedData('');
+    bumpTerminalBufferEpoch();
     if (baudRate !== undefined && baudRate !== baudRateRef.current) {
       baudRateRef.current = baudRate;
       const next = createSerialSession({ baudRate });
       sessionRef.current = next;
       sessionsRef.current?.next(next);
-      setReceivedData('');
     }
     return (sessionRef.current as SerialSession).connect$();
   };
@@ -93,7 +102,10 @@ export function useSerialSession(
     (sessionRef.current as SerialSession).disconnect$();
   const send$ = (data: string | Uint8Array): Observable<void> =>
     (sessionRef.current as SerialSession).send$(data);
-  const clearReceivedData = (): void => setReceivedData('');
+  const clearReceivedData = (): void => {
+    bumpTerminalBufferEpoch();
+    setReceivedData('');
+  };
 
   return {
     browserSupported,

--- a/apps/example-svelte/README.md
+++ b/apps/example-svelte/README.md
@@ -1,10 +1,10 @@
 # Svelte Example
 
-This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSession` wraps `state$` / `isConnected$` / `errors$` into `readable` stores and appends **raw decoder chunks** from `receive$` for terminal-like output.
+This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSession` wraps `state$` / `isConnected$` / `errors$` into `readable` stores and binds **`receivedData`** to `createTerminalBuffer(session.receive$).text$` for `\r`-safe terminal display.
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Connect, receive via `receive$`, send, disconnect only. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Connect, terminal display via `createTerminalBuffer(receive$)`, send, disconnect. Use `lines$` only for line-delimited logging or parsing—not for primary shell output. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -12,7 +12,7 @@ This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSessi
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
-- Receive terminal-oriented output via `receive$` (raw chunks)
+- Receive terminal-oriented display text via `createTerminalBuffer(receive$)`
 - Unified error channel via `errors$`
 - Full TypeScript type safety
 
@@ -64,7 +64,7 @@ The example uses the v2 `SerialSession` API directly:
 2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`. When the baud rate changes between calls, the helper transparently creates a new `SerialSession` so subsequent streams reflect the new port configuration.
 3. **State UI**: The helper subscribes to `session.state$` and `session.isConnected$`. `App.svelte` branches on `SerialSessionState` for status and uses `$isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.
-5. **Receiving**: `session.lines$` emits one line at a time; the store appends each line for display. Raw chunk streaming uses `receive$` (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+5. **Receiving**: The store reflects **`createTerminalBuffer(session.receive$).text$`** in `receivedData`. **`lines$`** is for one-line-at-a-time logging or newline-only parsing; raw chunk streaming without terminal folding uses `receive$` (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 6. **Errors**: All connect/read/write/close failures are multiplexed through `session.errors$` and surfaced as the `errorMessage` store. No per-call try/catch wrappers are needed.
 
 ## Code Structure

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -152,7 +152,7 @@ describe('useSerialSession', () => {
     unsub();
   });
 
-  it('receive$ のチャンクが receivedData に累積する', () => {
+  it('receive$ のチャンクは createTerminalBuffer 経由で receivedData に反映される', () => {
     const s = useSerialSession();
     const unsub = s.receivedData.subscribe(() => void 0);
     latestMock().receiveSubject.next('foo');

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,14 +1,22 @@
 import {
   createSerialSession,
+  createTerminalBuffer,
   SerialSessionState,
   type SerialError,
   type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import { type Observable, ReplaySubject, Subscription, switchMap } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  type Observable,
+  ReplaySubject,
+  Subscription,
+  switchMap,
+} from 'rxjs';
 import { onDestroy } from 'svelte';
 import { readable, type Readable } from 'svelte/store';
 
-/** v2 `SerialSession` を Svelte store に薄く写す。ターミナル表示は `receive$` を連結。 */
+/** v2 `SerialSession` を Svelte store に薄く写す。表示は `createTerminalBuffer(receive$).text$`（再接続は世代でリセット）。 */
 export interface UseSerialSessionReturn {
   browserSupported: Readable<boolean>;
   state: Readable<SerialSessionState>;
@@ -29,6 +37,7 @@ export function useSerialSession(
     baudRate: initialBaudRate,
   });
   const sessions$ = new ReplaySubject<SerialSession>(1);
+  const terminalBufferEpoch$ = new BehaviorSubject(0);
   sessions$.next(currentSession);
 
   const browserSupported = readable(currentSession.isBrowserSupported());
@@ -47,16 +56,16 @@ export function useSerialSession(
     return () => sub.unsubscribe();
   });
 
-  let receivedAcc = '';
+  const bumpTerminalBufferEpoch = (): void => {
+    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
+  };
+
   let setReceived: ((value: string) => void) | null = null;
   const receivedData = readable<string>('', (set) => {
     setReceived = set;
-    const sub = sessions$
-      .pipe(switchMap((s) => s.receive$))
-      .subscribe((chunk) => {
-        receivedAcc += chunk;
-        set(receivedAcc);
-      });
+    const sub = combineLatest([sessions$, terminalBufferEpoch$])
+      .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+      .subscribe(set);
     return () => {
       sub.unsubscribe();
       setReceived = null;
@@ -87,11 +96,11 @@ export function useSerialSession(
   });
 
   const connect$ = (baudRate?: number): Observable<void> => {
+    bumpTerminalBufferEpoch();
+    setReceived?.('');
     if (baudRate !== undefined && baudRate !== currentBaudRate) {
       currentBaudRate = baudRate;
       currentSession = createSerialSession({ baudRate });
-      receivedAcc = '';
-      setReceived?.('');
       sessions$.next(currentSession);
     }
     return currentSession.connect$();
@@ -103,7 +112,7 @@ export function useSerialSession(
     currentSession.send$(data);
 
   const clearReceivedData = (): void => {
-    receivedAcc = '';
+    bumpTerminalBufferEpoch();
     setReceived?.('');
   };
 

--- a/apps/example-vanilla-js/README.md
+++ b/apps/example-vanilla-js/README.md
@@ -4,7 +4,7 @@ This is a vanilla JavaScript example application demonstrating how to use the `@
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, raw receive via `receive$`, UI toggles via `isConnected$`, send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, display via `createTerminalBuffer(receive$)` (session-following subscription), UI toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-delimited logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -77,7 +77,7 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array`.
 
-5. **Data Receiving**: Data received from the serial port is decoded as UTF-8 and displayed in real-time in the textarea.
+5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`createTerminalBuffer(session.receive$).text$`** into the textarea. **`lines$`** is for line-oriented logs, not raw `\r`-heavy shell output.
 
 ## Code Structure
 

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,5 +1,10 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import { createSerialSession, SerialSessionState } from '@gurezo/web-serial-rxjs';
+import {
+  createSerialSession,
+  createTerminalBuffer,
+  SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+import { BehaviorSubject, combineLatest, ReplaySubject, switchMap } from 'rxjs';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -35,13 +40,18 @@ export class App {
     const receiveOutput = $('receive-output');
     this.baudRate = parseInt(baudRateSelect.value, 10);
     this.session = createSerialSession({ baudRate: this.baudRate });
+    this.sessions$ = new ReplaySubject(1);
+    this.terminalBufferEpoch$ = new BehaviorSubject(0);
+    this.sessions$.next(this.session);
+
     const supported = this.session.isBrowserSupported();
     setStatus(
       $('browser-support-status'),
       supported ? 'success' : 'error',
       supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
-    this.session.state$.subscribe((state) => {
+
+    this.sessions$.pipe(switchMap((s) => s.state$)).subscribe((state) => {
       const connected = state === SerialSessionState.Connected;
       const busy =
         state === SerialSessionState.Connecting ||
@@ -50,30 +60,44 @@ export class App {
       baudRateSelect.disabled = connected || busy;
       setStatus(status, ...STATUS[state]);
     });
-    this.session.isConnected$.subscribe((isConnected) => {
-      disconnectBtn.disabled = !isConnected;
-      sendInput.disabled = sendBtn.disabled = !isConnected;
-    });
-    this.session.receive$.subscribe((chunk) => {
-      receiveOutput.value += chunk;
-      receiveOutput.scrollTop = receiveOutput.scrollHeight;
-    });
-    this.session.errors$.subscribe((error) => {
-      setStatus(status, 'error', `エラー: ${error.message}`);
-      console.error('Serial port error:', error);
-    });
+
+    this.sessions$
+      .pipe(switchMap((s) => s.isConnected$))
+      .subscribe((isConnected) => {
+        disconnectBtn.disabled = !isConnected;
+        sendInput.disabled = sendBtn.disabled = !isConnected;
+      });
+
+    combineLatest([this.sessions$, this.terminalBufferEpoch$])
+      .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+      .subscribe((text) => {
+        receiveOutput.value = text;
+        receiveOutput.scrollTop = receiveOutput.scrollHeight;
+      });
+
+    this.sessions$
+      .pipe(switchMap((s) => s.errors$))
+      .subscribe((error) => {
+        setStatus(status, 'error', `エラー: ${error.message}`);
+        console.error('Serial port error:', error);
+      });
+
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
+      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+      receiveOutput.value = '';
       if (baudRate !== this.baudRate) {
         this.baudRate = baudRate;
         this.session = createSerialSession({ baudRate });
+        this.sessions$.next(this.session);
       }
-      receiveOutput.value = '';
       this.session.connect$().subscribe({ error: () => void 0 });
     });
+
     fromEvent(disconnectBtn, 'click').subscribe(() =>
       this.session.disconnect$().subscribe({ error: () => void 0 }),
     );
+
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
@@ -82,6 +106,7 @@ export class App {
         error: () => void 0,
       });
     };
+
     fromEvent(sendBtn, 'click').subscribe(send);
     fromEvent(sendInput, 'keydown')
       .pipe(filter((e) => e.key === 'Enter' && !e.shiftKey))
@@ -89,8 +114,10 @@ export class App {
         e.preventDefault();
         send();
       });
-    fromEvent($('clear-receive-btn'), 'click').subscribe(
-      () => (receiveOutput.value = ''),
-    );
+
+    fromEvent($('clear-receive-btn'), 'click').subscribe(() => {
+      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+      receiveOutput.value = '';
+    });
   }
 }

--- a/apps/example-vanilla-ts/README.md
+++ b/apps/example-vanilla-ts/README.md
@@ -4,7 +4,7 @@ This is a vanilla TypeScript example application demonstrating how to use the `@
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, raw receive via `receive$`, UI toggles via `isConnected$`, send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, display via `createTerminalBuffer(receive$)` (session-following subscription), UI toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-delimited logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -78,7 +78,7 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array`.
 
-5. **Data Receiving**: Data received from the serial port is decoded as UTF-8 and displayed in real-time in the textarea.
+5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`createTerminalBuffer(session.receive$).text$`** into the textarea so `\r`-based redraws (e.g. shell progress) stay aligned. Raw streaming without terminal folding uses `receive$`; **`lines$`** remains for line-oriented logs.
 
 ## Code Structure
 

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,9 +1,16 @@
 import {
   createSerialSession,
+  createTerminalBuffer,
   SerialSessionState,
   type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import { fromEvent } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  fromEvent,
+  ReplaySubject,
+  switchMap,
+} from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 type StatusType = 'info' | 'success' | 'error';
@@ -34,6 +41,12 @@ const setStatus = (el: HTMLElement, type: StatusType, msg: string): void => {
 export class App {
   private session: SerialSession;
   private baudRate: number;
+  private readonly sessions$ = new ReplaySubject<SerialSession>(1);
+  private readonly terminalBufferEpoch$ = new BehaviorSubject(0);
+
+  private bumpTerminalBufferEpoch(): void {
+    this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+  }
 
   constructor() {
     const connectBtn = $<HTMLButtonElement>('connect-btn');
@@ -45,43 +58,60 @@ export class App {
     const receiveOutput = $<HTMLTextAreaElement>('receive-output');
     this.baudRate = parseInt(baudRateSelect.value, 10);
     this.session = createSerialSession({ baudRate: this.baudRate });
+    this.sessions$.next(this.session);
+
     const supported = this.session.isBrowserSupported();
     setStatus(
       $<HTMLElement>('browser-support-status'),
       supported ? 'success' : 'error',
       supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
-    this.session.state$.subscribe((state) => {
+
+    this.sessions$.pipe(switchMap((s) => s.state$)).subscribe((state) => {
       const connected = state === S.Connected;
       const busy = state === S.Connecting || state === S.Disconnecting;
       connectBtn.disabled = !supported || connected || busy;
       baudRateSelect.disabled = connected || busy;
       setStatus(status, ...STATUS[state]);
     });
-    this.session.isConnected$.subscribe((isConnected) => {
-      disconnectBtn.disabled = !isConnected;
-      sendInput.disabled = sendBtn.disabled = !isConnected;
-    });
-    this.session.receive$.subscribe((chunk) => {
-      receiveOutput.value += chunk;
-      receiveOutput.scrollTop = receiveOutput.scrollHeight;
-    });
-    this.session.errors$.subscribe((error) => {
-      setStatus(status, 'error', `エラー: ${error.message}`);
-      console.error('Serial port error:', error);
-    });
+
+    this.sessions$
+      .pipe(switchMap((s) => s.isConnected$))
+      .subscribe((isConnected) => {
+        disconnectBtn.disabled = !isConnected;
+        sendInput.disabled = sendBtn.disabled = !isConnected;
+      });
+
+    combineLatest([this.sessions$, this.terminalBufferEpoch$])
+      .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+      .subscribe((text) => {
+        receiveOutput.value = text;
+        receiveOutput.scrollTop = receiveOutput.scrollHeight;
+      });
+
+    this.sessions$
+      .pipe(switchMap((s) => s.errors$))
+      .subscribe((error) => {
+        setStatus(status, 'error', `エラー: ${error.message}`);
+        console.error('Serial port error:', error);
+      });
+
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
+      this.bumpTerminalBufferEpoch();
+      receiveOutput.value = '';
       if (baudRate !== this.baudRate) {
         this.baudRate = baudRate;
         this.session = createSerialSession({ baudRate });
+        this.sessions$.next(this.session);
       }
-      receiveOutput.value = '';
       this.session.connect$().subscribe({ error: () => void 0 });
     });
+
     fromEvent(disconnectBtn, 'click').subscribe(() =>
       this.session.disconnect$().subscribe({ error: () => void 0 }),
     );
+
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
@@ -90,6 +120,7 @@ export class App {
         error: () => void 0,
       });
     };
+
     fromEvent(sendBtn, 'click').subscribe(send);
     fromEvent<KeyboardEvent>(sendInput, 'keydown')
       .pipe(filter((e) => e.key === 'Enter' && !e.shiftKey))
@@ -97,8 +128,10 @@ export class App {
         e.preventDefault();
         send();
       });
-    fromEvent($<HTMLButtonElement>('clear-receive-btn'), 'click').subscribe(
-      () => (receiveOutput.value = ''),
-    );
+
+    fromEvent($<HTMLButtonElement>('clear-receive-btn'), 'click').subscribe(() => {
+      this.bumpTerminalBufferEpoch();
+      receiveOutput.value = '';
+    });
   }
 }

--- a/apps/example-vue/README.md
+++ b/apps/example-vue/README.md
@@ -4,7 +4,7 @@ This is a Vue example application demonstrating how to use the `@gurezo/web-seri
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, raw receive via `receive$` for terminal-style display, connection toggles via `isConnected$`, send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, terminal display via `createTerminalBuffer(receive$)`, connection toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-based logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -79,7 +79,7 @@ This example uses Vue 3 Composition API and RxJS observables to handle serial po
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array` through the composable's `send` method.
 
-5. **Data Receiving**: Data received from the serial port is decoded as UTF-8 and displayed in real-time in the textarea. The received data is managed as Vue reactive state in the composable.
+5. **Data Receiving**: Incoming bytes are decoded as UTF-8; the composable surfaces **`createTerminalBuffer(session.receive$).text$`** into the textarea-bound ref. Use **`lines$`** for newline-delimited logs—not for interactive shell mirrors where `\r` redraw matters.
 
 ## Code Structure
 

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -193,7 +193,7 @@ describe('useSerialClient', () => {
     expect(latestMock().send$).toHaveBeenCalledWith('hello');
   });
 
-  it('should append receive$ emissions to receivedData', () => {
+  it('should map receive$ via createTerminalBuffer to receivedData', () => {
     const { api } = mountHarness();
     const mock = latestMock();
 

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,13 +1,20 @@
 import {
   createSerialSession,
+  createTerminalBuffer,
   SerialSessionState,
   type SerialError,
   type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import { Observable, ReplaySubject, switchMap } from 'rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  Observable,
+  ReplaySubject,
+  switchMap,
+} from 'rxjs';
 import { onUnmounted, ref, type Ref } from 'vue';
 
-/** v2 `SerialSession` を薄くラップ。ターミナル表示向けに生受信 `receive$` を連結。 */
+/** v2 `SerialSession` を薄くラップ。表示は `createTerminalBuffer(receive$).text$`（再接続は世代でリセット）。 */
 export interface UseSerialClientReturn {
   browserSupported: Ref<boolean>;
   state: Ref<SerialSessionState>;
@@ -28,6 +35,11 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
   let currentBaudRate = initialBaudRate;
   sessions$.next(currentSession);
 
+  const terminalBufferEpoch$ = new BehaviorSubject(0);
+  const bumpTerminalBufferEpoch = (): void => {
+    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
+  };
+
   const browserSupported = ref(currentSession.isBrowserSupported());
   const state = ref<SerialSessionState>(SerialSessionState.Idle);
   const isConnected = ref(false);
@@ -47,10 +59,10 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     .subscribe((next) => {
       isConnected.value = next;
     });
-  const receiveSub = sessions$
-    .pipe(switchMap((session) => session.receive$))
-    .subscribe((chunk) => {
-      receivedData.value = `${receivedData.value}${chunk}`;
+  const receiveSub = combineLatest([sessions$, terminalBufferEpoch$])
+    .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+    .subscribe((text) => {
+      receivedData.value = text;
     });
   const errorsSub = sessions$
     .pipe(switchMap((session) => session.errors$))
@@ -59,11 +71,12 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     });
 
   const connect$ = (baudRate?: number): Observable<void> => {
+    bumpTerminalBufferEpoch();
+    receivedData.value = '';
     if (baudRate !== undefined && baudRate !== currentBaudRate) {
       currentBaudRate = baudRate;
       currentSession = createSerialSession({ baudRate });
       sessions$.next(currentSession);
-      receivedData.value = '';
     }
     return currentSession.connect$();
   };
@@ -71,6 +84,7 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
   const send$ = (data: string | Uint8Array): Observable<void> =>
     currentSession.send$(data);
   const clearReceivedData = (): void => {
+    bumpTerminalBufferEpoch();
     receivedData.value = '';
   };
 


### PR DESCRIPTION
## Summary
Issue #278 に対応し、全 example の受信表示を `receive$` 上の `createTerminalBuffer(...).text$` に統一しました。`ls -la` のような `\r` を含む出力のずれを防ぎ、`lines$` は行ログ・パース用途として README で説明を揃えました。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Closes #278

## What changed?
- Angular: `SerialClientService` に `terminalText$` と `bumpTerminalBufferEpoch()` を追加し、コンポーネントはチャンク連結ではなくターミナルテキスト全体を表示
- React / Svelte / Vue: `combineLatest` + epoch で `createTerminalBuffer` を再接続・クリア時に切り替え
- Vanilla JS/TS: `ReplaySubject` と `switchMap` でセッションおよびターミナル表示を追従
- 各 example の README を `lines$` 誤記から修正
- Angular spec に `\r` と bump のテストを追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

公開パッケージの API 変更はありません（examples のみ）。

## How to test
1. Chromium 系ブラウザで `nx serve example-*` のいずれかを起動する
2. シリアル接続後、シェルで `ls -la` 等を実行し、受信 textarea の列が崩れないことを確認する
3. 「受信クリア」および切断→再接続後、表示が意図どおりリセットされることを確認する

## Environment (if relevant)
- Browser: Chrome / Edge（Web Serial 対応版）
- OS: macOS / Windows / Linux
- web-serial-rxjs: ワークスペースのパッケージ
- RxJS: モノレポの依存に従う

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)