### PR TITLE
test(web-serial-rxjs): terminal 表示のテストケースを追加 (#279)

### DIFF
--- a/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
+++ b/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
@@ -9,7 +9,9 @@ import {
 
 const empty: TerminalBufferState = { completed: '', currentLine: '' };
 
+/** Issue #279: terminal 表示の再発防止用テストケース群 */
 describe('applyTerminalChunk', () => {
+  // A\rB → B（同一行の carriage-return 上書き）
   it('treats A\\rB as B on one chunk', () => {
     const s = applyTerminalChunk(empty, 'A\rB');
     expect(terminalDisplayText(s)).toBe('B');
@@ -22,12 +24,14 @@ describe('applyTerminalChunk', () => {
     expect(terminalDisplayText(s)).toBe('B');
   });
 
-  it('treats CRLF as one line end', () => {
+  // A\r\nB → 正常改行（CRLF は 1 行末として扱う）
+  it('renders A\\r\\nB as normal newline (issue #279)', () => {
     const s = applyTerminalChunk(empty, 'a\r\nb');
     expect(terminalDisplayText(s)).toBe('a\nb');
   });
 
-  it('treats lone LF as line end', () => {
+  // A\nB → 2 行表示（論理行が LF で区切られる）
+  it('renders A\\nB as two display lines (issue #279)', () => {
     const s = applyTerminalChunk(empty, 'a\nb');
     expect(terminalDisplayText(s)).toBe('a\nb');
   });
@@ -41,7 +45,8 @@ describe('applyTerminalChunk', () => {
 });
 
 describe('createTerminalBuffer', () => {
-  it('emits cumulative display text with carriage-return collapse', () => {
+  // A\rB → B（text$ 経由でも累積表示が一致すること）
+  it('emits cumulative display text with carriage-return collapse (issue #279)', () => {
     const receive$ = new Subject<string>();
     const { text$ } = createTerminalBuffer(receive$);
     const out: string[] = [];
@@ -61,7 +66,8 @@ describe('createTerminalBuffer', () => {
     expect(out.at(-1)).toBe('line1\nx\nz\n');
   });
 
-  it('simulates ls-style same-line redraw without horizontal drift', () => {
+  // ls -la 形式: 同一行の \r 上書きで列がずれないこと
+  it('simulates ls-style same-line redraw without horizontal drift (issue #279)', () => {
     const receive$ = new Subject<string>();
     const { text$ } = createTerminalBuffer(receive$);
     let last = '';

--- a/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
+++ b/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
@@ -74,6 +74,22 @@ describe('createTerminalBuffer', () => {
     expect(last).not.toContain('alice');
   });
 
+  it('shows shell prompt ($ / #) after carriage-return redraw', () => {
+    const receive$ = new Subject<string>();
+    const { text$ } = createTerminalBuffer(receive$);
+    let last = '';
+    text$.subscribe((t) => {
+      last = t;
+    });
+    receive$.next('login: user\r');
+    receive$.next('$ ');
+    expect(last).toBe('$ ');
+    receive$.next('whoami\r\n');
+    receive$.next('user\r\n');
+    receive$.next('# ');
+    expect(last.endsWith('# ')).toBe(true);
+  });
+
   it('shares replayed text$ across subscribers', async () => {
     const receive$ = new Subject<string>();
     const { text$ } = createTerminalBuffer(receive$);


### PR DESCRIPTION
## Summary

親 Issue #275 の Sub Issue #279 に対応し、`createTerminalBuffer` の terminal 表示まわりを Issue の完了条件どおりテストで明示し、プロンプト（`$` / `#`）を含む `\r` 上書きシナリオの再発防止を追加した。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #279
- Related #275

## What changed?

- `shows shell prompt ($ / #) after carriage-return redraw` を追加（`text$` でログイン後プロンプトと root プロンプトの累積表示を検証）
- Issue #279 の完了条件に合わせ、`A\r\nB` / `A\nB` / `ls -la` 風 / `A\rB`（`text$`）のテスト名・コメントを整理

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm exec nx run web-serial-rxjs:test`
2. （任意）`pnpm exec nx run web-serial-rxjs:lint`

## Environment (if relevant)

- Browser: N/A（単体テストのみ）
- OS: （記載不要）
- web-serial-rxjs version (for verification): ブランチ `test/279-terminal-display-cases`
- RxJS version: （リポジトリの peer と同じ）

## Checklist

- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)
