### PR TITLE
refactor(examples): terminal表示をterminalText

### DIFF
--- a/apps/example-angular/README.md
+++ b/apps/example-angular/README.md
@@ -4,7 +4,7 @@ This is an Angular example application demonstrating how to use the `@gurezo/web
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, display via `terminalText$` (`createTerminalBuffer(session.receive$).text$` for `\r`-safe shells), optional line logging with `lines$`, UI via `isConnected$`, send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, display via `terminalText$` (`\r`-safe shells), optional line logging with `lines$`, UI via `isConnected$`, send, disconnect. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -79,7 +79,7 @@ This example uses Angular Services and RxJS observables to handle serial port co
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port via the service's `send$` method.
 
-5. **Data Receiving**: The service exposes **`terminalText$`** (`createTerminalBuffer` over `receive$`) for textarea display (carriage-return redraws collapsed). **`lines$`** is for newline-delimited logging or parsers only—not for raw terminal mirrors. Raw chunks use **`receive$`** directly (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+5. **Data Receiving**: The service exposes **`terminalText$`** for textarea display (carriage-return redraws collapsed). **`lines$`** is for newline-delimited logging or parsers only—not for raw terminal mirrors. Raw chunks use **`receive$`** directly (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 
 ## Code Structure
 

--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -52,6 +52,7 @@ const createMockSession = (): MockSession => {
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -1,7 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import {
   createSerialSession,
-  createTerminalBuffer,
   SerialError,
   SerialSession,
   SerialSessionState,
@@ -14,7 +13,7 @@ import {
   switchMap,
 } from 'rxjs';
 
-/** v2 SerialSession を薄くラップ。表示は `terminalText$`（`createTerminalBuffer`）、`receive$` は raw。 */
+/** v2 SerialSession を薄くラップ。表示は `terminalText$`、`receive$` は raw。 */
 @Injectable({ providedIn: 'root' })
 export class SerialClientService implements OnDestroy {
   private readonly sessions$ = new ReplaySubject<SerialSession>(1);
@@ -46,7 +45,7 @@ export class SerialClientService implements OnDestroy {
       this.sessions$,
       this.terminalBufferEpoch$,
     ]).pipe(
-      switchMap(([session]) => createTerminalBuffer(session.receive$).text$),
+      switchMap(([session]) => session.terminalText$),
     );
     this.isConnected$ = this.sessions$.pipe(
       switchMap((session) => session.isConnected$),
@@ -80,7 +79,7 @@ export class SerialClientService implements OnDestroy {
     return this.currentSession.send$(data);
   }
 
-  /** `createTerminalBuffer` の累積を捨て、以降の受信のみ表示する（textarea クリア・再接続時）。 */
+  /** `terminalText$` の表示累積をリセットし、以降の受信のみ表示する（textarea クリア・再接続時）。 */
   bumpTerminalBufferEpoch(): void {
     this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
   }

--- a/apps/example-react/README.md
+++ b/apps/example-react/README.md
@@ -1,10 +1,10 @@
 # React Example
 
-This is a minimal React example for the v2 `SerialSession` API (Web Serial). The `useSerialSession` hook maps `state$` / `isConnected$` / `errors$` into React state and binds **`receivedData`** to `createTerminalBuffer(session.receive$).text$` so `\r` redraws (e.g. `ls -la`) stay aligned. Use **`lines$`** only for newline-delimited logs or parsers, not as the primary terminal view.
+This is a minimal React example for the v2 `SerialSession` API (Web Serial). The `useSerialSession` hook maps `state$` / `isConnected$` / `errors$` into React state and binds **`receivedData`** to `session.terminalText$` so `\r` redraws (e.g. `ls -la`) stay aligned. Use **`lines$`** only for newline-delimited logs or parsers, not as the primary terminal view.
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Connect, display from `createTerminalBuffer(receive$)`, send, and disconnect. Use built-in `lines$` only when you need newline-delimited parsing or logging—not for interactive terminal mirrors. For richer recipes, see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Connect, display from `terminalText$`, send, and disconnect. Use built-in `lines$` only when you need newline-delimited parsing or logging—not for interactive terminal mirrors. For richer recipes, see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -12,7 +12,7 @@ This is a minimal React example for the v2 `SerialSession` API (Web Serial). The
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
-- Receive terminal-oriented display text via `createTerminalBuffer(receive$)` (see `receivedData`); raw chunks remain on `receive$`
+- Receive terminal-oriented display text via `terminalText$` (see `receivedData`); raw chunks remain on `receive$`
 - Unified error channel via `errors$`
 - Full TypeScript type safety
 
@@ -64,7 +64,7 @@ The example uses the v2 `SerialSession` API directly:
 2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`. When the baud rate changes between calls, the hook transparently creates a new `SerialSession` so subsequent streams reflect the new port configuration.
 3. **State UI**: The hook subscribes to `session.state$` and `session.isConnected$`. `App.tsx` uses `SerialSessionState` for status text and `isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.
-5. **Receiving**: The hook subscribes to **`createTerminalBuffer(session.receive$).text$`** and mirrors the result in `receivedData` (carriage-return safe). Use **`lines$`** for complete-line logging or simple parsers; it drops lone `\r` behavior (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+5. **Receiving**: The hook subscribes to **`session.terminalText$`** and mirrors the result in `receivedData` (carriage-return safe). Use **`lines$`** for complete-line logging or simple parsers; it drops lone `\r` behavior (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 6. **Errors**: All connect/read/write/close failures are multiplexed through `session.errors$` and surfaced as the hook's `errorMessage` state. No per-call try/catch wrappers are needed.
 
 ## Code Structure

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -47,6 +47,7 @@ const createMockSession = (): MockSession => {
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -48,6 +48,7 @@ const createMockSession = (
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
@@ -126,7 +127,7 @@ describe('useSerialSession', () => {
     expect(result.current.state).toBe(SS.Connected);
   });
 
-  it('receive$ のチャンクは createTerminalBuffer 経由で receivedData に反映される', () => {
+  it('terminalText$ の更新が receivedData に反映される', () => {
     const { result } = renderHook(() => useSerialSession());
     act(() => {
       latestMock().receiveSubject.next('foo');

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,6 +1,5 @@
 import {
   createSerialSession,
-  createTerminalBuffer,
   SerialSessionState,
   type SerialError,
   type SerialSession,
@@ -8,7 +7,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 import { BehaviorSubject, combineLatest, Observable, ReplaySubject, Subscription, switchMap } from 'rxjs';
 
-/** v2 `SerialSession` を薄くラップ。表示は `createTerminalBuffer(receive$).text$`（再接続時は世代でリセット）。 */
+/** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続時は世代でリセット）。 */
 export interface UseSerialSessionReturn {
   browserSupported: boolean;
   state: SerialSessionState;
@@ -65,7 +64,7 @@ export function useSerialSession(
         sessions$,
         terminalBufferEpoch$.current,
       ])
-        .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+        .pipe(switchMap(([s]) => s.terminalText$))
         .subscribe(setReceivedData),
     );
     sub.add(

--- a/apps/example-svelte/README.md
+++ b/apps/example-svelte/README.md
@@ -1,10 +1,10 @@
 # Svelte Example
 
-This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSession` wraps `state$` / `isConnected$` / `errors$` into `readable` stores and binds **`receivedData`** to `createTerminalBuffer(session.receive$).text$` for `\r`-safe terminal display.
+This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSession` wraps `state$` / `isConnected$` / `errors$` into `readable` stores and binds **`receivedData`** to `session.terminalText$` for `\r`-safe terminal display.
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Connect, terminal display via `createTerminalBuffer(receive$)`, send, disconnect. Use `lines$` only for line-delimited logging or parsing—not for primary shell output. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Connect, terminal display via `terminalText$`, send, disconnect. Use `lines$` only for line-delimited logging or parsing—not for primary shell output. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -12,7 +12,7 @@ This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSessi
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
-- Receive terminal-oriented display text via `createTerminalBuffer(receive$)`
+- Receive terminal-oriented display text via `terminalText$`
 - Unified error channel via `errors$`
 - Full TypeScript type safety
 
@@ -64,7 +64,7 @@ The example uses the v2 `SerialSession` API directly:
 2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`. When the baud rate changes between calls, the helper transparently creates a new `SerialSession` so subsequent streams reflect the new port configuration.
 3. **State UI**: The helper subscribes to `session.state$` and `session.isConnected$`. `App.svelte` branches on `SerialSessionState` for status and uses `$isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.
-5. **Receiving**: The store reflects **`createTerminalBuffer(session.receive$).text$`** in `receivedData`. **`lines$`** is for one-line-at-a-time logging or newline-only parsing; raw chunk streaming without terminal folding uses `receive$` (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+5. **Receiving**: The store reflects **`session.terminalText$`** in `receivedData`. **`lines$`** is for one-line-at-a-time logging or newline-only parsing; raw chunk streaming without terminal folding uses `receive$` (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
 6. **Errors**: All connect/read/write/close failures are multiplexed through `session.errors$` and surfaced as the `errorMessage` store. No per-call try/catch wrappers are needed.
 
 ## Code Structure

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -53,6 +53,7 @@ const createMockSession = (supported = true): MockSession => {
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
@@ -152,7 +153,7 @@ describe('useSerialSession', () => {
     unsub();
   });
 
-  it('receive$ のチャンクは createTerminalBuffer 経由で receivedData に反映される', () => {
+  it('terminalText$ の更新が receivedData に反映される', () => {
     const s = useSerialSession();
     const unsub = s.receivedData.subscribe(() => void 0);
     latestMock().receiveSubject.next('foo');

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,6 +1,5 @@
 import {
   createSerialSession,
-  createTerminalBuffer,
   SerialSessionState,
   type SerialError,
   type SerialSession,
@@ -16,7 +15,7 @@ import {
 import { onDestroy } from 'svelte';
 import { readable, type Readable } from 'svelte/store';
 
-/** v2 `SerialSession` を Svelte store に薄く写す。表示は `createTerminalBuffer(receive$).text$`（再接続は世代でリセット）。 */
+/** v2 `SerialSession` を Svelte store に薄く写す。表示は `terminalText$`（再接続は世代でリセット）。 */
 export interface UseSerialSessionReturn {
   browserSupported: Readable<boolean>;
   state: Readable<SerialSessionState>;
@@ -64,7 +63,7 @@ export function useSerialSession(
   const receivedData = readable<string>('', (set) => {
     setReceived = set;
     const sub = combineLatest([sessions$, terminalBufferEpoch$])
-      .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+      .pipe(switchMap(([s]) => s.terminalText$))
       .subscribe(set);
     return () => {
       sub.unsubscribe();

--- a/apps/example-vanilla-js/README.md
+++ b/apps/example-vanilla-js/README.md
@@ -4,7 +4,7 @@ This is a vanilla JavaScript example application demonstrating how to use the `@
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, display via `createTerminalBuffer(receive$)` (session-following subscription), UI toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-delimited logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, display via `terminalText$` (session-following subscription), UI toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-delimited logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -77,7 +77,7 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array`.
 
-5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`createTerminalBuffer(session.receive$).text$`** into the textarea. **`lines$`** is for line-oriented logs, not raw `\r`-heavy shell output.
+5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`session.terminalText$`** into the textarea. **`lines$`** is for line-oriented logs, not raw `\r`-heavy shell output.
 
 ## Code Structure
 

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,7 +1,6 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import {
   createSerialSession,
-  createTerminalBuffer,
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
 import { BehaviorSubject, combineLatest, ReplaySubject, switchMap } from 'rxjs';
@@ -69,7 +68,7 @@ export class App {
       });
 
     combineLatest([this.sessions$, this.terminalBufferEpoch$])
-      .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+      .pipe(switchMap(([s]) => s.terminalText$))
       .subscribe((text) => {
         receiveOutput.value = text;
         receiveOutput.scrollTop = receiveOutput.scrollHeight;

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -19,6 +19,8 @@ vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
     send$: vi.fn(() => of(undefined)),
     state$,
     receive$,
+    terminalText$: actual.createTerminalBuffer(receive$).text$,
+    receiveReplay$: receive$,
     lines$,
     errors$,
     isConnected$,

--- a/apps/example-vanilla-ts/README.md
+++ b/apps/example-vanilla-ts/README.md
@@ -4,7 +4,7 @@ This is a vanilla TypeScript example application demonstrating how to use the `@
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, display via `createTerminalBuffer(receive$)` (session-following subscription), UI toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-delimited logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, display via `terminalText$` (session-following subscription), UI toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-delimited logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -78,7 +78,7 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array`.
 
-5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`createTerminalBuffer(session.receive$).text$`** into the textarea so `\r`-based redraws (e.g. shell progress) stay aligned. Raw streaming without terminal folding uses `receive$`; **`lines$`** remains for line-oriented logs.
+5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`session.terminalText$`** into the textarea so `\r`-based redraws (e.g. shell progress) stay aligned. Raw streaming without terminal folding uses `receive$`; **`lines$`** remains for line-oriented logs.
 
 ## Code Structure
 

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -23,6 +23,7 @@ vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
     send$: vi.fn(() => of(undefined)),
     state$,
     receive$,
+    terminalText$: actual.createTerminalBuffer(receive$).text$,
     receiveReplay$: receive$,
     lines$,
     errors$,

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,6 +1,5 @@
 import {
   createSerialSession,
-  createTerminalBuffer,
   SerialSessionState,
   type SerialSession,
 } from '@gurezo/web-serial-rxjs';
@@ -83,7 +82,7 @@ export class App {
       });
 
     combineLatest([this.sessions$, this.terminalBufferEpoch$])
-      .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+      .pipe(switchMap(([s]) => s.terminalText$))
       .subscribe((text) => {
         receiveOutput.value = text;
         receiveOutput.scrollTop = receiveOutput.scrollHeight;

--- a/apps/example-vue/README.md
+++ b/apps/example-vue/README.md
@@ -4,7 +4,7 @@ This is a Vue example application demonstrating how to use the `@gurezo/web-seri
 
 **Using the library**: See the repository [Quick Start](../../docs/QUICK_START.md) ([日本語](../../docs/QUICK_START.ja.md)) and [SerialSession (v2) overview](../../packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](../../packages/web-serial-rxjs/docs/OVERVIEW.ja.md)).
 
