### PR TITLE
chore(workspace): docs/README/テストの整合性を更新

### DIFF
--- a/apps/example-angular/README.md
+++ b/apps/example-angular/README.md
@@ -92,7 +92,7 @@ This example uses Angular Services and RxJS observables to handle serial port co
 
 1. **Browser Support Check**: On initialization, the app checks if the browser supports the Web Serial API using the `SerialClientService`.
 
-2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses the `SerialClientService`, which internally wraps a v2 `SerialSession` created via `createSerialSession()`.
+2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses the `SerialClientService`, which internally wraps `createSerialClientCore()`.
 
 3. **Configuration**: Users can select the baud rate before connecting. The baud rate is managed as component property.
 

--- a/apps/example-react/README.md
+++ b/apps/example-react/README.md
@@ -77,20 +77,20 @@ pnpm exec nx lint example-react
 
 ## How It Works
 
-The example uses the v2 `SerialSession` API directly:
+The example uses `@gurezo/serial-client-core` through `useSerialSession`:
 
 1. **Browser support check**: `useSerialSession` calls `session.isBrowserSupported()` once on mount and exposes the result as `browserSupported`.
-2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`. When the baud rate changes between calls, the hook transparently creates a new `SerialSession` so subsequent streams reflect the new port configuration.
-3. **State UI**: The hook subscribes to `session.state$` and `session.isConnected$`. `App.tsx` uses `SerialSessionState` for status text and `isConnected` for button enablement.
+2. **Connection**: Clicking "接続" invokes `connect$(baudRate)` on the shared core wrapper. When the baud rate changes between calls, the core transparently re-creates the underlying session so subsequent streams reflect the new port configuration.
+3. **State UI**: The hook subscribes to `core.state$` and `core.isConnected$`. `App.tsx` uses `SerialSessionState` for status text and `isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.
-5. **Receiving**: The hook subscribes to **`session.terminalText$`** and mirrors the result in `receivedData` (carriage-return safe). Use **`lines$`** for complete-line logging or simple parsers; it drops lone `\r` behavior (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
-6. **Errors**: All connect/read/write/close failures are multiplexed through `session.errors$` and surfaced as the hook's `errorMessage` state. No per-call try/catch wrappers are needed.
+5. **Receiving**: The hook subscribes to **`core.terminalText$`** and mirrors the result in `receivedData` (carriage-return safe). Use **`lines$`** for complete-line logging or simple parsers; it drops lone `\r` behavior (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+6. **Errors**: All connect/read/write/close failures are multiplexed through `core.errors$` and surfaced as the hook's `errorMessage` state. No per-call try/catch wrappers are needed.
 
 ## Code Structure
 
 - `src/main.tsx`: Application entry point (React 18 `createRoot` API)
 - `src/App.tsx`: Main component; renders UI from `useSerialSession` state
-- `src/hooks/useSerialSession.ts`: Custom hook wrapping `createSerialSession`
+- `src/hooks/useSerialSession.ts`: Custom hook wrapping `createSerialClientCore`
 - `src/hooks/useSerialSession.test.ts`: Hook unit tests (Testing Library + Vitest)
 - `src/App.test.tsx`: Component-level tests
 - `src/styles.css`: Styling

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -209,6 +209,19 @@ describe('useSerialSession', () => {
     expect(result.current.state).toBe(SS.Connecting);
   });
 
+  it('connect$ 実行時に terminalText の表示状態をリセットする', () => {
+    const { result } = renderHook(() => useSerialSession());
+    act(() => latestMock().receiveSubject.next('stale-data'));
+    expect(result.current.receivedData).toBe('stale-data');
+
+    act(() => {
+      result.current.connect$().subscribe();
+    });
+
+    expect(latestMock().clearTerminalText).toHaveBeenCalledTimes(1);
+    expect(result.current.receivedData).toBe('');
+  });
+
   it('connect$ が失敗すると subscriber にエラーが渡る', () => {
     const { result } = renderHook(() => useSerialSession());
     const err = new Error('no port');

--- a/apps/example-svelte/README.md
+++ b/apps/example-svelte/README.md
@@ -77,20 +77,20 @@ pnpm exec nx lint example-svelte
 
 ## How It Works
 
-The example uses the v2 `SerialSession` API directly:
+The example uses `@gurezo/serial-client-core` through `useSerialSession`:
 
 1. **Browser support check**: `useSerialSession` calls `session.isBrowserSupported()` once at creation time and exposes the result as the `browserSupported` store.
-2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`. When the baud rate changes between calls, the helper transparently creates a new `SerialSession` so subsequent streams reflect the new port configuration.
-3. **State UI**: The helper subscribes to `session.state$` and `session.isConnected$`. `App.svelte` branches on `SerialSessionState` for status and uses `$isConnected` for button enablement.
+2. **Connection**: Clicking "接続" invokes `connect$(baudRate)` on the shared core wrapper. When the baud rate changes between calls, the core transparently re-creates the underlying session so subsequent streams reflect the new port configuration.
+3. **State UI**: The helper subscribes to `core.state$` and `core.isConnected$`. `App.svelte` branches on `SerialSessionState` for status and uses `$isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.
-5. **Receiving**: The store reflects **`session.terminalText$`** in `receivedData`. **`lines$`** is for one-line-at-a-time logging or newline-only parsing; raw chunk streaming without terminal folding uses `receive$` (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
-6. **Errors**: All connect/read/write/close failures are multiplexed through `session.errors$` and surfaced as the `errorMessage` store. No per-call try/catch wrappers are needed.
+5. **Receiving**: The store reflects **`core.terminalText$`** in `receivedData`. **`lines$`** is for one-line-at-a-time logging or newline-only parsing; raw chunk streaming without terminal folding uses `receive$` (see [Advanced Usage](../../packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+6. **Errors**: All connect/read/write/close failures are multiplexed through `core.errors$` and surfaced as the `errorMessage` store. No per-call try/catch wrappers are needed.
 
 ## Code Structure
 
 - `src/main.ts`: Application entry point
 - `src/App.svelte`: Main component; renders UI from the `useSerialSession` stores
-- `src/stores/useSerialSession.ts`: Svelte helper wrapping `createSerialSession`
+- `src/stores/useSerialSession.ts`: Svelte helper wrapping `createSerialClientCore`
 - `src/stores/useSerialSession.test.ts`: Store unit tests (Vitest)
 - `src/App.test.ts`: Smoke test for the component
 - `src/styles.css`: Styling

--- a/apps/example-vanilla-js/README.md
+++ b/apps/example-vanilla-js/README.md
@@ -90,13 +90,13 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 1. **Browser Support Check**: On initialization, the app checks if the browser supports the Web Serial API.
 
-2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses `createSerialSession()` to create a session instance.
+2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses `createSerialClientCore()` and delegates connect/disconnect/send through the shared core.
 
 3. **Configuration**: Users can select the baud rate before connecting.
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array`.
 
-5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`session.terminalText$`** into the textarea. **`lines$`** is for line-oriented logs, not raw `\r`-heavy shell output.
+5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`core.terminalText$`** into the textarea. **`lines$`** is for line-oriented logs, not raw `\r`-heavy shell output.
 
 ## Code Structure
 

--- a/apps/example-vanilla-ts/README.md
+++ b/apps/example-vanilla-ts/README.md
@@ -91,13 +91,13 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 1. **Browser Support Check**: On initialization, the app checks if the browser supports the Web Serial API.
 
-2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses `createSerialSession()` to create a session instance.
+2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses `createSerialClientCore()` and delegates connect/disconnect/send through the shared core.
 
 3. **Configuration**: Users can select the baud rate before connecting.
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array`.
 
-5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`session.terminalText$`** into the textarea so `\r`-based redraws (e.g. shell progress) stay aligned. Raw streaming without terminal folding uses `receive$`; **`lines$`** remains for line-oriented logs.
+5. **Data Receiving**: Data is decoded as UTF-8; the app mirrors **`core.terminalText$`** into the textarea so `\r`-based redraws (e.g. shell progress) stay aligned. Raw streaming without terminal folding uses `receive$`; **`lines$`** remains for line-oriented logs.
 
 ## Code Structure
 

--- a/apps/example-vue/README.md
+++ b/apps/example-vue/README.md
@@ -92,13 +92,13 @@ This example uses Vue 3 Composition API and RxJS observables to handle serial po
 
 1. **Browser Support Check**: On initialization, the app checks if the browser supports the Web Serial API using the `useSerialClient` composable.
 
-2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses the `useSerialClient` composable, which internally wraps a v2 `SerialSession` created via `createSerialSession()`.
+2. **Connection**: Users can connect to a serial port by clicking the "接続" (Connect) button. The app uses the `useSerialClient` composable, which internally wraps `createSerialClientCore()`.
 
 3. **Configuration**: Users can select the baud rate before connecting. The baud rate is managed as Vue reactive state using `ref`.
 
 4. **Data Sending**: Users can type text in the input field and send it to the serial port. The text is encoded as UTF-8 and sent as `Uint8Array` through the composable's `send` method.
 
-5. **Data Receiving**: Incoming bytes are decoded as UTF-8; the composable surfaces **`session.terminalText$`** into the textarea-bound ref. Use **`lines$`** for newline-delimited logs—not for interactive shell mirrors where `\r` redraw matters.
+5. **Data Receiving**: Incoming bytes are decoded as UTF-8; the composable surfaces **`core.terminalText$`** into the textarea-bound ref. Use **`lines$`** for newline-delimited logs—not for interactive shell mirrors where `\r` redraw matters.
 
 ## Code Structure
 

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -191,6 +191,19 @@ describe('useSerialClient', () => {
     ).toHaveBeenCalledTimes(1);
   });
 
+  it('should reset terminal text state before connect$', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
+
+    mock.receiveSubject.next('stale-data');
+    expect(api.receivedData.value).toBe('stale-data');
+
+    api.connect$().subscribe();
+
+    expect(mock.clearTerminalText).toHaveBeenCalledTimes(1);
+    expect(api.receivedData.value).toBe('');
+  });
+
   it('should disconnect through the core', () => {
     const { api } = mountHarness();
     api.disconnect$().subscribe();

--- a/docs/OVERVIEW.ja.md
+++ b/docs/OVERVIEW.ja.md
@@ -32,6 +32,8 @@
 - Svelte
 - Vanilla JavaScript / TypeScript
 
+このモノレポの example アプリでは、`SerialSession` の薄い共通ラッパーとして `@gurezo/serial-client-core` を利用し、接続ロジックを共通化しつつ UI バインディングは各フレームワーク側で扱います。
+
 ## SerialSession（v2）の全体像
 
 `createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**ターミナルにそのまま出す出力**は **`receive$`**、**改行区切りのログや解析**は **`lines$`** が担当します。独自区切りが必要なときは **`receive$`** 上に RxJS で組み立てます（[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -32,6 +32,8 @@ This library is framework-agnostic and can be used with:
 - Svelte
 - Vanilla JavaScript / TypeScript
 
+In this monorepo, the example apps use `@gurezo/serial-client-core` as a thin shared wrapper over `SerialSession` so UI bindings stay framework-specific while connection behavior stays consistent.
+
 ## SerialSession (v2) at a glance
 
 `createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; **`receive$`** is for **raw decoder output** (including terminals and `\r` redraws), **`lines$`** for **newline-delimited logs and parsers**. When you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).


### PR DESCRIPTION
## Summary
Issue #304 の完了条件に合わせて、example 群の README 記述・テスト観点・概要ドキュメントを実装状態に同期しました。
共通化済みの `@gurezo/serial-client-core` 利用実態に説明を揃え、再接続時の terminal 表示リセットをテストで明示しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #304
- Refs #299

## What changed?
- 6つの example README で、`createSerialSession()` 直利用の説明を `createSerialClientCore()` ベースへ更新
- React/Vue の wrapper テストに、`connect$` 実行時の terminalText リセット（`clearTerminalText` 呼び出し + 表示クリア）検証を追加
- `docs/OVERVIEW.md` / `docs/OVERVIEW.ja.md` に、example アプリが共有コアを利用する旨を追記

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx run-many -t lint -p example-angular,example-react,example-vue,example-svelte,example-vanilla-js,example-vanilla-ts`
2. `pnpm exec nx run-many -t test -p example-angular,example-react,example-vue,serial-client-core`
3. README/OVERVIEW の記述が `@gurezo/serial-client-core` ベースの実装説明に一致していることを確認

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / etc. (version: N/A)
- OS: macOS
- web-serial-rxjs version (for verification): workspace source
- RxJS version: workspace managed

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)