### PR TITLE
feat(serial-client-core): 共通Serial clientコアを追加しセッション制御を集約

### DIFF
--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,11 +1,13 @@
 import {
-  createSerialSession,
   SerialSessionState,
   type SerialError,
-  type SerialSession,
 } from '@gurezo/web-serial-rxjs';
+import {
+  createSerialClientCore,
+  type SerialClientCore,
+} from '@gurezo/serial-client-core';
 import { useEffect, useRef, useState } from 'react';
-import { BehaviorSubject, combineLatest, Observable, ReplaySubject, Subscription, switchMap } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 /** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続時は世代でリセット）。 */
 export interface UseSerialSessionReturn {
@@ -23,18 +25,13 @@ export interface UseSerialSessionReturn {
 export function useSerialSession(
   initialBaudRate = 9600,
 ): UseSerialSessionReturn {
-  const sessionsRef = useRef<ReplaySubject<SerialSession> | null>(null);
-  const sessionRef = useRef<SerialSession | null>(null);
-  const terminalBufferEpoch$ = useRef(new BehaviorSubject(0));
-  const baudRateRef = useRef<number>(initialBaudRate);
-  if (sessionsRef.current === null) {
-    sessionRef.current = createSerialSession({ baudRate: initialBaudRate });
-    sessionsRef.current = new ReplaySubject<SerialSession>(1);
-    sessionsRef.current.next(sessionRef.current);
+  const coreRef = useRef<SerialClientCore | null>(null);
+  if (coreRef.current === null) {
+    coreRef.current = createSerialClientCore(initialBaudRate);
   }
 
   const [browserSupported] = useState(() =>
-    (sessionRef.current as SerialSession).isBrowserSupported(),
+    (coreRef.current as SerialClientCore).isBrowserSupported(),
   );
   const [state, setState] = useState<SerialSessionState>(SerialSessionState.Idle);
   const [isConnected, setIsConnected] = useState(false);
@@ -42,10 +39,10 @@ export function useSerialSession(
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    const sessions$ = sessionsRef.current as ReplaySubject<SerialSession>;
+    const core = coreRef.current as SerialClientCore;
     const sub = new Subscription();
     sub.add(
-      sessions$.pipe(switchMap((s) => s.state$)).subscribe((next) => {
+      core.state$.subscribe((next) => {
         setState(next);
         if (
           next === SerialSessionState.Connected ||
@@ -55,54 +52,30 @@ export function useSerialSession(
       }),
     );
     sub.add(
-      sessions$
-        .pipe(switchMap((s) => s.isConnected$))
-        .subscribe((next) => setIsConnected(next)),
+      core.isConnected$.subscribe((next) => setIsConnected(next)),
     );
+    sub.add(core.terminalText$.subscribe(setReceivedData));
     sub.add(
-      combineLatest([
-        sessions$,
-        terminalBufferEpoch$.current,
-      ])
-        .pipe(switchMap(([s]) => s.terminalText$))
-        .subscribe(setReceivedData),
-    );
-    sub.add(
-      sessions$
-        .pipe(switchMap((s) => s.errors$))
-        .subscribe((e: SerialError) => setErrorMessage(e.message)),
+      core.errors$.subscribe((e: SerialError) => setErrorMessage(e.message)),
     );
     return () => {
       sub.unsubscribe();
-      sessionRef.current?.disconnect$().subscribe({ error: () => void 0 });
-      sessions$.complete();
-      sessionsRef.current = null;
-      sessionRef.current = null;
+      core.dispose$().subscribe({ error: () => void 0 });
+      coreRef.current = null;
     };
   }, []);
 
-  const bumpTerminalBufferEpoch = (): void => {
-    const b = terminalBufferEpoch$.current;
-    b.next(b.value + 1);
-  };
-
   const connect$ = (baudRate?: number): Observable<void> => {
     setReceivedData('');
-    bumpTerminalBufferEpoch();
-    if (baudRate !== undefined && baudRate !== baudRateRef.current) {
-      baudRateRef.current = baudRate;
-      const next = createSerialSession({ baudRate });
-      sessionRef.current = next;
-      sessionsRef.current?.next(next);
-    }
-    return (sessionRef.current as SerialSession).connect$();
+    (coreRef.current as SerialClientCore).clearTerminalText();
+    return (coreRef.current as SerialClientCore).connect$(baudRate);
   };
   const disconnect$ = (): Observable<void> =>
-    (sessionRef.current as SerialSession).disconnect$();
+    (coreRef.current as SerialClientCore).disconnect$();
   const send$ = (data: string | Uint8Array): Observable<void> =>
-    (sessionRef.current as SerialSession).send$(data);
+    (coreRef.current as SerialClientCore).send$(data);
   const clearReceivedData = (): void => {
-    bumpTerminalBufferEpoch();
+    (coreRef.current as SerialClientCore).clearTerminalText();
     setReceivedData('');
   };
 

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -5,7 +5,7 @@ module.exports = [
   ...nx.configs['flat/typescript'],
   ...nx.configs['flat/javascript'],
   {
-    ignores: ['**/dist'],
+    ignores: ['**/dist', '**/vitest.config.*.timestamp*'],
   },
   {
     files: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx'],

--- a/libs/serial-client-core/README.md
+++ b/libs/serial-client-core/README.md
@@ -1,0 +1,7 @@
+# serial-client-core
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test serial-client-core` to execute the unit tests via [Vitest](https://vitest.dev/).

--- a/libs/serial-client-core/eslint.config.cjs
+++ b/libs/serial-client-core/eslint.config.cjs
@@ -1,0 +1,3 @@
+const baseConfig = require('../../eslint.config.cjs');
+
+module.exports = [...baseConfig];

--- a/libs/serial-client-core/project.json
+++ b/libs/serial-client-core/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "serial-client-core",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/serial-client-core/src",
+  "projectType": "library",
+  "tags": [],
+  "// targets": "to see all targets run: nx show project serial-client-core --web",
+  "targets": {}
+}

--- a/libs/serial-client-core/src/index.ts
+++ b/libs/serial-client-core/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/serial-client-core';

--- a/libs/serial-client-core/src/lib/serial-client-core.spec.ts
+++ b/libs/serial-client-core/src/lib/serial-client-core.spec.ts
@@ -1,7 +1,173 @@
-import { serialClientCore } from './serial-client-core';
+import type {
+  SerialError,
+  SerialSession,
+  SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
+import { firstValueFrom, map, of, Subject, throwError, BehaviorSubject } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSerialClientCore } from './serial-client-core';
 
-describe('serialClientCore', () => {
-  it('should work', () => {
-    expect(serialClientCore()).toEqual('serial-client-core');
+const SS = webSerialRxjs.SerialSessionState;
+
+interface MockSession {
+  session: SerialSession;
+  stateSubject: BehaviorSubject<SerialSessionState>;
+  receiveSubject: Subject<string>;
+  errorsSubject: Subject<SerialError>;
+  connect$: ReturnType<typeof vi.fn>;
+  disconnect$: ReturnType<typeof vi.fn>;
+  send$: ReturnType<typeof vi.fn>;
+  isBrowserSupported: ReturnType<typeof vi.fn>;
+}
+
+const createMockSession = (supported = true): MockSession => {
+  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const receiveSubject = new Subject<string>();
+  const errorsSubject = new Subject<SerialError>();
+  const isConnected$ = stateSubject.pipe(map((s) => s === SS.Connected));
+  const connect$ = vi.fn(() => of(undefined));
+  const disconnect$ = vi.fn(() => of(undefined));
+  const send$ = vi.fn(() => of(undefined));
+  const isBrowserSupported = vi.fn(() => supported);
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
+
+  const session: SerialSession = {
+    isBrowserSupported,
+    connect$,
+    disconnect$,
+    send$,
+    state$: stateSubject.asObservable(),
+    errors$: errorsSubject.asObservable(),
+    receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
+    receiveReplay$: receiveSubject.asObservable(),
+    lines$: receiveSubject.asObservable(),
+    isConnected$,
+    portInfo$: portInfoSubject.asObservable(),
+    getPortInfo: () => portInfoSubject.getValue(),
+    getCurrentPort: () => null,
+  };
+
+  return {
+    session,
+    stateSubject,
+    receiveSubject,
+    errorsSubject,
+    connect$,
+    disconnect$,
+    send$,
+    isBrowserSupported,
+  };
+};
+
+let mockSessions: MockSession[] = [];
+let nextSupported = true;
+
+vi.mock('@gurezo/web-serial-rxjs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
+      '@gurezo/web-serial-rxjs',
+    );
+  return {
+    ...actual,
+    createSerialSession: vi.fn(() => {
+      const mock = createMockSession(nextSupported);
+      mockSessions.push(mock);
+      return mock.session;
+    }),
+  };
+});
+
+const latestMock = (): MockSession => {
+  const mock = mockSessions.at(-1);
+  if (!mock) throw new Error('createSerialSession was not called');
+  return mock;
+};
+
+describe('createSerialClientCore', () => {
+  beforeEach(() => {
+    mockSessions = [];
+    nextSupported = true;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initializes with an idle session and browser support', async () => {
+    const core = createSerialClientCore();
+    expect(core.isBrowserSupported()).toBe(true);
+    await expect(firstValueFrom(core.state$)).resolves.toBe(SS.Idle);
+    await expect(firstValueFrom(core.isConnected$)).resolves.toBe(false);
+  });
+
+  it('forwards receive$ and terminalText$ from the current session', async () => {
+    const core = createSerialClientCore();
+    const receivePending = firstValueFrom(core.receive$);
+    const terminalValues: string[] = [];
+    const sub = core.terminalText$.subscribe((value) => terminalValues.push(value));
+    latestMock().receiveSubject.next('A\r');
+    latestMock().receiveSubject.next('B');
+    await expect(receivePending).resolves.toBe('A\r');
+    expect(terminalValues.at(-1)).toBe('B');
+    sub.unsubscribe();
+  });
+
+  it('delegates connect$, disconnect$, and send$ to active session', async () => {
+    const core = createSerialClientCore();
+    await firstValueFrom(core.connect$());
+    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
+
+    await firstValueFrom(core.send$('ping'));
+    expect(latestMock().send$).toHaveBeenCalledWith('ping');
+
+    await firstValueFrom(core.disconnect$());
+    expect(latestMock().disconnect$).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates session when baud rate changes on connect$', async () => {
+    const core = createSerialClientCore(9600);
+    expect(mockSessions).toHaveLength(1);
+    await firstValueFrom(core.connect$(115200));
+    expect(mockSessions).toHaveLength(2);
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenLastCalledWith({ baudRate: 115200 });
+  });
+
+  it('resets terminal fold when clearTerminalText is called', () => {
+    const core = createSerialClientCore();
+    const values: string[] = [];
+    const sub = core.terminalText$.subscribe((value) => values.push(value));
+    latestMock().receiveSubject.next('left');
+    core.clearTerminalText();
+    latestMock().receiveSubject.next('new');
+    expect(values.at(-1)).toBe('new');
+    sub.unsubscribe();
+  });
+
+  it('forwards errors$ and keeps state stream transition behavior', async () => {
+    const core = createSerialClientCore();
+    const pending = firstValueFrom(core.errors$);
+    const error = new webSerialRxjs.SerialError(
+      webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+      'boom',
+    );
+    latestMock().errorsSubject.next(error);
+    await expect(pending).resolves.toBe(error);
+  });
+
+  it('propagates connect errors to caller', async () => {
+    const core = createSerialClientCore();
+    const err = new Error('no port');
+    latestMock().connect$.mockReturnValueOnce(throwError(() => err));
+    await expect(firstValueFrom(core.connect$())).rejects.toBe(err);
+  });
+
+  it('dispose$ disconnects and completes resources', async () => {
+    const core = createSerialClientCore();
+    await firstValueFrom(core.dispose$());
+    expect(latestMock().disconnect$).toHaveBeenCalledTimes(1);
   });
 });

--- a/libs/serial-client-core/src/lib/serial-client-core.spec.ts
+++ b/libs/serial-client-core/src/lib/serial-client-core.spec.ts
@@ -1,0 +1,7 @@
+import { serialClientCore } from './serial-client-core';
+
+describe('serialClientCore', () => {
+  it('should work', () => {
+    expect(serialClientCore()).toEqual('serial-client-core');
+  });
+});

--- a/libs/serial-client-core/src/lib/serial-client-core.ts
+++ b/libs/serial-client-core/src/lib/serial-client-core.ts
@@ -1,0 +1,3 @@
+export function serialClientCore(): string {
+  return 'serial-client-core';
+}

--- a/libs/serial-client-core/src/lib/serial-client-core.ts
+++ b/libs/serial-client-core/src/lib/serial-client-core.ts
@@ -1,3 +1,99 @@
-export function serialClientCore(): string {
-  return 'serial-client-core';
+import {
+  createSerialSession,
+  type SerialError,
+  type SerialSession,
+  type SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  type Observable,
+  ReplaySubject,
+  shareReplay,
+  switchMap,
+} from 'rxjs';
+
+export interface SerialClientCore {
+  readonly state$: Observable<SerialSessionState>;
+  readonly isConnected$: Observable<boolean>;
+  readonly receive$: Observable<string>;
+  readonly terminalText$: Observable<string>;
+  readonly errors$: Observable<SerialError>;
+  isBrowserSupported(): boolean;
+  connect$(baudRate?: number): Observable<void>;
+  disconnect$(): Observable<void>;
+  send$(data: string | Uint8Array): Observable<void>;
+  clearTerminalText(): void;
+  dispose$(): Observable<void>;
+}
+
+export function createSerialClientCore(initialBaudRate = 9600): SerialClientCore {
+  const sessions$ = new ReplaySubject<SerialSession>(1);
+  const terminalBufferEpoch$ = new BehaviorSubject(0);
+
+  let currentBaudRate = initialBaudRate;
+  let currentSession = createSerialSession({ baudRate: initialBaudRate });
+  sessions$.next(currentSession);
+
+  const state$ = sessions$.pipe(
+    switchMap((session) => session.state$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const isConnected$ = sessions$.pipe(
+    switchMap((session) => session.isConnected$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const receive$ = sessions$.pipe(
+    switchMap((session) => session.receive$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const terminalText$ = combineLatest([sessions$, terminalBufferEpoch$]).pipe(
+    switchMap(([session]) => session.terminalText$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const errors$ = sessions$.pipe(
+    switchMap((session) => session.errors$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  const bumpTerminalBufferEpoch = (): void => {
+    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
+  };
+
+  const connect$ = (baudRate?: number): Observable<void> => {
+    bumpTerminalBufferEpoch();
+    if (baudRate !== undefined && baudRate !== currentBaudRate) {
+      currentBaudRate = baudRate;
+      currentSession = createSerialSession({ baudRate });
+      sessions$.next(currentSession);
+    }
+    return currentSession.connect$();
+  };
+
+  const disconnect$ = (): Observable<void> => currentSession.disconnect$();
+  const send$ = (data: string | Uint8Array): Observable<void> =>
+    currentSession.send$(data);
+  const clearTerminalText = (): void => {
+    bumpTerminalBufferEpoch();
+  };
+  const dispose$ = (): Observable<void> => {
+    const disconnected$ = currentSession.disconnect$();
+    sessions$.complete();
+    terminalBufferEpoch$.complete();
+    return disconnected$;
+  };
+
+  return {
+    state$,
+    isConnected$,
+    receive$,
+    terminalText$,
+    errors$,
+    isBrowserSupported: () => currentSession.isBrowserSupported(),
+    connect$,
+    disconnect$,
+    send$,
+    clearTerminalText,
+    dispose$,
+  };
 }

--- a/libs/serial-client-core/tsconfig.json
+++ b/libs/serial-client-core/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/serial-client-core/tsconfig.lib.json
+++ b/libs/serial-client-core/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/libs/serial-client-core/tsconfig.spec.json
+++ b/libs/serial-client-core/tsconfig.spec.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/serial-client-core/vitest.config.mts
+++ b/libs/serial-client-core/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/libs/serial-client-core',
+  plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  test: {
+    name: 'serial-client-core',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/libs/serial-client-core',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,21 +10,14 @@
     "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": [
-      "es2020",
-      "dom"
-    ],
+    "lib": ["es2020", "dom"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@gurezo/web-serial-rxjs": [
-        "packages/web-serial-rxjs/src/index.ts"
-      ]
+      "@gurezo/web-serial-rxjs": ["packages/web-serial-rxjs/src/index.ts"],
+      "@gurezo/serial-client-core": ["./libs/serial-client-core/src/index.ts"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }


### PR DESCRIPTION
## Summary
Issue #300 に対応し、examples 間で重複していた SerialSession ラップ処理を `libs/serial-client-core` に集約しました。これにより、セッション切替・受信表示バッファ制御・コマンド委譲の実装を共通化し、各 UI 実装はバインディング責務に集中できるようにします。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #300
- Refs #299

## What changed?
- `nx` generator で `libs/serial-client-core` を新規作成
- `createSerialClientCore(initialBaudRate?)` を実装し、以下を公開
  - `state$` / `isConnected$` / `receive$` / `terminalText$` / `errors$`
  - `connect$` / `disconnect$` / `send$` / `clearTerminalText()` / `dispose$()`
- `connect$(baudRate)` で baudRate 変更時に内部 `SerialSession` を再生成する挙動を統一
- terminal 表示リセット（再接続時・明示クリア時）を epoch 制御で共通化
- `libs/serial-client-core` にユニットテストを追加
- `example-react` の hook を共通コア利用へ置換し、参照可能性を確認

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `@gurezo/serial-client-core`（`createSerialClientCore`）を追加
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm nx test serial-client-core`
2. `pnpm nx test example-react`
3. React exampleで `connect$` / `send$` / `disconnect$` と `clearReceivedData` の挙動が従来どおりであることを確認

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / etc. (version: N/A)
- OS: macOS
- web-serial-rxjs version (for verification): workspace latest
- RxJS version: ^7.8.2

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)