### PR TITLE
test(web-serial-rxjs): terminal表示の再発防止テストを強化（#290）

### DIFF
--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -697,6 +697,59 @@ describe('createSerialSession', () => {
       await expect(rawChunk).resolves.toBe('A\rB');
       await expect(terminalText).resolves.toBe('B');
     });
+
+    it('covers issue #290 ls -la style redraw on terminalText$', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const latest = firstValueFrom(session.terminalText$.pipe(take(2), toArray()));
+
+      await firstValueFrom(session.connect$());
+      controller.enqueue(
+        new TextEncoder().encode('-rw-r--r--  1 alice  staff  123 ./foo\r'),
+      );
+      await flushMicrotasks();
+      controller.enqueue(
+        new TextEncoder().encode('-rw-r--r--  1 bob    staff  123 ./foo\n'),
+      );
+      await flushMicrotasks();
+
+      await expect(latest).resolves.toEqual([
+        '',
+        '-rw-r--r--  1 bob    staff  123 ./foo\n',
+      ]);
+    });
+
+    it('covers issue #290 prompt redraw flow on terminalText$', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const latest = firstValueFrom(session.terminalText$.pipe(take(5), toArray()));
+
+      await firstValueFrom(session.connect$());
+      controller.enqueue(new TextEncoder().encode('login: user\r'));
+      await flushMicrotasks();
+      controller.enqueue(new TextEncoder().encode('$ '));
+      await flushMicrotasks();
+      controller.enqueue(new TextEncoder().encode('whoami\r\n'));
+      await flushMicrotasks();
+      controller.enqueue(new TextEncoder().encode('user\r\n'));
+      await flushMicrotasks();
+      controller.enqueue(new TextEncoder().encode('# '));
+      await flushMicrotasks();
+
+      await expect(latest).resolves.toEqual([
+        '',
+        '$ ',
+        '$ whoami\n',
+        '$ whoami\nuser\n',
+        '$ whoami\nuser\n# ',
+      ]);
+    });
   });
 
   describe('send$', () => {

--- a/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
+++ b/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
@@ -9,29 +9,29 @@ import {
 
 const empty: TerminalBufferState = { completed: '', currentLine: '' };
 
-/** Issue #279: terminal 表示の再発防止用テストケース群 */
+/** Issue #290: terminal 表示の再発防止用テストケース群 */
 describe('applyTerminalChunk', () => {
-  // A\rB → B（同一行の carriage-return 上書き）
-  it('treats A\\rB as B on one chunk', () => {
+  // #290: A\rB
+  it('issue #290: A\\rB を同一チャンクで B に畳み込む', () => {
     const s = applyTerminalChunk(empty, 'A\rB');
     expect(terminalDisplayText(s)).toBe('B');
   });
 
-  it('treats A\\rB when split across chunks', () => {
+  it('issue #290: A\\rB を分割チャンクでも B に畳み込む', () => {
     let s = applyTerminalChunk(empty, 'A');
     expect(terminalDisplayText(s)).toBe('A');
     s = applyTerminalChunk(s, '\rB');
     expect(terminalDisplayText(s)).toBe('B');
   });
 
-  // A\r\nB → 正常改行（CRLF は 1 行末として扱う）
-  it('renders A\\r\\nB as normal newline (issue #279)', () => {
+  // #290: A\r\nB
+  it('issue #290: A\\r\\nB を通常改行として扱う', () => {
     const s = applyTerminalChunk(empty, 'a\r\nb');
     expect(terminalDisplayText(s)).toBe('a\nb');
   });
 
-  // A\nB → 2 行表示（論理行が LF で区切られる）
-  it('renders A\\nB as two display lines (issue #279)', () => {
+  // #290: A\nB
+  it('issue #290: A\\nB を2行表示として扱う', () => {
     const s = applyTerminalChunk(empty, 'a\nb');
     expect(terminalDisplayText(s)).toBe('a\nb');
   });
@@ -45,8 +45,8 @@ describe('applyTerminalChunk', () => {
 });
 
 describe('createTerminalBuffer', () => {
-  // A\rB → B（text$ 経由でも累積表示が一致すること）
-  it('emits cumulative display text with carriage-return collapse (issue #279)', () => {
+  // #290: A\rB
+  it('issue #290: text$ でも A\\rB を B に畳み込む', () => {
     const receive$ = new Subject<string>();
     const { text$ } = createTerminalBuffer(receive$);
     const out: string[] = [];
@@ -66,8 +66,8 @@ describe('createTerminalBuffer', () => {
     expect(out.at(-1)).toBe('line1\nx\nz\n');
   });
 
-  // ls -la 形式: 同一行の \r 上書きで列がずれないこと
-  it('simulates ls-style same-line redraw without horizontal drift (issue #279)', () => {
+  // #290: ls -la 形式
+  it('issue #290: ls -la 形式の同一行 redraw で古い行を残さない', () => {
     const receive$ = new Subject<string>();
     const { text$ } = createTerminalBuffer(receive$);
     let last = '';
@@ -80,7 +80,8 @@ describe('createTerminalBuffer', () => {
     expect(last).not.toContain('alice');
   });
 
-  it('shows shell prompt ($ / #) after carriage-return redraw', () => {
+  // #290: prompt 表示
+  it('issue #290: carriage-return redraw 後に shell prompt を正しく表示する', () => {
     const receive$ = new Subject<string>();
     const { text$ } = createTerminalBuffer(receive$);
     let last = '';


### PR DESCRIPTION
## Summary
Issue #290 の完了条件を満たすため、terminal 表示の再発防止テストを強化しました。
`A\rB` / `A\nB` / `A\r\nB` / `ls -la` 形式 / prompt 表示を、単体テストと統合テストの両面で保証しています。

## Type of change
- [x] Chore (build/test/ci)

## Related issues
- Fixes #290
- Related #286

## What changed?
- `create-terminal-buffer` テストのケース名・コメントを Issue #290 の5ケースに対応する形へ整理
- `terminalText$` 統合テストに `ls -la` redraw ケースを追加
- `terminalText$` 統合テストに prompt 表示フローケースを追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm --filter web-serial-rxjs exec vitest run tests/terminal/create-terminal-buffer.test.ts tests/session/create-serial-session.test.ts`
2. `Test Files 2 passed` / `Tests 57 passed` になることを確認
3. 失敗時に `#290` の各ケース名からどの観点が壊れたか追跡できることを確認

## Environment (if relevant)
- Browser: N/A (unit/integration tests)
- OS: macOS
- web-serial-rxjs version (for verification): workspace HEAD
- RxJS version: workspace dependency

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)