### PR TITLE
docs(web-serial-rxjs): terminalText$ を overview に追記

### DIFF
--- a/docs/OVERVIEW.ja.md
+++ b/docs/OVERVIEW.ja.md
@@ -42,6 +42,7 @@
 | `SerialSessionState` | **状態定数** — エクスポートされる const object（例: `SerialSessionState.Connected`, `SerialSessionState.Idle`）。`state$` が emit する値と同じ。 |
 | `isConnected$` | **接続中かどうか** — `state$` が `SerialSessionState.Connected` のときだけ `true`、それ以外は `false`（`state$` から `distinctUntilChanged` 付きで派生）。 |
 | `receive$` | **生のデコードチャンク** — UTF-8 テキストを read pump が返すとおりに受け取る（行揃えではない。マルチバイト安全）。`\r` 等も保持。**ターミナル風の表示**や `\r` による上書き表示向け。 |
+| `terminalText$` | **ターミナル表示向けの累積テキスト** — `receive$` 由来の表示用テキスト。`\r` による上書きを折りたたみつつ通常の改行挙動は維持するため、ターミナル風ビューへ 1 つの文字列をそのままバインドしたい場合に使います。 |
 | `lines$` | **行単位の受信** — `\n` / `\r\n` / 内部の `\r` など実装に従い 1 行ずつ emit。**ログ・1 行ごとの解析**向け。`\r` をそのまま残す必要がある raw ターミナル表示には向かない。 |
 | `errors$` | **すべての `SerialError`**（接続・読み取り・書き込み・クローズ）の主チャネル。 |
 | `connect$()` | ポート選択 → オープン → 内部 read pump 開始。 |

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -42,6 +42,7 @@ This library is framework-agnostic and can be used with:
 | `SerialSessionState` | **State constants** — exported const object (e.g. `SerialSessionState.Connected`, `SerialSessionState.Idle`) with the same values `state$` emits. |
 | `isConnected$` | **Connected flag** — `true` only when `state$` is `SerialSessionState.Connected`; `false` in every other state (derived from `state$` with `distinctUntilChanged`). |
 | `receive$` | **Raw decoder chunks** — UTF-8 text as emitted by the pump (not line-aligned; multi-byte safe). Preserves `\r` and other control characters. Use for **terminal-like mirrors** and progress output that relies on carriage-return redraws. |
+| `terminalText$` | **Terminal-ready cumulative text** — display-oriented text derived from `receive$` that folds carriage-return redraws while keeping normal newline behavior. Use when you want to bind one string directly to a terminal-like viewport. |
 | `lines$` | **Line-delimited UTF-8 text** — one string per complete line via the built-in buffer (`\n`, `\r\n`, interior `\r`). Use for **logs** and **line-by-line parsing**, not for mirroring raw terminal streams where `\r` must stay intact. |
 | `errors$` | **All `SerialError` instances** from connect / read / write / close (primary error channel). |
 | `connect$()` | **Open** a user-selected port and start the internal read pump. |

--- a/docs/index.html
+++ b/docs/index.html
@@ -55,6 +55,10 @@
 <td><strong>Raw decoder chunks</strong> — UTF-8 text as emitted by the pump (not line-aligned; multi-byte safe). Preserves <code>\r</code> and other control characters. Use for <strong>terminal-like mirrors</strong> and progress output that relies on carriage-return redraws.</td>
 </tr>
 <tr>
+<td><code>terminalText$</code></td>
+<td><strong>Terminal-ready cumulative text</strong> — display-oriented text derived from <code>receive$</code> that folds carriage-return redraws while keeping normal newline behavior. Use when you want to bind one string directly to a terminal-like viewport.</td>
+</tr>
+<tr>
 <td><code>lines$</code></td>
 <td><strong>Line-delimited UTF-8 text</strong> — one string per complete line via the built-in buffer (<code>\n</code>, <code>\r\n</code>, interior <code>\r</code>). Use for <strong>logs</strong> and <strong>line-by-line parsing</strong>, not for mirroring raw terminal streams where <code>\r</code> must stay intact.</td>
 </tr>

--- a/docs/media/OVERVIEW.ja.md
+++ b/docs/media/OVERVIEW.ja.md
@@ -42,6 +42,7 @@
 | `SerialSessionState` | **状態定数** — エクスポートされる const object（例: `SerialSessionState.Connected`, `SerialSessionState.Idle`）。`state$` が emit する値と同じ。 |
 | `isConnected$` | **接続中かどうか** — `state$` が `SerialSessionState.Connected` のときだけ `true`、それ以外は `false`（`state$` から `distinctUntilChanged` 付きで派生）。 |
 | `receive$` | **生のデコードチャンク** — UTF-8 テキストを read pump が返すとおりに受け取る（行揃えではない。マルチバイト安全）。`\r` 等も保持。**ターミナル風の表示**や `\r` による上書き表示向け。 |
