### PR TITLE
chore(release): v2.2.0 へのバージョン更新

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Issue #280 への対応として、`@gurezo/web-serial-rxjs` のバージョンを `2.1.0` から `2.2.0` に更新しました。
リリース準備として、パッケージ版数を最新化しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #280

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `2.1.0` から `2.2.0` に更新
- 変更後にワークスペーステストとライブラリビルドを実行して確認

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm test` を実行
2. `pnpm exec nx build web-serial-rxjs` を実行
3. いずれも成功することを確認

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / etc. (version: N/A)
- OS: macOS
- web-serial-rxjs version (for verification): 2.2.0
- RxJS version: ^7.8.0

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)