### PR TITLE
refactor(example-angular): serial-client-core へ移行

### DIFF
--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -90,8 +90,7 @@ export class App {
   }
 
   handleConnect(): void {
-    this.receivedData.set('');
-    this.serialService.bumpTerminalBufferEpoch();
+    this.resetTerminalView();
     this.errorMessage.set(null);
     this.serialService.connect$(this.baudRate).subscribe({
       error: (error: unknown) => {
@@ -131,6 +130,10 @@ export class App {
   }
 
   clearReceivedData(): void {
+    this.resetTerminalView();
+  }
+
+  private resetTerminalView(): void {
     this.serialService.bumpTerminalBufferEpoch();
     this.receivedData.set('');
   }

--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import * as serialClientCore from '@gurezo/serial-client-core';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
-import type { SerialSession } from '@gurezo/web-serial-rxjs';
 import {
   BehaviorSubject,
   distinctUntilChanged,
@@ -15,24 +15,24 @@ import { SerialClientService } from './serial-client.service';
 
 const SS = webSerialRxjs.SerialSessionState;
 
-interface MockSession {
-  session: SerialSession;
+interface MockCore {
+  core: serialClientCore.SerialClientCore;
   stateSubject: BehaviorSubject<webSerialRxjs.SerialSessionState>;
   receiveSubject: Subject<string>;
-  linesSubject: Subject<string>;
   errorsSubject: Subject<webSerialRxjs.SerialError>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
+  clearTerminalText: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockSession = (): MockSession => {
+const createMockCore = (): MockCore => {
   const stateSubject = new BehaviorSubject<webSerialRxjs.SerialSessionState>(
     SS.Idle,
   );
   const receiveSubject = new Subject<string>();
-  const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<webSerialRxjs.SerialError>();
   const isConnected$ = stateSubject.pipe(
     map((s) => s === SS.Connected),
@@ -41,10 +41,11 @@ const createMockSession = (): MockSession => {
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
+  const clearTerminalText = vi.fn();
+  const dispose$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
-  const session: SerialSession = {
+  const core: serialClientCore.SerialClientCore = {
     isBrowserSupported,
     connect$,
     disconnect$,
@@ -53,48 +54,45 @@ const createMockSession = (): MockSession => {
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    receiveReplay$: receiveSubject.asObservable(),
-    lines$: linesSubject.asObservable(),
     isConnected$,
-    portInfo$: portInfoSubject.asObservable(),
-    getPortInfo: () => portInfoSubject.getValue(),
-    getCurrentPort: () => null,
+    clearTerminalText,
+    dispose$,
   };
 
   return {
-    session,
+    core,
     stateSubject,
     receiveSubject,
-    linesSubject,
     errorsSubject,
     connect$,
     disconnect$,
     send$,
+    clearTerminalText,
+    dispose$,
     isBrowserSupported,
   };
 };
 
-let mockSessions: MockSession[] = [];
+let mockCores: MockCore[] = [];
 
-vi.mock('@gurezo/web-serial-rxjs', async () => {
-  const actual =
-    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
-      '@gurezo/web-serial-rxjs',
-    );
+vi.mock('@gurezo/serial-client-core', async () => {
+  const actual = await vi.importActual<typeof import('@gurezo/serial-client-core')>(
+    '@gurezo/serial-client-core',
+  );
   return {
     ...actual,
-    createSerialSession: vi.fn(() => {
-      const mock = createMockSession();
-      mockSessions.push(mock);
-      return mock.session;
+    createSerialClientCore: vi.fn(() => {
+      const mock = createMockCore();
+      mockCores.push(mock);
+      return mock.core;
     }),
   };
 });
 
-const latestMock = (): MockSession => {
-  const mock = mockSessions.at(-1);
+const latestMock = (): MockCore => {
+  const mock = mockCores.at(-1);
   if (!mock) {
-    throw new Error('createSerialSession was not called');
+    throw new Error('createSerialClientCore was not called');
   }
   return mock;
 };
@@ -104,7 +102,7 @@ describe('SerialClientService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSessions = [];
+    mockCores = [];
     TestBed.configureTestingModule({});
     service = TestBed.inject(SerialClientService);
   });
@@ -113,13 +111,10 @@ describe('SerialClientService', () => {
     vi.restoreAllMocks();
   });
 
-  it('should create a session on construction', () => {
+  it('should create core on construction', () => {
     expect(
-      vi.mocked(webSerialRxjs.createSerialSession),
+      vi.mocked(serialClientCore.createSerialClientCore),
     ).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(webSerialRxjs.createSerialSession)).toHaveBeenCalledWith({
-      baudRate: 9600,
-    });
     expect(service).toBeTruthy();
   });
 
@@ -142,21 +137,15 @@ describe('SerialClientService', () => {
     expect(state).toBe(SS.Connected);
   });
 
-  it('should connect through the session', async () => {
+  it('should connect through the core', async () => {
     await firstValueFrom(service.connect$());
     expect(latestMock().connect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should recreate the session when baud rate changes', async () => {
+  it('should pass baud rate to core connect$', async () => {
     await firstValueFrom(service.connect$(115200));
 
-    expect(
-      vi.mocked(webSerialRxjs.createSerialSession),
-    ).toHaveBeenCalledTimes(2);
-    expect(
-      vi.mocked(webSerialRxjs.createSerialSession),
-    ).toHaveBeenLastCalledWith({ baudRate: 115200 });
-    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
+    expect(latestMock().connect$).toHaveBeenCalledWith(115200);
   });
 
   it('should disconnect through the session', async () => {
@@ -194,15 +183,9 @@ describe('SerialClientService', () => {
     sub.unsubscribe();
   });
 
-  it('bumpTerminalBufferEpoch starts a fresh terminal fold for the same session', () => {
-    const mock = latestMock();
-    const values: string[] = [];
-    const sub = service.terminalText$.subscribe((t) => values.push(t));
-    mock.receiveSubject.next('leftover');
+  it('bumpTerminalBufferEpoch delegates to clearTerminalText', () => {
     service.bumpTerminalBufferEpoch();
-    mock.receiveSubject.next('new');
-    expect(values.at(-1)).toBe('new');
-    sub.unsubscribe();
+    expect(latestMock().clearTerminalText).toHaveBeenCalledTimes(1);
   });
 
   it('should forward errors$ emissions', async () => {
@@ -214,5 +197,10 @@ describe('SerialClientService', () => {
     );
     mock.errorsSubject.next(error);
     await expect(pending).resolves.toBe(error);
+  });
+
+  it('should dispose core on destroy', () => {
+    service.ngOnDestroy();
+    expect(latestMock().dispose$).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -1,26 +1,15 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import {
-  createSerialSession,
-  SerialError,
-  SerialSession,
-  SerialSessionState,
-} from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  Observable,
-  ReplaySubject,
-  switchMap,
-} from 'rxjs';
+  createSerialClientCore,
+  type SerialClientCore,
+} from '@gurezo/serial-client-core';
+import { type SerialError, type SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { type Observable } from 'rxjs';
 
 /** v2 SerialSession を薄くラップ。表示は `terminalText$`、`receive$` は raw。 */
 @Injectable({ providedIn: 'root' })
 export class SerialClientService implements OnDestroy {
-  private readonly sessions$ = new ReplaySubject<SerialSession>(1);
-  /** 同一セッションでも表示バッファだけ切り替え（クリア・再接続）するための世代。 */
-  private readonly terminalBufferEpoch$ = new BehaviorSubject(0);
-  private currentSession: SerialSession;
-  private currentBaudRate: number;
+  private readonly core: SerialClientCore = createSerialClientCore();
 
   readonly state$: Observable<SerialSessionState>;
   /** デコード済み raw チャンク。textarea には `terminalText$` を参照。 */
@@ -31,56 +20,35 @@ export class SerialClientService implements OnDestroy {
   readonly errors$: Observable<SerialError>;
 
   constructor() {
-    this.currentBaudRate = 9600;
-    this.currentSession = createSerialSession({
-      baudRate: this.currentBaudRate,
-    });
-    this.sessions$.next(this.currentSession);
-
-    this.state$ = this.sessions$.pipe(switchMap((session) => session.state$));
-    this.receive$ = this.sessions$.pipe(
-      switchMap((session) => session.receive$),
-    );
-    this.terminalText$ = combineLatest([
-      this.sessions$,
-      this.terminalBufferEpoch$,
-    ]).pipe(
-      switchMap(([session]) => session.terminalText$),
-    );
-    this.isConnected$ = this.sessions$.pipe(
-      switchMap((session) => session.isConnected$),
-    );
-    this.errors$ = this.sessions$.pipe(switchMap((session) => session.errors$));
+    this.state$ = this.core.state$;
+    this.receive$ = this.core.receive$;
+    this.terminalText$ = this.core.terminalText$;
+    this.isConnected$ = this.core.isConnected$;
+    this.errors$ = this.core.errors$;
   }
 
   ngOnDestroy(): void {
-    this.currentSession.disconnect$().subscribe({ error: () => void 0 });
-    this.sessions$.complete();
+    this.core.dispose$().subscribe({ error: () => void 0 });
   }
 
   isBrowserSupported(): boolean {
-    return this.currentSession.isBrowserSupported();
+    return this.core.isBrowserSupported();
   }
 
   connect$(baudRate?: number): Observable<void> {
-    if (baudRate !== undefined && baudRate !== this.currentBaudRate) {
-      this.currentBaudRate = baudRate;
-      this.currentSession = createSerialSession({ baudRate });
-      this.sessions$.next(this.currentSession);
-    }
-    return this.currentSession.connect$();
+    return this.core.connect$(baudRate);
   }
 
   disconnect$(): Observable<void> {
-    return this.currentSession.disconnect$();
+    return this.core.disconnect$();
   }
 
   send$(data: string | Uint8Array): Observable<void> {
-    return this.currentSession.send$(data);
+    return this.core.send$(data);
   }
 
   /** `terminalText$` の表示累積をリセットし、以降の受信のみ表示する（textarea クリア・再接続時）。 */
   bumpTerminalBufferEpoch(): void {
-    this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+    this.core.clearTerminalText();
   }
 }


### PR DESCRIPTION
## Summary
`apps/example-angular` の `SerialClientService` を共通コアに委譲し、重複していたセッション管理ロジックを削減しました。あわせて `app.ts` の connect/clear の責務を整理し、既存の `terminalText$` ベース表示を維持しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #301
- Refs #299

## What changed?
- `SerialClientService` の内部実装を `createSerialClientCore` ベースの薄いラッパへ置換
- `app.ts` で connect/clear 共通処理を `resetTerminalView()` に集約し、UI 側責務を整理
- `serial-client.service.spec.ts` を共通コア委譲前提のモック構成へ更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `npx nx test example-angular` を実行する
2. `apps/example-angular/src/app/services/serial-client.service.spec.ts` が含まれるテストが通過することを確認する
3. Angular example 上で接続・切断・送信・表示クリアの操作感が従来どおりであることを確認する

## Environment (if relevant)
- Browser: Chrome (version: latest)
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: workspace

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)