### PR TITLE
feat(web-serial-rxjs): SerialSessionにterminalText

### DIFF
--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -10,7 +10,7 @@
  *
  * The v2 public API intentionally exposes a single, session-oriented surface
  * so that apps (Angular, Vue, React, Svelte, vanilla JS/TS) can drive their
- * UI entirely from `state$` + `isConnected$` + `receive$` + `lines$` + `errors$` without rebuilding any
+ * UI entirely from `state$` + `isConnected$` + `receive$` + `terminalText$` + `lines$` + `errors$` without rebuilding any
  * state, read loops, or write queues themselves.
  *
  * - {@link createSerialSession} - factory for a {@link SerialSession}

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -10,6 +10,7 @@ import {
 } from 'rxjs';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
+import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
 import { buildRequestOptions } from './internal/build-request-options';
 import { hasWebSerialSupport } from './internal/has-web-serial-support';
 import { createLineBuffer } from './internal/line-buffer';
@@ -111,6 +112,7 @@ export function createSerialSession(
   const errors$ = errorsSubject.asObservable();
   const receive$ = receiveSubject.asObservable();
   const lines$ = linesSubject.asObservable();
+  const terminalText$ = createTerminalBuffer(receive$).text$;
 
   const isConnected$ = machine.state$.pipe(
     map((state) => state === SerialSessionState.Connected),
@@ -434,6 +436,7 @@ export function createSerialSession(
     },
     errors$,
     receive$,
+    terminalText$,
     receiveReplay$,
     lines$,
   };

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -7,7 +7,7 @@ import type { SerialSessionState } from './serial-session-state';
  * minimal, session-oriented surface.
  *
  * The session is intentionally slim so that apps (Angular, Vue, React, etc.)
- * can drive their UI purely from `state$` + `isConnected$` + `receive$` + `lines$` + `errors$` and never
+ * can drive their UI purely from `state$` + `isConnected$` + `receive$` + `terminalText$` + `lines$` + `errors$` and never
  * have to rebuild BehaviorSubjects, manage a read loop, or serialize writes
  * themselves.
  *
@@ -148,6 +148,21 @@ export interface SerialSession {
   readonly receive$: Observable<string>;
 
   /**
+   * Terminal-display oriented cumulative text derived from {@link receive$}.
+   *
+   * This stream collapses carriage-return redraws (`\r`) and keeps normal
+   * newline behavior (`\n`, `\r\n`) so apps can bind terminal-like output
+   * directly without wrapping {@link createTerminalBuffer} in every consumer.
+   *
+   * Equivalent behavior:
+   *
+   * ```typescript
+   * createTerminalBuffer(receive$).text$
+   * ```
+   */
+  readonly terminalText$: Observable<string>;
+
+  /**
    * Same source data as {@link receive$} but, when
    * {@link SerialSessionOptions.receiveReplay} has `enabled: true`, it uses a
    * replay buffer **per open connection** so new subscribers can receive the
@@ -164,7 +179,8 @@ export interface SerialSession {
    * Decoded text split into **complete lines** using `\n`, `\r\n`, and
    * lone interior `\r` (see implementation). Intended for **logs**,
    * newline-framed command responses, and parsers—not for mirroring raw
-   * terminal output where `\r` must be preserved for progress/redraw.
+   * terminal output where `\r` must be preserved for progress/redraw. For
+   * rendering terminal text, prefer {@link terminalText$}.
    *
    * A trailing fragment without a line terminator is buffered until a later
    * chunk completes a line, or discarded on disconnect. It is **not**

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -136,6 +136,7 @@ describe('createSerialSession', () => {
       expect(session.portInfo$).toBeDefined();
       expect(session.errors$).toBeDefined();
       expect(session.receive$).toBeDefined();
+      expect(session.terminalText$).toBeDefined();
       expect(session.receiveReplay$).toBeDefined();
       expect(session.lines$).toBeDefined();
     });
@@ -638,6 +639,63 @@ describe('createSerialSession', () => {
       await flushMicrotasks();
 
       await expect(twoLines).resolves.toEqual(['A', 'B']);
+    });
+  });
+
+  describe('terminalText$', () => {
+    it('collapses carriage-return redraw (A\\rB -> B)', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const textPromise = firstValueFrom(session.terminalText$.pipe(take(1)));
+
+      await firstValueFrom(session.connect$());
+      controller.enqueue(new TextEncoder().encode('A\rB'));
+      await flushMicrotasks();
+
+      await expect(textPromise).resolves.toBe('B');
+    });
+
+    it('handles mixed newline styles (\\n and \\r\\n)', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const latest = firstValueFrom(session.terminalText$.pipe(take(3), toArray()));
+
+      await firstValueFrom(session.connect$());
+      controller.enqueue(new TextEncoder().encode('line1\n'));
+      await flushMicrotasks();
+      controller.enqueue(new TextEncoder().encode('line2\r\n'));
+      await flushMicrotasks();
+      controller.enqueue(new TextEncoder().encode('line3\n'));
+      await flushMicrotasks();
+
+      await expect(latest).resolves.toEqual([
+        'line1\n',
+        'line1\nline2\n',
+        'line1\nline2\nline3\n',
+      ]);
+    });
+
+    it('does not alter receive$ raw chunk semantics', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const rawChunk = firstValueFrom(session.receive$.pipe(take(1)));
+      const terminalText = firstValueFrom(session.terminalText$.pipe(take(1)));
+
+      await firstValueFrom(session.connect$());
+      controller.enqueue(new TextEncoder().encode('A\rB'));
+      await flushMicrotasks();
+
+      await expect(rawChunk).resolves.toBe('A\rB');
+      await expect(terminalText).resolves.toBe('B');
     });
   });
 


### PR DESCRIPTION
## Summary
SerialSessionに terminal 表示向けの `terminalText$` を追加し、`createTerminalBuffer(receive$).text$` を内部公開するようにしました。
これによりアプリ側で terminal バッファ処理を毎回実装する必要をなくし、表示実装を簡素化します。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #287
- Refs #286

## What changed?
- `SerialSession` インターフェースに `terminalText$` を追加
- `createSerialSession` で `createTerminalBuffer(receive$).text$` を `terminalText$` として公開
- `create-serial-session` テストに `terminalText$` の挙動（`A\rB`、改行混在、`receive$` 互換）を追加

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialSession` の公開プロパティとして `terminalText$` を追加
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm nx test web-serial-rxjs` を実行し、`create-serial-session` の `terminalText$` テストが通ることを確認する
2. `pnpm nx lint web-serial-rxjs` を実行し、lintエラーがないことを確認する
3. `pnpm exec tsc --project packages/web-serial-rxjs/tsconfig.lib.json --noEmit` を実行し、型エラーがないことを確認する

## Environment (if relevant)
- Browser: N/A (unit test)
- OS: macOS
- web-serial-rxjs version (for verification): 2.2.0 (workspace)
- RxJS version: ^7.8.2

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)