### PR TITLE
refactor(examples): vanilla-ts / vanilla-js の serial-client-core 共通化 (#303)

### DIFF
--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,9 +1,8 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
 import {
-  createSerialSession,
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import { BehaviorSubject, combineLatest, ReplaySubject, switchMap } from 'rxjs';
+import { createSerialClientCore } from '@gurezo/serial-client-core';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -37,20 +36,16 @@ export class App {
     const sendInput = $('send-input');
     const sendBtn = $('send-btn');
     const receiveOutput = $('receive-output');
-    this.baudRate = parseInt(baudRateSelect.value, 10);
-    this.session = createSerialSession({ baudRate: this.baudRate });
-    this.sessions$ = new ReplaySubject(1);
-    this.terminalBufferEpoch$ = new BehaviorSubject(0);
-    this.sessions$.next(this.session);
+    this.core = createSerialClientCore();
 
-    const supported = this.session.isBrowserSupported();
+    const supported = this.core.isBrowserSupported();
     setStatus(
       $('browser-support-status'),
       supported ? 'success' : 'error',
       supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
 
-    this.sessions$.pipe(switchMap((s) => s.state$)).subscribe((state) => {
+    this.core.state$.subscribe((state) => {
       const connected = state === SerialSessionState.Connected;
       const busy =
         state === SerialSessionState.Connecting ||
@@ -60,47 +55,36 @@ export class App {
       setStatus(status, ...STATUS[state]);
     });
 
-    this.sessions$
-      .pipe(switchMap((s) => s.isConnected$))
-      .subscribe((isConnected) => {
-        disconnectBtn.disabled = !isConnected;
-        sendInput.disabled = sendBtn.disabled = !isConnected;
-      });
+    this.core.isConnected$.subscribe((isConnected) => {
+      disconnectBtn.disabled = !isConnected;
+      sendInput.disabled = sendBtn.disabled = !isConnected;
+    });
 
-    combineLatest([this.sessions$, this.terminalBufferEpoch$])
-      .pipe(switchMap(([s]) => s.terminalText$))
-      .subscribe((text) => {
-        receiveOutput.value = text;
-        receiveOutput.scrollTop = receiveOutput.scrollHeight;
-      });
+    this.core.terminalText$.subscribe((text) => {
+      receiveOutput.value = text;
+      receiveOutput.scrollTop = receiveOutput.scrollHeight;
+    });
 
-    this.sessions$
-      .pipe(switchMap((s) => s.errors$))
-      .subscribe((error) => {
-        setStatus(status, 'error', `エラー: ${error.message}`);
-        console.error('Serial port error:', error);
-      });
+    this.core.errors$.subscribe((error) => {
+      setStatus(status, 'error', `エラー: ${error.message}`);
+      console.error('Serial port error:', error);
+    });
 
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
-      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+      this.core.clearTerminalText();
       receiveOutput.value = '';
-      if (baudRate !== this.baudRate) {
-        this.baudRate = baudRate;
-        this.session = createSerialSession({ baudRate });
-        this.sessions$.next(this.session);
-      }
-      this.session.connect$().subscribe({ error: () => void 0 });
+      this.core.connect$(baudRate).subscribe({ error: () => void 0 });
     });
 
     fromEvent(disconnectBtn, 'click').subscribe(() =>
-      this.session.disconnect$().subscribe({ error: () => void 0 }),
+      this.core.disconnect$().subscribe({ error: () => void 0 }),
     );
 
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
-      this.session.send$(`${text}\n`).subscribe({
+      this.core.send$(`${text}\n`).subscribe({
         next: () => (sendInput.value = ''),
         error: () => void 0,
       });
@@ -115,7 +99,7 @@ export class App {
       });
 
     fromEvent($('clear-receive-btn'), 'click').subscribe(() => {
-      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+      this.core.clearTerminalText();
       receiveOutput.value = '';
     });
   }

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line @nx/enforce-module-boundaries
 import {
   SerialSessionState,
 } from '@gurezo/web-serial-rxjs';

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -2,32 +2,29 @@ import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './app.js';
 
-vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
-  const actual = await importOriginal();
-  const state$ = new BehaviorSubject(actual.SerialSessionState.Idle);
+vi.mock('@gurezo/serial-client-core', () => {
+  const state$ = new BehaviorSubject('idle');
   const receive$ = new Subject();
-  const lines$ = new Subject();
   const errors$ = new Subject();
   const isConnected$ = state$.pipe(
-    map((s) => s === actual.SerialSessionState.Connected),
+    map((s) => s === 'connected'),
     distinctUntilChanged(),
   );
-  const mockSession = {
+  const core = {
     isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
     disconnect$: vi.fn(() => of(undefined)),
     send$: vi.fn(() => of(undefined)),
     state$,
     receive$,
-    terminalText$: actual.createTerminalBuffer(receive$).text$,
-    receiveReplay$: receive$,
-    lines$,
+    terminalText$: receive$,
     errors$,
     isConnected$,
+    clearTerminalText: vi.fn(),
+    dispose$: vi.fn(() => of(undefined)),
   };
   return {
-    ...actual,
-    createSerialSession: vi.fn(() => mockSession),
+    createSerialClientCore: vi.fn(() => core),
   };
 });
 
@@ -67,10 +64,10 @@ describe('App', () => {
     expect(app).toBeInstanceOf(App);
   });
 
-  it('should create a SerialSession via createSerialSession on init', async () => {
-    const { createSerialSession } = await import('@gurezo/web-serial-rxjs');
+  it('should create serial client core on init', async () => {
+    const { createSerialClientCore } = await import('@gurezo/serial-client-core');
     app = new App();
-    expect(createSerialSession).toHaveBeenCalled();
+    expect(createSerialClientCore).toHaveBeenCalled();
   });
 
   it('should render browser support status based on session.isBrowserSupported', () => {

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -1,5 +1,6 @@
 import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSerialClientCore } from '@gurezo/serial-client-core';
 import { App } from './app.js';
 
 vi.mock('@gurezo/serial-client-core', () => {
@@ -64,8 +65,7 @@ describe('App', () => {
     expect(app).toBeInstanceOf(App);
   });
 
-  it('should create serial client core on init', async () => {
-    const { createSerialClientCore } = await import('@gurezo/serial-client-core');
+  it('should create serial client core on init', () => {
     app = new App();
     expect(createSerialClientCore).toHaveBeenCalled();
   });

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -1,37 +1,30 @@
-import type { SerialError, SerialSession } from '@gurezo/web-serial-rxjs';
 import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './app.js';
 
-vi.mock('@gurezo/web-serial-rxjs', async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import('@gurezo/web-serial-rxjs')>();
-  const state$ = new BehaviorSubject<string>(
-    actual.SerialSessionState.Idle,
-  );
+vi.mock('@gurezo/serial-client-core', () => {
+  const state$ = new BehaviorSubject<string>('idle');
   const receive$ = new Subject<string>();
-  const lines$ = new Subject<string>();
-  const errors$ = new Subject<SerialError>();
+  const errors$ = new Subject<{ message: string }>();
   const isConnected$ = state$.pipe(
-    map((s) => s === actual.SerialSessionState.Connected),
+    map((s) => s === 'connected'),
     distinctUntilChanged(),
   );
-  const mockSession = {
+  const core = {
     isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
     disconnect$: vi.fn(() => of(undefined)),
     send$: vi.fn(() => of(undefined)),
     state$,
     receive$,
-    terminalText$: actual.createTerminalBuffer(receive$).text$,
-    receiveReplay$: receive$,
-    lines$,
+    terminalText$: receive$,
     errors$,
     isConnected$,
+    clearTerminalText: vi.fn(),
+    dispose$: vi.fn(() => of(undefined)),
   };
   return {
-    ...actual,
-    createSerialSession: vi.fn(() => mockSession as unknown as SerialSession),
+    createSerialClientCore: vi.fn(() => core),
   };
 });
 
@@ -71,10 +64,10 @@ describe('App', () => {
     expect(app).toBeInstanceOf(App);
   });
 
-  it('should create a SerialSession via createSerialSession on init', async () => {
-    const { createSerialSession } = await import('@gurezo/web-serial-rxjs');
+  it('should create serial client core on init', async () => {
+    const { createSerialClientCore } = await import('@gurezo/serial-client-core');
     app = new App();
-    expect(createSerialSession).toHaveBeenCalled();
+    expect(createSerialClientCore).toHaveBeenCalled();
   });
 
   it('should render browser support status based on session.isBrowserSupported', () => {

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -1,5 +1,6 @@
 import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSerialClientCore } from '@gurezo/serial-client-core';
 import { App } from './app.js';
 
 vi.mock('@gurezo/serial-client-core', () => {
@@ -64,8 +65,7 @@ describe('App', () => {
     expect(app).toBeInstanceOf(App);
   });
 
-  it('should create serial client core on init', async () => {
-    const { createSerialClientCore } = await import('@gurezo/serial-client-core');
+  it('should create serial client core on init', () => {
     app = new App();
     expect(createSerialClientCore).toHaveBeenCalled();
   });

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,15 +1,8 @@
 import {
-  createSerialSession,
   SerialSessionState,
-  type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  fromEvent,
-  ReplaySubject,
-  switchMap,
-} from 'rxjs';
+import { createSerialClientCore } from '@gurezo/serial-client-core';
+import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 type StatusType = 'info' | 'success' | 'error';
@@ -38,14 +31,7 @@ const setStatus = (el: HTMLElement, type: StatusType, msg: string): void => {
 };
 
 export class App {
-  private session: SerialSession;
-  private baudRate: number;
-  private readonly sessions$ = new ReplaySubject<SerialSession>(1);
-  private readonly terminalBufferEpoch$ = new BehaviorSubject(0);
-
-  private bumpTerminalBufferEpoch(): void {
-    this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
-  }
+  private readonly core = createSerialClientCore();
 
   constructor() {
     const connectBtn = $<HTMLButtonElement>('connect-btn');
@@ -55,18 +41,14 @@ export class App {
     const sendInput = $<HTMLInputElement>('send-input');
     const sendBtn = $<HTMLButtonElement>('send-btn');
     const receiveOutput = $<HTMLTextAreaElement>('receive-output');
-    this.baudRate = parseInt(baudRateSelect.value, 10);
-    this.session = createSerialSession({ baudRate: this.baudRate });
-    this.sessions$.next(this.session);
-
-    const supported = this.session.isBrowserSupported();
+    const supported = this.core.isBrowserSupported();
     setStatus(
       $<HTMLElement>('browser-support-status'),
       supported ? 'success' : 'error',
       supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
 
-    this.sessions$.pipe(switchMap((s) => s.state$)).subscribe((state) => {
+    this.core.state$.subscribe((state) => {
       const connected = state === S.Connected;
       const busy = state === S.Connecting || state === S.Disconnecting;
       connectBtn.disabled = !supported || connected || busy;
@@ -74,47 +56,36 @@ export class App {
       setStatus(status, ...STATUS[state]);
     });
 
-    this.sessions$
-      .pipe(switchMap((s) => s.isConnected$))
-      .subscribe((isConnected) => {
-        disconnectBtn.disabled = !isConnected;
-        sendInput.disabled = sendBtn.disabled = !isConnected;
-      });
+    this.core.isConnected$.subscribe((isConnected) => {
+      disconnectBtn.disabled = !isConnected;
+      sendInput.disabled = sendBtn.disabled = !isConnected;
+    });
 
-    combineLatest([this.sessions$, this.terminalBufferEpoch$])
-      .pipe(switchMap(([s]) => s.terminalText$))
-      .subscribe((text) => {
-        receiveOutput.value = text;
-        receiveOutput.scrollTop = receiveOutput.scrollHeight;
-      });
+    this.core.terminalText$.subscribe((text) => {
+      receiveOutput.value = text;
+      receiveOutput.scrollTop = receiveOutput.scrollHeight;
+    });
 
-    this.sessions$
-      .pipe(switchMap((s) => s.errors$))
-      .subscribe((error) => {
-        setStatus(status, 'error', `エラー: ${error.message}`);
-        console.error('Serial port error:', error);
-      });
+    this.core.errors$.subscribe((error) => {
+      setStatus(status, 'error', `エラー: ${error.message}`);
+      console.error('Serial port error:', error);
+    });
 
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
-      this.bumpTerminalBufferEpoch();
+      this.core.clearTerminalText();
       receiveOutput.value = '';
-      if (baudRate !== this.baudRate) {
-        this.baudRate = baudRate;
-        this.session = createSerialSession({ baudRate });
-        this.sessions$.next(this.session);
-      }
-      this.session.connect$().subscribe({ error: () => void 0 });
+      this.core.connect$(baudRate).subscribe({ error: () => void 0 });
     });
 
     fromEvent(disconnectBtn, 'click').subscribe(() =>
-      this.session.disconnect$().subscribe({ error: () => void 0 }),
+      this.core.disconnect$().subscribe({ error: () => void 0 }),
     );
 
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
-      this.session.send$(`${text}\n`).subscribe({
+      this.core.send$(`${text}\n`).subscribe({
         next: () => (sendInput.value = ''),
         error: () => void 0,
       });
@@ -129,7 +100,7 @@ export class App {
       });
 
     fromEvent($<HTMLButtonElement>('clear-receive-btn'), 'click').subscribe(() => {
-      this.bumpTerminalBufferEpoch();
+      this.core.clearTerminalText();
       receiveOutput.value = '';
     });
   }


### PR DESCRIPTION
## Summary
vanilla-ts / vanilla-js のシリアル状態管理を `serial-client-core` に統一し、重複していたセッション管理実装を削減しました。
DOM イベント処理と UI 挙動は維持したまま、接続・切断・送信・受信表示の責務を共通コアへ集約しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #303

## What changed?
- vanilla-ts の `App` 実装を `createSerialClientCore` 利用へ移行
- vanilla-js の `App` 実装を `createSerialClientCore` 利用へ移行
- `sessions$` / `terminalBufferEpoch$` の直接管理を削減
- テストモックを `serial-client-core` ベースへ更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `npx nx test example-vanilla-ts`
2. `npx nx test example-vanilla-js`
3. 可能であれば `example-vanilla-ts` / `example-vanilla-js` を起動し、connect/disconnect/send/clear の UI 挙動を確認

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / etc. (version: )
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification):
- RxJS version:

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)