-**Scope**: Minimal smoke test—connect, terminal display via `createTerminalBuffer(receive$)`, connection toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-based logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
+**Scope**: Minimal smoke test—connect, terminal display via `terminalText$`, connection toggles via `isConnected$`, send, disconnect. Use `lines$` only for line-based logging. Richer patterns: [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) ([日本語](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)).
 
 ## Features
 
@@ -79,7 +79,7 @@ This example uses Vue 3 Composition API and RxJS observables to handle serial po
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array` through the composable's `send` method.
 
-5. **Data Receiving**: Incoming bytes are decoded as UTF-8; the composable surfaces **`createTerminalBuffer(session.receive$).text$`** into the textarea-bound ref. Use **`lines$`** for newline-delimited logs—not for interactive shell mirrors where `\r` redraw matters.
+5. **Data Receiving**: Incoming bytes are decoded as UTF-8; the composable surfaces **`session.terminalText$`** into the textarea-bound ref. Use **`lines$`** for newline-delimited logs—not for interactive shell mirrors where `\r` redraw matters.
 
 ## Code Structure
 

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -55,6 +55,7 @@ const createMockSession = (): MockSession => {
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -46,6 +46,7 @@ const createMockSession = (): MockSession => {
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
     isConnected$,
@@ -193,7 +194,7 @@ describe('useSerialClient', () => {
     expect(latestMock().send$).toHaveBeenCalledWith('hello');
   });
 
-  it('should map receive$ via createTerminalBuffer to receivedData', () => {
+  it('should map terminalText$ updates to receivedData', () => {
     const { api } = mountHarness();
     const mock = latestMock();
 

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,6 +1,5 @@
 import {
   createSerialSession,
-  createTerminalBuffer,
   SerialSessionState,
   type SerialError,
   type SerialSession,
@@ -14,7 +13,7 @@ import {
 } from 'rxjs';
 import { onUnmounted, ref, type Ref } from 'vue';
 
-/** v2 `SerialSession` を薄くラップ。表示は `createTerminalBuffer(receive$).text$`（再接続は世代でリセット）。 */
+/** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続は世代でリセット）。 */
 export interface UseSerialClientReturn {
   browserSupported: Ref<boolean>;
   state: Ref<SerialSessionState>;
@@ -60,7 +59,7 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
       isConnected.value = next;
     });
   const receiveSub = combineLatest([sessions$, terminalBufferEpoch$])
-    .pipe(switchMap(([s]) => createTerminalBuffer(s.receive$).text$))
+    .pipe(switchMap(([s]) => s.terminalText$))
     .subscribe((text) => {
       receivedData.value = text;
     });


### PR DESCRIPTION
## Summary
Issue #288 の方針に合わせて、全 example の terminal 表示を `session.terminalText$` ベースに統一しました。
`createTerminalBuffer(receive$)` の直接利用を example 実装から外し、推奨 API surface を明確化しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #288
- Related #286

## What changed?
- Angular / React / Svelte / Vue / Vanilla JS / Vanilla TS の表示ストリームを `terminalText$` に統一
- 各 example のテストモックに `terminalText$` を追加し、購読先変更に追従
- 各 example README の説明を `terminalText$` 前提の利用方針に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx run-many -t test -p example-angular,example-react,example-svelte,example-vue,example-vanilla-ts,example-vanilla-js`
2. `pnpm exec nx run-many -t lint -p example-angular,example-react,example-svelte,example-vue,example-vanilla-ts,example-vanilla-js`
3. 各 example を起動し、接続・受信表示・クリア・再接続で terminal 表示が崩れないことを確認

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / etc. (version: )
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification):
- RxJS version:

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)