### PR TITLE
feat(web-serial-rxjs): TypeDoc に projectDocuments を追加して docs Markdown を統合

### DIFF
--- a/packages/web-serial-rxjs/typedoc.json
+++ b/packages/web-serial-rxjs/typedoc.json
@@ -20,5 +20,7 @@
   "name": "web-serial-rxjs API Documentation",
   "includeVersion": false,
   "gitRevision": "main",
+  "projectDocuments": ["./docs/**/*.md"],
+  "searchInDocuments": true,
   "plugin": ["typedoc-rhineai-theme"]
 }


### PR DESCRIPTION
## Summary
TypeDoc 設定に `projectDocuments` を追加し、`docs/**/*.md` を API ドキュメントサイト内に統合しました。
あわせて `searchInDocuments` を有効化し、ガイド系 Markdown も検索対象に含めました。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #317
- Related #316

## What changed?
- `packages/web-serial-rxjs/typedoc.json` に `"projectDocuments": ["./docs/**/*.md"]` を追加
- `packages/web-serial-rxjs/typedoc.json` に `"searchInDocuments": true` を追加
- `pnpm run docs:generate` を実行し、`docs/documents/*.html` が生成されることを確認

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs:generate` を実行する
2. 生成されたドキュメント内に `documents/OVERVIEW.html` など docs 由来ページが作成されることを確認する
3. TypeDoc の検索で docs 配下の文言が対象になることを確認する

## Environment (if relevant)
- Browser: N/A
- OS: macOS
- web-serial-rxjs version (for verification): current workspace
- RxJS version: workspace peer dependency (`^7.8.0`)

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)