+| `terminalText$` | **ターミナル表示向けの累積テキスト** — `receive$` 由来の表示用テキスト。`\r` による上書きを折りたたみつつ通常の改行挙動は維持するため、ターミナル風ビューへ 1 つの文字列をそのままバインドしたい場合に使います。 |
 | `lines$` | **行単位の受信** — `\n` / `\r\n` / 内部の `\r` など実装に従い 1 行ずつ emit。**ログ・1 行ごとの解析**向け。`\r` をそのまま残す必要がある raw ターミナル表示には向かない。 |
 | `errors$` | **すべての `SerialError`**（接続・読み取り・書き込み・クローズ）の主チャネル。 |
 | `connect$()` | ポート選択 → オープン → 内部 read pump 開始。 |

--- a/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
@@ -42,6 +42,7 @@
 | `SerialSessionState` | **状態定数** — エクスポートされる const object（例: `SerialSessionState.Connected`, `SerialSessionState.Idle`）。`state$` が emit する値と同じ。 |
 | `isConnected$` | **接続中かどうか** — `state$` が `SerialSessionState.Connected` のときだけ `true`、それ以外は `false`（`state$` から `distinctUntilChanged` 付きで派生）。 |
 | `receive$` | **生のデコードチャンク** — UTF-8 テキストを read pump が返すとおりに受け取る（行揃えではない。マルチバイト安全）。`\r` 等も保持。**ターミナル風の表示**や `\r` による上書き表示向け。 |
+| `terminalText$` | **ターミナル表示向けの累積テキスト** — `receive$` 由来の表示用テキスト。`\r` による上書きを折りたたみつつ通常の改行挙動は維持するため、ターミナル風ビューへ 1 つの文字列をそのままバインドしたい場合に使います。 |
 | `lines$` | **行単位の受信** — `\n` / `\r\n` / 内部の `\r` など実装に従い 1 行ずつ emit。**ログ・1 行ごとの解析**向け。`\r` をそのまま残す必要がある raw ターミナル表示には向かない。 |
 | `errors$` | **すべての `SerialError`**（接続・読み取り・書き込み・クローズ）の主チャネル。 |
 | `connect$()` | ポート選択 → オープン → 内部 read pump 開始。 |

--- a/packages/web-serial-rxjs/docs/OVERVIEW.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.md
@@ -42,6 +42,7 @@ This library is framework-agnostic and can be used with:
 | `SerialSessionState` | **State constants** — exported const object (e.g. `SerialSessionState.Connected`, `SerialSessionState.Idle`) with the same values `state$` emits. |
 | `isConnected$` | **Connected flag** — `true` only when `state$` is `SerialSessionState.Connected`; `false` in every other state (derived from `state$` with `distinctUntilChanged`). |
 | `receive$` | **Raw decoder chunks** — UTF-8 text as emitted by the pump (not line-aligned; multi-byte safe). Preserves `\r` and other control characters. Use for **terminal-like mirrors** and progress output that relies on carriage-return redraws. |
+| `terminalText$` | **Terminal-ready cumulative text** — display-oriented text derived from `receive$` that folds carriage-return redraws while keeping normal newline behavior. Use when you want to bind one string directly to a terminal-like viewport. |
 | `lines$` | **Line-delimited UTF-8 text** — one string per complete line via the built-in buffer (`\n`, `\r\n`, interior `\r`). Use for **logs** and **line-by-line parsing**, not for mirroring raw terminal streams where `\r` must stay intact. |
 | `errors$` | **All `SerialError` instances** from connect / read / write / close (primary error channel). |
 | `connect$()` | **Open** a user-selected port and start the internal read pump. |


### PR DESCRIPTION
## Summary
`SerialSession` の公開APIに含まれる `terminalText$` が `OVERVIEW.md` / `OVERVIEW.ja.md` の公開面テーブルから漏れていたため、英日両方の概要ドキュメントに追記しました。
実装済みAPIと概要ドキュメントの記載を一致させ、`receive$` / `terminalText$` / `lines$` の使い分けを読み取りやすくしています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #296

## What changed?
- `packages/web-serial-rxjs/docs/OVERVIEW.md` の公開面テーブルに `terminalText$` を追加
- `packages/web-serial-rxjs/docs/OVERVIEW.ja.md` の公開面テーブルに `terminalText$` を追加
- `terminalText$` の用途（ターミナル表示向け累積テキスト）を英日で明記

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/docs/OVERVIEW.md` を開き、公開面テーブルに `terminalText$` 行があることを確認する
2. `packages/web-serial-rxjs/docs/OVERVIEW.ja.md` を開き、同様に `terminalText$` 行があることを確認する
3. 両ファイルで `receive$` / `terminalText$` / `lines$` の役割説明が矛盾していないことを確認する

## Environment (if relevant)
- Browser: N/A (documentation only)
- OS: N/A (documentation only)
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)