### PR TITLE
docs(workspace): OVERVIEW導入の重複説明を整理

### DIFF
--- a/docs/OVERVIEW.ja.md
+++ b/docs/OVERVIEW.ja.md
@@ -32,8 +32,6 @@
 - Svelte
 - Vanilla JavaScript / TypeScript
 
-このモノレポの example アプリでは、`createSerialSession` を直接利用し、各アプリ単体で最小利用方法が読み取れる構成にしています。
-
 ## SerialSession（v2）の全体像
 
 `createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**ターミナルにそのまま出す出力**は **`receive$`**、**改行区切りのログや解析**は **`lines$`** が担当します。独自区切りが必要なときは **`receive$`** 上に RxJS で組み立てます（[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -32,8 +32,6 @@ This library is framework-agnostic and can be used with:
 - Svelte
 - Vanilla JavaScript / TypeScript
 
-In this monorepo, the example apps use `createSerialSession` directly so each app is self-contained and the minimum integration surface is visible in place.
-
 ## SerialSession (v2) at a glance
 
 `createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; **`receive$`** is for **raw decoder output** (including terminals and `\r` redraws), **`lines$`** for **newline-delimited logs and parsers**. When you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).


### PR DESCRIPTION
## Summary
Issue #314 に対応し、docs/OVERVIEW.md と docs/OVERVIEW.ja.md の導入部にあった重複的な補足説明を削除しました。
読者が SerialSession（v2）概要までより短い導線で到達できるようにしています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #314

## What changed?
- docs/OVERVIEW.md の導入部からモノレポ example 構成の補足文を削除
- docs/OVERVIEW.ja.md の同等箇所から同内容の補足文を削除
- API 説明本体やリンク構成は変更せず、導入文のみを整理

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. git checkout docs/workspace-overview-trim-intro
2. git diff main...HEAD -- docs/OVERVIEW.md docs/OVERVIEW.ja.md
3. 導入部の重複説明のみ削除され、SerialSession（v2）以降の内容が維持されていることを確認

## Environment (if relevant)
- Browser: N/A (version: N/A)
- OS: macOS
- web-serial-rxjs version (for verification): N/A (docs only)
- RxJS version: N/A (docs only)

## Checklist
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)
