### PR TITLE
refactor(examples): React/Vue/Svelte の Serial client を共通コアへ移行 (#302)

### DIFF
--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -1,34 +1,39 @@
 import type {
   SerialError,
-  SerialSession,
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
+import * as serialClientCore from '@gurezo/serial-client-core';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { act, renderHook } from '@testing-library/react';
-import { BehaviorSubject, distinctUntilChanged, map, of, Subject, throwError } from 'rxjs';
+import {
+  BehaviorSubject,
+  distinctUntilChanged,
+  map,
+  of,
+  Subject,
+  throwError,
+} from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSerialSession } from './useSerialSession';
 
 const SS = webSerialRxjs.SerialSessionState;
 
-interface MockSession {
-  session: SerialSession;
+interface MockCore {
+  core: serialClientCore.SerialClientCore;
   stateSubject: BehaviorSubject<SerialSessionState>;
   receiveSubject: Subject<string>;
-  linesSubject: Subject<string>;
   errorsSubject: Subject<SerialError>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
+  clearTerminalText: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockSession = (
-  supported = true,
-): MockSession => {
+const createMockCore = (supported = true): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
   const receiveSubject = new Subject<string>();
-  const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnected$ = stateSubject.pipe(
     map((s) => s === SS.Connected),
@@ -37,10 +42,11 @@ const createMockSession = (
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
+  const clearTerminalText = vi.fn();
+  const dispose$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => supported);
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
-  const session: SerialSession = {
+  const core: serialClientCore.SerialClientCore = {
     isBrowserSupported,
     connect$,
     disconnect$,
@@ -49,54 +55,52 @@ const createMockSession = (
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    receiveReplay$: receiveSubject.asObservable(),
-    lines$: linesSubject.asObservable(),
     isConnected$,
-    portInfo$: portInfoSubject.asObservable(),
-    getPortInfo: () => portInfoSubject.getValue(),
-    getCurrentPort: () => null,
+    clearTerminalText,
+    dispose$,
   };
 
   return {
-    session,
+    core,
     stateSubject,
     receiveSubject,
-    linesSubject,
     errorsSubject,
     connect$,
     disconnect$,
     send$,
+    clearTerminalText,
+    dispose$,
     isBrowserSupported,
   };
 };
 
-let mockSessions: MockSession[] = [];
+let mockCores: MockCore[] = [];
 let nextSupported = true;
 
-vi.mock('@gurezo/web-serial-rxjs', async () => {
+vi.mock('@gurezo/serial-client-core', async () => {
   const actual =
-    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
-      '@gurezo/web-serial-rxjs',
+    await vi.importActual<typeof import('@gurezo/serial-client-core')>(
+      '@gurezo/serial-client-core',
     );
   return {
     ...actual,
-    createSerialSession: vi.fn(() => {
-      const mock = createMockSession(nextSupported);
-      mockSessions.push(mock);
-      return mock.session;
+    createSerialClientCore: vi.fn(() => {
+      const mock = createMockCore(nextSupported);
+      mockCores.push(mock);
+      return mock.core;
     }),
   };
 });
 
-const latestMock = (): MockSession => {
-  const mock = mockSessions.at(-1);
-  if (!mock) throw new Error('createSerialSession was not called');
+const latestMock = (): MockCore => {
+  const mock = mockCores.at(-1);
+  if (!mock) throw new Error('createSerialClientCore was not called');
   return mock;
 };
 
 describe('useSerialSession', () => {
   beforeEach(() => {
-    mockSessions = [];
+    mockCores = [];
     nextSupported = true;
   });
 
@@ -111,6 +115,13 @@ describe('useSerialSession', () => {
     expect(result.current.receivedData).toBe('');
     expect(result.current.errorMessage).toBeNull();
     expect(result.current.browserSupported).toBe(true);
+  });
+
+  it('createSerialClientCore に初期ボーレートを渡す', () => {
+    renderHook(() => useSerialSession(9600));
+    expect(
+      vi.mocked(serialClientCore.createSerialClientCore),
+    ).toHaveBeenCalledWith(9600);
   });
 
   it('browserSupported は session.isBrowserSupported() の結果を反映する', () => {
@@ -159,10 +170,11 @@ describe('useSerialSession', () => {
     act(() => latestMock().receiveSubject.next('data'));
     expect(result.current.receivedData).toBe('data');
     act(() => result.current.clearReceivedData());
+    expect(latestMock().clearTerminalText).toHaveBeenCalled();
     expect(result.current.receivedData).toBe('');
   });
 
-  it('connect$ / disconnect$ / send$ は session の対応メソッドへ委譲する', () => {
+  it('connect$ / disconnect$ / send$ は core の対応メソッドへ委譲する', () => {
     const { result } = renderHook(() => useSerialSession());
 
     act(() => {
@@ -181,14 +193,17 @@ describe('useSerialSession', () => {
     expect(latestMock().disconnect$).toHaveBeenCalled();
   });
 
-  it('connect$(baudRate) で baudRate が変わると新しい session を生成する', () => {
+  it('connect$(baudRate) は core.connect$ にボーレートを渡す', () => {
     const { result } = renderHook(() => useSerialSession(9600));
-    expect(mockSessions).toHaveLength(1);
+    expect(mockCores).toHaveLength(1);
 
     act(() => {
       result.current.connect$(115200).subscribe();
     });
-    expect(mockSessions).toHaveLength(2);
+    expect(latestMock().connect$).toHaveBeenCalledWith(115200);
+    expect(
+      vi.mocked(serialClientCore.createSerialClientCore),
+    ).toHaveBeenCalledTimes(1);
 
     act(() => latestMock().stateSubject.next(SS.Connecting));
     expect(result.current.state).toBe(SS.Connecting);
@@ -206,10 +221,10 @@ describe('useSerialSession', () => {
     expect(onError).toHaveBeenCalledWith(err);
   });
 
-  it('unmount 時に session の disconnect$ を呼び、購読を解除する', () => {
+  it('unmount 時に core.dispose$ を呼ぶ', () => {
     const { unmount } = renderHook(() => useSerialSession());
     const mock = latestMock();
     unmount();
-    expect(mock.disconnect$).toHaveBeenCalled();
+    expect(mock.dispose$).toHaveBeenCalled();
   });
 });

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -1,8 +1,8 @@
 import type {
   SerialError,
-  SerialSession,
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
+import * as serialClientCore from '@gurezo/serial-client-core';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import {
   BehaviorSubject,
@@ -18,22 +18,22 @@ import { useSerialSession } from './useSerialSession';
 
 const SS = webSerialRxjs.SerialSessionState;
 
-interface MockSession {
-  session: SerialSession;
+interface MockCore {
+  core: serialClientCore.SerialClientCore;
   stateSubject: BehaviorSubject<SerialSessionState>;
   receiveSubject: Subject<string>;
-  linesSubject: Subject<string>;
   errorsSubject: Subject<SerialError>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
+  clearTerminalText: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockSession = (supported = true): MockSession => {
+const createMockCore = (supported = true): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
   const receiveSubject = new Subject<string>();
-  const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnected$ = stateSubject.pipe(
     map((s) => s === SS.Connected),
@@ -42,10 +42,11 @@ const createMockSession = (supported = true): MockSession => {
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
+  const clearTerminalText = vi.fn();
+  const dispose$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => supported);
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
-  const session: SerialSession = {
+  const core: serialClientCore.SerialClientCore = {
     isBrowserSupported,
     connect$,
     disconnect$,
@@ -54,28 +55,26 @@ const createMockSession = (supported = true): MockSession => {
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    receiveReplay$: receiveSubject.asObservable(),
-    lines$: linesSubject.asObservable(),
     isConnected$,
-    portInfo$: portInfoSubject.asObservable(),
-    getPortInfo: () => portInfoSubject.getValue(),
-    getCurrentPort: () => null,
+    clearTerminalText,
+    dispose$,
   };
 
   return {
-    session,
+    core,
     stateSubject,
     receiveSubject,
-    linesSubject,
     errorsSubject,
     connect$,
     disconnect$,
     send$,
+    clearTerminalText,
+    dispose$,
     isBrowserSupported,
   };
 };
 
-let mockSessions: MockSession[] = [];
+let mockCores: MockCore[] = [];
 let nextSupported = true;
 
 vi.mock('svelte', async () => {
@@ -89,30 +88,30 @@ vi.mock('svelte', async () => {
   };
 });
 
-vi.mock('@gurezo/web-serial-rxjs', async () => {
+vi.mock('@gurezo/serial-client-core', async () => {
   const actual =
-    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
-      '@gurezo/web-serial-rxjs',
+    await vi.importActual<typeof import('@gurezo/serial-client-core')>(
+      '@gurezo/serial-client-core',
     );
   return {
     ...actual,
-    createSerialSession: vi.fn(() => {
-      const mock = createMockSession(nextSupported);
-      mockSessions.push(mock);
-      return mock.session;
+    createSerialClientCore: vi.fn(() => {
+      const mock = createMockCore(nextSupported);
+      mockCores.push(mock);
+      return mock.core;
     }),
   };
 });
 
-const latestMock = (): MockSession => {
-  const mock = mockSessions.at(-1);
-  if (!mock) throw new Error('createSerialSession was not called');
+const latestMock = (): MockCore => {
+  const mock = mockCores.at(-1);
+  if (!mock) throw new Error('createSerialClientCore was not called');
   return mock;
 };
 
 describe('useSerialSession', () => {
   beforeEach(() => {
-    mockSessions = [];
+    mockCores = [];
     nextSupported = true;
     (globalThis as unknown as { __svelteCleanup?: () => void }).__svelteCleanup =
       undefined;
@@ -135,6 +134,13 @@ describe('useSerialSession', () => {
     expect(get(s.receivedData)).toBe('');
     expect(get(s.errorMessage)).toBeNull();
     expect(get(s.browserSupported)).toBe(true);
+  });
+
+  it('createSerialClientCore に初期ボーレートを渡す', () => {
+    useSerialSession(9600);
+    expect(
+      vi.mocked(serialClientCore.createSerialClientCore),
+    ).toHaveBeenCalledWith(9600);
   });
 
   it('browserSupported は session.isBrowserSupported() の結果を反映する', () => {
@@ -186,11 +192,12 @@ describe('useSerialSession', () => {
     latestMock().receiveSubject.next('data');
     expect(get(s.receivedData)).toBe('data');
     s.clearReceivedData();
+    expect(latestMock().clearTerminalText).toHaveBeenCalled();
     expect(get(s.receivedData)).toBe('');
     unsub();
   });
 
-  it('connect$ / disconnect$ / send$ は session の対応メソッドへ委譲する', () => {
+  it('connect$ / disconnect$ / send$ は core の対応メソッドへ委譲する', () => {
     const s = useSerialSession();
 
     s.connect$().subscribe();
@@ -203,13 +210,16 @@ describe('useSerialSession', () => {
     expect(latestMock().disconnect$).toHaveBeenCalled();
   });
 
-  it('connect$(baudRate) で baudRate が変わると新しい session を生成する', () => {
+  it('connect$(baudRate) は core.connect$ にボーレートを渡す', () => {
     const s = useSerialSession(9600);
-    expect(mockSessions).toHaveLength(1);
+    expect(mockCores).toHaveLength(1);
 
     const unsub = s.state.subscribe(() => void 0);
     s.connect$(115200).subscribe();
-    expect(mockSessions).toHaveLength(2);
+    expect(latestMock().connect$).toHaveBeenCalledWith(115200);
+    expect(
+      vi.mocked(serialClientCore.createSerialClientCore),
+    ).toHaveBeenCalledTimes(1);
 
     latestMock().stateSubject.next(SS.Connecting);
     expect(get(s.state)).toBe(SS.Connecting);
@@ -226,13 +236,13 @@ describe('useSerialSession', () => {
     expect(onError).toHaveBeenCalledWith(err);
   });
 
-  it('onDestroy で session.disconnect$ が呼ばれる', () => {
+  it('onDestroy で core.dispose$ が呼ばれる', () => {
     useSerialSession();
     const mock = latestMock();
     const cleanup = (
       globalThis as unknown as { __svelteCleanup?: () => void }
     ).__svelteCleanup;
     cleanup?.();
-    expect(mock.disconnect$).toHaveBeenCalled();
+    expect(mock.dispose$).toHaveBeenCalled();
   });
 });

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,19 +1,14 @@
 import {
-  createSerialSession,
+  createSerialClientCore,
+  type SerialClientCore,
+} from '@gurezo/serial-client-core';
+import {
   SerialSessionState,
   type SerialError,
-  type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  type Observable,
-  ReplaySubject,
-  Subscription,
-  switchMap,
-} from 'rxjs';
+import { type Observable, Subscription } from 'rxjs';
 import { onDestroy } from 'svelte';
-import { readable, type Readable } from 'svelte/store';
+import { readable, writable, type Readable } from 'svelte/store';
 
 /** v2 `SerialSession` を Svelte store に薄く写す。表示は `terminalText$`（再接続は世代でリセット）。 */
 export interface UseSerialSessionReturn {
@@ -31,88 +26,58 @@ export interface UseSerialSessionReturn {
 export function useSerialSession(
   initialBaudRate = 9600,
 ): UseSerialSessionReturn {
-  let currentBaudRate = initialBaudRate;
-  let currentSession: SerialSession = createSerialSession({
-    baudRate: initialBaudRate,
-  });
-  const sessions$ = new ReplaySubject<SerialSession>(1);
-  const terminalBufferEpoch$ = new BehaviorSubject(0);
-  sessions$.next(currentSession);
+  const core: SerialClientCore = createSerialClientCore(initialBaudRate);
 
-  const browserSupported = readable(currentSession.isBrowserSupported());
+  const browserSupported = readable(core.isBrowserSupported());
 
   const state = readable<SerialSessionState>(SerialSessionState.Idle, (set) => {
-    const sub = sessions$
-      .pipe(switchMap((s) => s.state$))
-      .subscribe((next) => set(next));
+    const sub = core.state$.subscribe((next) => set(next));
     return () => sub.unsubscribe();
   });
 
   const isConnected = readable<boolean>(false, (set) => {
-    const sub = sessions$
-      .pipe(switchMap((s) => s.isConnected$))
-      .subscribe((next) => set(next));
+    const sub = core.isConnected$.subscribe((next) => set(next));
     return () => sub.unsubscribe();
   });
 
-  const bumpTerminalBufferEpoch = (): void => {
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
-  };
-
-  let setReceived: ((value: string) => void) | null = null;
-  const receivedData = readable<string>('', (set) => {
-    setReceived = set;
-    const sub = combineLatest([sessions$, terminalBufferEpoch$])
-      .pipe(switchMap(([s]) => s.terminalText$))
-      .subscribe(set);
-    return () => {
-      sub.unsubscribe();
-      setReceived = null;
-    };
+  const receivedData = writable('');
+  const terminalSub = core.terminalText$.subscribe((t) => {
+    receivedData.set(t);
   });
 
   const errorMessage = readable<string | null>(null, (set) => {
     const subs = new Subscription();
     subs.add(
-      sessions$
-        .pipe(switchMap((s) => s.errors$))
-        .subscribe((e: SerialError) => set(e.message)),
+      core.errors$.subscribe((e: SerialError) => set(e.message)),
     );
     subs.add(
-      sessions$
-        .pipe(switchMap((s) => s.state$))
-        .subscribe((next) => {
-          if (next === SerialSessionState.Connected || next === SerialSessionState.Idle)
-            set(null);
-        }),
+      core.state$.subscribe((next) => {
+        if (next === SerialSessionState.Connected || next === SerialSessionState.Idle)
+          set(null);
+      }),
     );
     return () => subs.unsubscribe();
   });
 
   onDestroy(() => {
-    currentSession.disconnect$().subscribe({ error: () => void 0 });
-    sessions$.complete();
+    terminalSub.unsubscribe();
+    core.dispose$().subscribe({ error: () => void 0 });
   });
 
   const connect$ = (baudRate?: number): Observable<void> => {
-    bumpTerminalBufferEpoch();
-    setReceived?.('');
-    if (baudRate !== undefined && baudRate !== currentBaudRate) {
-      currentBaudRate = baudRate;
-      currentSession = createSerialSession({ baudRate });
-      sessions$.next(currentSession);
-    }
-    return currentSession.connect$();
+    receivedData.set('');
+    core.clearTerminalText();
+    return core.connect$(baudRate);
   };
 
-  const disconnect$ = (): Observable<void> => currentSession.disconnect$();
+  const disconnect$ = (): Observable<void> => core.disconnect$();
 
   const send$ = (data: string | Uint8Array): Observable<void> =>
-    currentSession.send$(data);
+    core.send$(data);
 
   const clearReceivedData = (): void => {
-    bumpTerminalBufferEpoch();
-    setReceived?.('');
+    core.clearTerminalText();
+    receivedData.set('');
   };
 
   return {

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -1,32 +1,39 @@
 import type {
   SerialError,
-  SerialSession,
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
+import * as serialClientCore from '@gurezo/serial-client-core';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { mount } from '@vue/test-utils';
-import { BehaviorSubject, map, of, Subject, throwError, distinctUntilChanged } from 'rxjs';
+import {
+  BehaviorSubject,
+  distinctUntilChanged,
+  map,
+  of,
+  Subject,
+  throwError,
+} from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSerialClient } from './useSerialClient';
 
 const SS = webSerialRxjs.SerialSessionState;
 
-interface MockSession {
-  session: SerialSession;
+interface MockCore {
+  core: serialClientCore.SerialClientCore;
   stateSubject: BehaviorSubject<SerialSessionState>;
   receiveSubject: Subject<string>;
-  linesSubject: Subject<string>;
   errorsSubject: Subject<SerialError>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
+  clearTerminalText: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockSession = (): MockSession => {
+const createMockCore = (supported = true): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
   const receiveSubject = new Subject<string>();
-  const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnected$ = stateSubject.pipe(
     map((s) => s === SS.Connected),
@@ -35,10 +42,11 @@ const createMockSession = (): MockSession => {
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => true);
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
+  const clearTerminalText = vi.fn();
+  const dispose$ = vi.fn(() => of(undefined));
+  const isBrowserSupported = vi.fn(() => supported);
 
-  const session: SerialSession = {
+  const core: serialClientCore.SerialClientCore = {
     isBrowserSupported,
     connect$,
     disconnect$,
@@ -47,54 +55,51 @@ const createMockSession = (): MockSession => {
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    receiveReplay$: receiveSubject.asObservable(),
-    lines$: linesSubject.asObservable(),
     isConnected$,
-    portInfo$: portInfoSubject.asObservable(),
-    getPortInfo: () => portInfoSubject.getValue(),
-    getCurrentPort: () => null,
+    clearTerminalText,
+    dispose$,
   };
 
   return {
-    session,
+    core,
     stateSubject,
     receiveSubject,
-    linesSubject,
     errorsSubject,
     connect$,
     disconnect$,
     send$,
+    clearTerminalText,
+    dispose$,
     isBrowserSupported,
   };
 };
 
-let mockSessions: MockSession[] = [];
+let mockCores: MockCore[] = [];
+let nextSupported = true;
 
-vi.mock('@gurezo/web-serial-rxjs', async () => {
+vi.mock('@gurezo/serial-client-core', async () => {
   const actual =
-    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
-      '@gurezo/web-serial-rxjs',
+    await vi.importActual<typeof import('@gurezo/serial-client-core')>(
+      '@gurezo/serial-client-core',
     );
   return {
     ...actual,
-    createSerialSession: vi.fn(() => {
-      const mock = createMockSession();
-      mockSessions.push(mock);
-      return mock.session;
+    createSerialClientCore: vi.fn(() => {
+      const mock = createMockCore(nextSupported);
+      mockCores.push(mock);
+      return mock.core;
     }),
   };
 });
 
-const latestMock = (): MockSession => {
-  const mock = mockSessions.at(-1);
+const latestMock = (): MockCore => {
+  const mock = mockCores.at(-1);
   if (!mock) {
-    throw new Error('createSerialSession was not called');
+    throw new Error('createSerialClientCore was not called');
   }
   return mock;
 };
 
-// Test harness that mounts the composable inside a component so
-// `onUnmounted` works as in real usage.
 const TestComponent = {
   setup() {
     const api = useSerialClient(9600);
@@ -115,21 +120,22 @@ const mountHarness = () => {
 describe('useSerialClient', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockSessions = [];
+    mockCores = [];
+    nextSupported = true;
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('should create a session with the initial baud rate', () => {
+  it('should create core with the initial baud rate', () => {
     mountHarness();
     expect(
-      vi.mocked(webSerialRxjs.createSerialSession),
+      vi.mocked(serialClientCore.createSerialClientCore),
     ).toHaveBeenCalledTimes(1);
     expect(
-      vi.mocked(webSerialRxjs.createSerialSession),
-    ).toHaveBeenCalledWith({ baudRate: 9600 });
+      vi.mocked(serialClientCore.createSerialClientCore),
+    ).toHaveBeenCalledWith(9600);
   });
 
   it('should initialize with default refs', () => {
@@ -139,6 +145,12 @@ describe('useSerialClient', () => {
     expect(api.isConnected.value).toBe(false);
     expect(api.receivedData.value).toBe('');
     expect(api.errorMessage.value).toBe(null);
+  });
+
+  it('browserSupported reflects isBrowserSupported when unsupported', () => {
+    nextSupported = false;
+    const { api } = mountHarness();
+    expect(api.browserSupported.value).toBe(false);
   });
 
   it('should forward session state transitions to the state ref', () => {
@@ -163,32 +175,29 @@ describe('useSerialClient', () => {
     expect(api.errorMessage.value).toBe(null);
   });
 
-  it('should connect through the session', () => {
+  it('should connect through the core', () => {
     const { api } = mountHarness();
     api.connect$().subscribe();
     expect(latestMock().connect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should recreate the session when baud rate changes', () => {
+  it('should pass baud rate to core connect$', () => {
     const { api } = mountHarness();
     api.connect$(115200).subscribe();
 
+    expect(latestMock().connect$).toHaveBeenCalledWith(115200);
     expect(
-      vi.mocked(webSerialRxjs.createSerialSession),
-    ).toHaveBeenCalledTimes(2);
-    expect(
-      vi.mocked(webSerialRxjs.createSerialSession),
-    ).toHaveBeenLastCalledWith({ baudRate: 115200 });
-    expect(latestMock().connect$).toHaveBeenCalledTimes(1);
+      vi.mocked(serialClientCore.createSerialClientCore),
+    ).toHaveBeenCalledTimes(1);
   });
 
-  it('should disconnect through the session', () => {
+  it('should disconnect through the core', () => {
     const { api } = mountHarness();
     api.disconnect$().subscribe();
     expect(latestMock().disconnect$).toHaveBeenCalledTimes(1);
   });
 
-  it('should send payloads through the session', () => {
+  it('should send payloads through the core', () => {
     const { api } = mountHarness();
     api.send$('hello').subscribe();
     expect(latestMock().send$).toHaveBeenCalledWith('hello');
@@ -231,15 +240,16 @@ describe('useSerialClient', () => {
 
     expect(api.receivedData.value).toBe('chunk-1');
     api.clearReceivedData();
+    expect(mock.clearTerminalText).toHaveBeenCalled();
     expect(api.receivedData.value).toBe('');
   });
 
-  it('should disconnect the session on unmount', () => {
+  it('should dispose core on unmount', () => {
     const { wrapper } = mountHarness();
     const mock = latestMock();
 
     wrapper.unmount();
 
-    expect(mock.disconnect$).toHaveBeenCalledTimes(1);
+    expect(mock.dispose$).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,19 +1,15 @@
 import {
-  createSerialSession,
+  createSerialClientCore,
+  type SerialClientCore,
+} from '@gurezo/serial-client-core';
+import {
   SerialSessionState,
   type SerialError,
-  type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  Observable,
-  ReplaySubject,
-  switchMap,
-} from 'rxjs';
+import type { Observable } from 'rxjs';
 import { onUnmounted, ref, type Ref } from 'vue';
 
-/** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続は世代でリセット）。 */
+/** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続時は世代でリセット）。 */
 export interface UseSerialClientReturn {
   browserSupported: Ref<boolean>;
   state: Ref<SerialSessionState>;
@@ -27,63 +23,40 @@ export interface UseSerialClientReturn {
 }
 
 export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
-  const sessions$ = new ReplaySubject<SerialSession>(1);
-  let currentSession: SerialSession = createSerialSession({
-    baudRate: initialBaudRate,
-  });
-  let currentBaudRate = initialBaudRate;
-  sessions$.next(currentSession);
+  const core: SerialClientCore = createSerialClientCore(initialBaudRate);
 
-  const terminalBufferEpoch$ = new BehaviorSubject(0);
-  const bumpTerminalBufferEpoch = (): void => {
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
-  };
-
-  const browserSupported = ref(currentSession.isBrowserSupported());
+  const browserSupported = ref(core.isBrowserSupported());
   const state = ref<SerialSessionState>(SerialSessionState.Idle);
   const isConnected = ref(false);
   const receivedData = ref('');
   const errorMessage = ref<string | null>(null);
 
-  const stateSub = sessions$
-    .pipe(switchMap((session) => session.state$))
-    .subscribe((next) => {
-      state.value = next;
-      if (next === SerialSessionState.Connected || next === SerialSessionState.Idle) {
-        errorMessage.value = null;
-      }
-    });
-  const isConnectedSub = sessions$
-    .pipe(switchMap((session) => session.isConnected$))
-    .subscribe((next) => {
-      isConnected.value = next;
-    });
-  const receiveSub = combineLatest([sessions$, terminalBufferEpoch$])
-    .pipe(switchMap(([s]) => s.terminalText$))
-    .subscribe((text) => {
-      receivedData.value = text;
-    });
-  const errorsSub = sessions$
-    .pipe(switchMap((session) => session.errors$))
-    .subscribe((error: SerialError) => {
-      errorMessage.value = error.message;
-    });
+  const stateSub = core.state$.subscribe((next) => {
+    state.value = next;
+    if (next === SerialSessionState.Connected || next === SerialSessionState.Idle) {
+      errorMessage.value = null;
+    }
+  });
+  const isConnectedSub = core.isConnected$.subscribe((next) => {
+    isConnected.value = next;
+  });
+  const receiveSub = core.terminalText$.subscribe((text) => {
+    receivedData.value = text;
+  });
+  const errorsSub = core.errors$.subscribe((error: SerialError) => {
+    errorMessage.value = error.message;
+  });
 
   const connect$ = (baudRate?: number): Observable<void> => {
-    bumpTerminalBufferEpoch();
     receivedData.value = '';
-    if (baudRate !== undefined && baudRate !== currentBaudRate) {
-      currentBaudRate = baudRate;
-      currentSession = createSerialSession({ baudRate });
-      sessions$.next(currentSession);
-    }
-    return currentSession.connect$();
+    core.clearTerminalText();
+    return core.connect$(baudRate);
   };
-  const disconnect$ = (): Observable<void> => currentSession.disconnect$();
+  const disconnect$ = (): Observable<void> => core.disconnect$();
   const send$ = (data: string | Uint8Array): Observable<void> =>
-    currentSession.send$(data);
+    core.send$(data);
   const clearReceivedData = (): void => {
-    bumpTerminalBufferEpoch();
+    core.clearTerminalText();
     receivedData.value = '';
   };
 
@@ -92,8 +65,7 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     isConnectedSub.unsubscribe();
     receiveSub.unsubscribe();
     errorsSub.unsubscribe();
-    currentSession.disconnect$().subscribe({ error: () => void 0 });
-    sessions$.complete();
+    core.dispose$().subscribe({ error: () => void 0 });
   });
 
   return {


### PR DESCRIPTION
## Summary
Vue / Svelte の Serial 周りの重複ロジックを `@gurezo/serial-client-core` へ集約し、React のテストは Angular 例に合わせ `createSerialClientCore` を直接 mock する形に統一しました。親 #299 / 子 #302 の対応です。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #302

## What changed?
- `apps/example-vue/src/composables/useSerialClient.ts` を `createSerialClientCore` 経由の薄いラッパに変更
- `apps/example-svelte/src/stores/useSerialSession.ts` を同様に共通コア利用へ変更（受信表示は `writable` + `terminalText$` で React / Vue と同等にクリア可能）
- Vue / Svelte / React のユニットテストを `vi.mock('@gurezo/serial-client-core')` + MockCore パターンへ統一（ボーレート変更は `connect$` への引数、 teardown は `dispose$` で検証）

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

公開される hook / composable / store のプロパティ名・メソッド署名は変更していません。`@gurezo/web-serial-rxjs` の公開 API は変更していません。

## How to test
1. `pnpm nx run-many -t lint,test --projects=example-vue,example-svelte,example-react`
2. Chromium 系ブラウザで各 example を起動し、接続・送信・受信・クリア・再接続が従来どおりであることを確認

## Environment (if relevant)
- Browser: Chrome / Edge / Opera など（Web Serial API）
- OS: （確認環境に応じて記載）

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)