### PR TITLE
chore(web-serial-rxjs): v2.3.0 へバージョン更新

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
`@gurezo/web-serial-rxjs` の npm 公開バージョンを `2.2.0` から `2.3.0` へ更新し、公開前の build / dry-run により配布内容を確認しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #291

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `2.2.0` から `2.3.0` に更新
- `pnpm install` を実行して lockfile 同期を確認（差分なし）
- `pnpm --filter @gurezo/web-serial-rxjs build` と `pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs` で検証

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm install`
2. `pnpm --filter @gurezo/web-serial-rxjs build`
3. `pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs`

## Environment (if relevant)
- Browser: N/A
- OS: macOS
- web-serial-rxjs version (for verification): `2.3.0`
- RxJS version: `^7.8.x`

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)