### PR TITLE
docs(web-serial-rxjs): TypeDoc向けにMarkdown内リンクを相対パスへ修正

### DIFF
--- a/docs/documents/OVERVIEW.html
+++ b/docs/documents/OVERVIEW.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html><html class="default" lang="en" data-base="../"><head><meta charset="utf-8"/><meta http-equiv="x-ua-compatible" content="IE=edge"/><title>OVERVIEW | web-serial-rxjs API Documentation</title><meta name="description" content="Documentation for web-serial-rxjs API Documentation"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="../assets/style.css"/><link rel="stylesheet" href="../assets/highlight.css"/><script defer src="../assets/main.js"></script><script async src="../assets/icons.js" id="tsd-icons-script"></script><script async src="../assets/search.js" id="tsd-search-script"></script><script async src="../assets/navigation.js" id="tsd-nav-script"></script><link rel="stylesheet" href="../assets/rhineai-style.css"/></head><body><script>document.documentElement.dataset.theme = localStorage.getItem("tsd-theme") || "os";document.body.style.display="none";setTimeout(() => window.app?app.showPage():document.body.style.removeProperty("display"),500)</script><header class="tsd-page-toolbar"><div class="tsd-toolbar-contents container"><a href="../index.html" class="title">web-serial-rxjs API Documentation</a><div id="tsd-toolbar-links"></div><button id="tsd-search-trigger" class="tsd-widget" aria-label="Search"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-search"></use></svg></button><dialog id="tsd-search" aria-label="Search"><input role="combobox" id="tsd-search-input" aria-controls="tsd-search-results" aria-autocomplete="list" aria-expanded="true" autocapitalize="off" autocomplete="off" placeholder="Search the docs" maxLength="100"/><ul role="listbox" id="tsd-search-results"></ul><div id="tsd-search-status" aria-live="polite" aria-atomic="true"><div>Preparing search index...</div></div></dialog><a href="#" class="tsd-widget menu" id="tsd-toolbar-menu-trigger" data-toggle="menu" aria-label="Menu"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-menu"></use></svg></a></div></header><div class="container container-main"><div class="col-content"><div class="tsd-page-title"><ul class="tsd-breadcrumb" aria-label="Breadcrumb"><li><a href="" aria-current="page">OVERVIEW</a></li></ul></div><div class="tsd-panel tsd-typography"><h1 id="serialsession-v2-overview" class="tsd-anchor-link">SerialSession (v2) overview<a href="#serialsession-v2-overview" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h1>
+<p align="center">
+  <img src="../media/web-serial-rxjs-icon.png" alt="web-serial-rxjs project icon" width="512" />
+</p>
+<p>This page is the <strong>mental model</strong> for the v2 public API: what each <code>SerialSession</code> surface does, how <code>SerialSessionState</code> maps to <code>state$</code>, and how to choose between <code>receive$</code> and <code>lines$</code>. For options, error codes, and formal type details, see <a href="modules.html">API Reference</a>.</p>
+<h2 id="table-of-contents" class="tsd-anchor-link">Table of Contents<a href="#table-of-contents" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<ul>
+<li><a href="#features">Features</a></li>
+<li><a href="#framework-support">Framework support</a></li>
+<li><a href="#serialsession-v2-at-a-glance">SerialSession (v2) at a glance</a></li>
+<li><a href="#documentation-index">Documentation index</a></li>
+</ul>
+<h2 id="features" class="tsd-anchor-link">Features<a href="#features" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<ul>
+<li><strong>Session-oriented reactive API</strong>: a single <code>SerialSession</code> exposes <code>state$</code>, <code>isConnected$</code>, <code>receive$</code>, <code>lines$</code>, <code>errors$</code>, plus <code>connect$</code>, <code>disconnect$</code>, and <code>send$</code></li>
+<li><strong>UTF-8 text stream</strong>: <code>receive$</code> is already decoded with a streaming <code>TextDecoder</code>, so multi-byte characters split across chunks are joined correctly</li>
+<li><strong>Ordered send queue</strong>: concurrent <code>send$</code> calls are serialized internally in call order, without the caller having to manage a writer</li>
+<li><strong>Unified error channel</strong>: every I/O error is normalised into <code>SerialError</code> and multiplexed on <code>errors$</code></li>
+<li><strong>Explicit lifecycle</strong>: <code>state$</code> emits <code>idle</code> / <code>connecting</code> / <code>connected</code> / <code>disconnecting</code> / <code>unsupported</code> / <code>error</code> so UIs can drive directly from it</li>
+<li><strong>TypeScript support</strong>: full TypeScript type definitions included</li>
+<li><strong>Framework agnostic</strong>: works with any JavaScript/TypeScript framework or vanilla JavaScript</li>
+</ul>
+<h2 id="framework-support" class="tsd-anchor-link">Framework support<a href="#framework-support" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<p>This library is framework-agnostic and can be used with:</p>
+<ul>
+<li>Angular</li>
+<li>React</li>
+<li>Svelte</li>
+<li>Vanilla JavaScript / TypeScript</li>
+</ul>
+<h2 id="serialsession-v2-at-a-glance" class="tsd-anchor-link">SerialSession (v2) at a glance<a href="#serialsession-v2-at-a-glance" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<p><code>createSerialSession</code> returns a single <strong>SerialSession</strong>. All interaction goes through the fields below. The public API is intentionally small; <strong><code>receive$</code></strong> is for <strong>raw decoder output</strong> (including terminals and <code>\r</code> redraws), <strong><code>lines$</code></strong> for <strong>newline-delimited logs and parsers</strong>. When you need <strong>custom</strong> framing, compose plain RxJS on <code>receive$</code> (see <a href="ADVANCED_USAGE.html">Advanced Usage</a>).</p>
+<table>
+<thead>
+<tr>
+<th>Surface</th>
+<th>Role</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>state$</code></td>
+<td><strong>Connection lifecycle</strong> — <code>idle</code> / <code>connecting</code> / <code>connected</code> / <code>disconnecting</code> / <code>error</code> / <code>unsupported</code>. Replays the current state on subscribe. Compare with <strong><code>SerialSessionState</code></strong> instead of string literals.</td>
+</tr>
+<tr>
+<td><code>SerialSessionState</code></td>
+<td><strong>State constants</strong> — exported const object (e.g. <code>SerialSessionState.Connected</code>, <code>SerialSessionState.Idle</code>) with the same values <code>state$</code> emits.</td>
+</tr>
+<tr>
+<td><code>isConnected$</code></td>
+<td><strong>Connected flag</strong> — <code>true</code> only when <code>state$</code> is <code>SerialSessionState.Connected</code>; <code>false</code> in every other state (derived from <code>state$</code> with <code>distinctUntilChanged</code>).</td>
+</tr>
+<tr>
+<td><code>receive$</code></td>
+<td><strong>Raw decoder chunks</strong> — UTF-8 text as emitted by the pump (not line-aligned; multi-byte safe). Preserves <code>\r</code> and other control characters. Use for <strong>terminal-like mirrors</strong> and progress output that relies on carriage-return redraws.</td>
+</tr>
+<tr>
+<td><code>terminalText$</code></td>
+<td><strong>Terminal-ready cumulative text</strong> — display-oriented text derived from <code>receive$</code> that folds carriage-return redraws while keeping normal newline behavior. Use when you want to bind one string directly to a terminal-like viewport.</td>
+</tr>
+<tr>
+<td><code>lines$</code></td>
+<td><strong>Line-delimited UTF-8 text</strong> — one string per complete line via the built-in buffer (<code>\n</code>, <code>\r\n</code>, interior <code>\r</code>). Use for <strong>logs</strong> and <strong>line-by-line parsing</strong>, not for mirroring raw terminal streams where <code>\r</code> must stay intact.</td>
+</tr>
+<tr>
+<td><code>errors$</code></td>
+<td><strong>All <code>SerialError</code> instances</strong> from connect / read / write / close (primary error channel).</td>
+</tr>
+<tr>
+<td><code>connect$()</code></td>
+<td><strong>Open</strong> a user-selected port and start the internal read pump.</td>
+</tr>
+<tr>
+<td><code>disconnect$()</code></td>
+<td><strong>Close</strong> the port and stop the pump.</td>
+</tr>
+<tr>
+<td><code>send$(string | Uint8Array)</code></td>
+<td><strong>Enqueue</strong> outgoing data; writes are <strong>FIFO-ordered</strong> when multiple <code>send$</code> run concurrently.</td>
+</tr>
+<tr>
+<td><code>isBrowserSupported()</code></td>
+<td>Synchronous <code>boolean</code> for Web Serial availability before <code>connect$</code>.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serialsessionstate-quick-reference" class="tsd-anchor-link">SerialSessionState (quick reference)<a href="#serialsessionstate-quick-reference" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h3>
+<p><code>state$</code> uses the string union below. Prefer the <strong>const object</strong> (e.g. <code>SerialSessionState.Connected</code> → <code>'connected'</code>) in code. Full lifecycle diagram, transitions, and edge cases: <a href="variables/SerialSessionState.html">API Reference – SerialSessionState</a>.</p>
+<table>
+<thead>
+<tr>
+<th>Constant</th>
+<th>Value</th>
+<th>Meaning</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>SerialSessionState.Idle</code></td>
+<td><code>'idle'</code></td>
+<td>No open port; initial state when the browser supports Web Serial.</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Connecting</code></td>
+<td><code>'connecting'</code></td>
+<td><code>connect$</code> in progress.</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Connected</code></td>
+<td><code>'connected'</code></td>
+<td>Port is open; internal read pump is running.</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Disconnecting</code></td>
+<td><code>'disconnecting'</code></td>
+<td><code>disconnect$</code> in progress.</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Unsupported</code></td>
+<td><code>'unsupported'</code></td>
+<td>Web Serial was not available when the session was created.</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Error</code></td>
+<td><code>'error'</code></td>
+<td>Fatal I/O or lifecycle failure; call <code>disconnect$</code> or build a new session.</td>
+</tr>
+</tbody>
+</table>
+<p><strong><code>receive$</code> vs <code>lines$</code>:</strong> use <strong><code>receive$</code></strong> when the UI must show <strong>exactly</strong> what the device sent (e.g. interactive shells, <code>ls</code> progress, any stream using <code>\r</code> to redraw a line). Use <strong><code>lines$</code></strong> for <strong>newline-oriented</strong> consumers—logs, one-line replies, parsers. Feeding <strong><code>lines$</code></strong> into a terminal widget can drop or split on <code>\r</code> and break redraw semantics. For custom delimiters beyond the built-in line buffer, compose on <strong><code>receive$</code></strong> (<a href="ADVANCED_USAGE.html#line-framing">Advanced Usage</a>).</p>
+<p><strong><code>isConnected$</code> (for simple UIs)</strong> — a read-only <code>Observable&lt;boolean&gt;</code>. Use it for “port open?” toggles without comparing <code>state$</code> to <code>SerialSessionState.Connected</code> yourself. You can still derive your own boolean from <code>state$</code> with <code>map</code> if you need different rules.</p>
+<p><strong><code>lines$</code> (newline framing)</strong> — built-in line splitting; for non-line protocols or terminal mirrors, subscribe to <strong><code>receive$</code></strong> instead (recipes in <a href="ADVANCED_USAGE.html#line-framing">Advanced Usage</a>).</p>
+<h3 id="minimal-example" class="tsd-anchor-link">Minimal example<a href="#minimal-example" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h3>
+<pre><code class="typescript"><span class="hl-0">import</span><span class="hl-1"> { </span><span class="hl-2">createSerialSession</span><span class="hl-1">, </span><span class="hl-2">SerialSessionState</span><span class="hl-1"> } </span><span class="hl-0">from</span><span class="hl-1"> </span><span class="hl-3">&#39;@gurezo/web-serial-rxjs&#39;</span><span class="hl-1">;</span><br/><span class="hl-0">import</span><span class="hl-1"> { </span><span class="hl-2">filter</span><span class="hl-1"> } </span><span class="hl-0">from</span><span class="hl-1"> </span><span class="hl-3">&#39;rxjs&#39;</span><span class="hl-1">;</span><br/><br/><span class="hl-4">const</span><span class="hl-1"> </span><span class="hl-5">session</span><span class="hl-1"> = </span><span class="hl-6">createSerialSession</span><span class="hl-1">({ </span><span class="hl-2">baudRate:</span><span class="hl-1"> </span><span class="hl-7">115200</span><span class="hl-1"> });</span><br/><br/><span class="hl-0">if</span><span class="hl-1"> (!</span><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">isBrowserSupported</span><span class="hl-1">()) {</span><br/><span class="hl-1">  </span><span class="hl-0">throw</span><span class="hl-1"> </span><span class="hl-4">new</span><span class="hl-1"> </span><span class="hl-6">Error</span><span class="hl-1">(</span><span class="hl-3">&#39;Web Serial is not available in this browser&#39;</span><span class="hl-1">);</span><br/><span class="hl-1">}</span><br/><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">lines$</span><span class="hl-1">.</span><span class="hl-6">subscribe</span><span class="hl-1">(</span><span class="hl-2">console</span><span class="hl-1">.</span><span class="hl-2">log</span><span class="hl-1">);</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">errors$</span><span class="hl-1">.</span><span class="hl-6">subscribe</span><span class="hl-1">(</span><span class="hl-2">console</span><span class="hl-1">.</span><span class="hl-2">error</span><span class="hl-1">);</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">state$</span><br/><span class="hl-1">  .</span><span class="hl-6">pipe</span><span class="hl-1">(</span><span class="hl-6">filter</span><span class="hl-1">((</span><span class="hl-2">s</span><span class="hl-1">) </span><span class="hl-4">=&gt;</span><span class="hl-1"> </span><span class="hl-2">s</span><span class="hl-1"> === </span><span class="hl-2">SerialSessionState</span><span class="hl-1">.</span><span class="hl-2">Connected</span><span class="hl-1">))</span><br/><span class="hl-1">  .</span><span class="hl-6">subscribe</span><span class="hl-1">(() </span><span class="hl-4">=&gt;</span><span class="hl-1"> {</span><br/><span class="hl-1">    </span><span class="hl-8">/* e.g. enable UI that must wait until the port is open */</span><br/><span class="hl-1">  });</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">connect$</span><span class="hl-1">().</span><span class="hl-6">subscribe</span><span class="hl-1">();</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">send$</span><span class="hl-1">(</span><span class="hl-3">&#39;hello</span><span class="hl-9">\r\n</span><span class="hl-3">&#39;</span><span class="hl-1">).</span><span class="hl-6">subscribe</span><span class="hl-1">();</span>
+</code><button type="button">Copy</button></pre>
+
+<p>In real apps, handle <code>connect$().subscribe({ next, error })</code> and <code>send$().subscribe({ error })</code> (errors are also on <code>errors$</code>). A fuller walkthrough is in <a href="QUICK_START.html">Quick Start</a>.</p>
+<h2 id="documentation-index" class="tsd-anchor-link">Documentation index<a href="#documentation-index" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<table>
+<thead>
+<tr>
+<th>Doc</th>
+<th>Use it for</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>Repository <a href="https://github.com/gurezo/web-serial-rxjs/blob/main/README.md">README</a></strong></td>
+<td>Monorepo overview, examples index, and contribution links.</td>
+</tr>
+<tr>
+<td><strong><a href="QUICK_START.html">Quick Start</a></strong></td>
+<td>Shortest path to a working open port and subscriptions.</td>
+</tr>
+<tr>
+<td><strong><a href="ADVANCED_USAGE.html">Advanced Usage</a></strong></td>
+<td>Line framing, request/response-style flows, and recovery.</td>
+</tr>
+<tr>
+<td><strong><a href="modules.html">API Reference</a></strong></td>
+<td>Options, <code>SerialSessionState</code>, and <code>SerialError</code> details (generated TypeDoc); narrative tables also on <a href="API_REFERENCE.html">GitHub</a>.</td>
+</tr>
+<tr>
+<td><strong><a href="MIGRATION_V2.html">v1 → v2 Migration Guide</a></strong></td>
+<td>Replacing the removed v1 <code>SerialClient</code> / <code>ShellClient</code> API.</td>
+</tr>
+<tr>
+<td><strong><a href="archive_MIGRATION_PHASE5.html">Phase 5 archive (legacy v1 doc)</a></strong></td>
+<td>Historical v1 context only.</td>
+</tr>
+</tbody>
+</table>
+</div></div><div class="col-sidebar"><div class="page-menu"><div class="tsd-navigation settings"><details class="tsd-accordion"><summary class="tsd-accordion-summary"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-chevronDown"></use></svg><h3>Settings</h3></summary><div class="tsd-accordion-details"><div class="tsd-filter-visibility"><span class="settings-label">Member Visibility</span><ul id="tsd-filter-options"><li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-protected" name="protected"/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>Protected</span></label></li><li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-inherited" name="inherited" checked/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>Inherited</span></label></li><li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-external" name="external"/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>External</span></label></li></ul></div><div class="tsd-theme-toggle"><label class="settings-label" for="tsd-theme">Theme</label><select id="tsd-theme"><option value="os">OS</option><option value="light">Light</option><option value="dark">Dark</option></select></div></div></details></div><details open class="tsd-accordion tsd-page-navigation"><summary class="tsd-accordion-summary"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-chevronDown"></use></svg><h3>On This Page</h3></summary><div class="tsd-accordion-details"><a href="#serialsession-v2-overview"><span>Serial<wbr/>Session (v2) overview</span></a><ul><li><a href="#table-of-contents"><span>Table of <wbr/>Contents</span></a></li><li><a href="#features"><span>Features</span></a></li><li><a href="#framework-support"><span>Framework support</span></a></li><li><a href="#serialsession-v2-at-a-glance"><span>Serial<wbr/>Session (v2) at a glance</span></a></li><li><ul><li><a href="#serialsessionstate-quick-reference"><span>Serial<wbr/>Session<wbr/>State (quick reference)</span></a></li><li><a href="#minimal-example"><span>Minimal example</span></a></li></ul></li><li><a href="#documentation-index"><span>Documentation index</span></a></li></ul></div></details></div><div class="site-menu"><nav class="tsd-navigation"><a href="../modules.html">web-serial-rxjs API Documentation</a><ul class="tsd-small-nested-navigation" id="tsd-nav-container"><li>Loading...</li></ul></nav></div></div></div><footer></footer><div class="overlay"></div></body></html>

--- a/docs/documents/OVERVIEW.ja.html
+++ b/docs/documents/OVERVIEW.ja.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html><html class="default" lang="en" data-base="../"><head><meta charset="utf-8"/><meta http-equiv="x-ua-compatible" content="IE=edge"/><title>OVERVIEW.ja | web-serial-rxjs API Documentation</title><meta name="description" content="Documentation for web-serial-rxjs API Documentation"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="../assets/style.css"/><link rel="stylesheet" href="../assets/highlight.css"/><script defer src="../assets/main.js"></script><script async src="../assets/icons.js" id="tsd-icons-script"></script><script async src="../assets/search.js" id="tsd-search-script"></script><script async src="../assets/navigation.js" id="tsd-nav-script"></script><link rel="stylesheet" href="../assets/rhineai-style.css"/></head><body><script>document.documentElement.dataset.theme = localStorage.getItem("tsd-theme") || "os";document.body.style.display="none";setTimeout(() => window.app?app.showPage():document.body.style.removeProperty("display"),500)</script><header class="tsd-page-toolbar"><div class="tsd-toolbar-contents container"><a href="../index.html" class="title">web-serial-rxjs API Documentation</a><div id="tsd-toolbar-links"></div><button id="tsd-search-trigger" class="tsd-widget" aria-label="Search"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-search"></use></svg></button><dialog id="tsd-search" aria-label="Search"><input role="combobox" id="tsd-search-input" aria-controls="tsd-search-results" aria-autocomplete="list" aria-expanded="true" autocapitalize="off" autocomplete="off" placeholder="Search the docs" maxLength="100"/><ul role="listbox" id="tsd-search-results"></ul><div id="tsd-search-status" aria-live="polite" aria-atomic="true"><div>Preparing search index...</div></div></dialog><a href="#" class="tsd-widget menu" id="tsd-toolbar-menu-trigger" data-toggle="menu" aria-label="Menu"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-menu"></use></svg></a></div></header><div class="container container-main"><div class="col-content"><div class="tsd-page-title"><ul class="tsd-breadcrumb" aria-label="Breadcrumb"><li><a href="" aria-current="page">OVERVIEW.ja</a></li></ul></div><div class="tsd-panel tsd-typography"><h1 id="serialsession（v2）の概要" class="tsd-anchor-link">SerialSession（v2）の概要<a href="#serialsession（v2）の概要" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h1>
+<p align="center">
+  <img src="../media/web-serial-rxjs-icon.png" alt="web-serial-rxjs プロジェクトアイコン" width="512" />
+</p>
+<p>このページは v2 公開 API の<strong>考え方</strong>をまとめたものです。各 <code>SerialSession</code> 面の役割、<code>SerialSessionState</code> と <code>state$</code> の対応、<code>receive$</code> と <code>lines$</code> の使い分け。オプション、エラーコード、型の詳細は <a href="https://gurezo.github.io/web-serial-rxjs/modules.html">API リファレンス</a> を参照してください。</p>
+<h2 id="目次" class="tsd-anchor-link">目次<a href="#目次" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<ul>
+<li><a href="#%E6%A9%9F%E8%83%BD">機能</a></li>
+<li><a href="#%E5%AF%BE%E5%BF%9C%E3%83%95%E3%83%AC%E3%83%BC%E3%83%A0%E3%83%AF%E3%83%BC%E3%82%AF">対応フレームワーク</a></li>
+<li><a href="#serialsessionv2%E3%81%AE%E5%85%A8%E4%BD%93%E5%83%8F">SerialSession（v2）の全体像</a></li>
+<li><a href="#%E3%83%89%E3%82%AD%E3%83%A5%E3%83%A1%E3%83%B3%E3%83%88%E7%B4%A2%E5%BC%95">ドキュメント索引</a></li>
+</ul>
+<h2 id="機能" class="tsd-anchor-link">機能<a href="#機能" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<ul>
+<li><strong>Session 指向のリアクティブ API</strong>: 1 つの <code>SerialSession</code> が <code>state$</code> / <code>isConnected$</code> / <code>receive$</code> / <code>lines$</code> / <code>errors$</code> と <code>connect$</code> / <code>disconnect$</code> / <code>send$</code> を公開</li>
+<li><strong>UTF-8 テキストストリーム</strong>: <code>receive$</code> は内部でストリーミング <code>TextDecoder</code> を用いてデコード済み。マルチバイト文字がチャンクにまたがっても正しく結合されます</li>
+<li><strong>順序保証された送信キュー</strong>: 並行する <code>send$</code> 呼び出しも内部キューで FIFO 処理され、呼び出し順に書き込まれます</li>
+<li><strong>統一エラーチャネル</strong>: すべての I/O エラーは <code>SerialError</code> に正規化され <code>errors$</code> に多重化されます</li>
+<li><strong>明示的なライフサイクル</strong>: <code>state$</code> は <code>idle</code> / <code>connecting</code> / <code>connected</code> / <code>disconnecting</code> / <code>unsupported</code> / <code>error</code> を emit するので UI から直接駆動できます</li>
+<li><strong>TypeScript サポート</strong>: 完全な TypeScript 型定義を同梱</li>
+<li><strong>フレームワーク非依存</strong>: 任意の JavaScript/TypeScript フレームワークまたはバニラ JavaScript で利用可能</li>
+</ul>
+<h2 id="対応フレームワーク" class="tsd-anchor-link">対応フレームワーク<a href="#対応フレームワーク" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<p>このライブラリはフレームワーク非依存で、以下の環境で利用できます。</p>
+<ul>
+<li>Angular</li>
+<li>React</li>
+<li>Svelte</li>
+<li>Vanilla JavaScript / TypeScript</li>
+</ul>
+<h2 id="serialsession（v2）の全体像" class="tsd-anchor-link">SerialSession（v2）の全体像<a href="#serialsession（v2）の全体像" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<p><code>createSerialSession</code> が返す <strong>SerialSession</strong> だけを使います。公開 API は意図的に小さく、<strong>ターミナルにそのまま出す出力</strong>は <strong><code>receive$</code></strong>、<strong>改行区切りのログや解析</strong>は <strong><code>lines$</code></strong> が担当します。独自区切りが必要なときは <strong><code>receive$</code></strong> 上に RxJS で組み立てます（<a href="ADVANCED_USAGE.ja.html">高度な使用方法</a>）。接続真偽は <code>isConnected$</code> も利用できます。</p>
+<table>
+<thead>
+<tr>
+<th>公開面</th>
+<th>役割</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>state$</code></td>
+<td><strong>接続ライフサイクル</strong> — <code>idle</code> / <code>connecting</code> / <code>connected</code> / <code>disconnecting</code> / <code>error</code> / <code>unsupported</code>。購読時に現在値をリプレイ。分岐は文字列直書きではなく <strong><code>SerialSessionState</code></strong> との比較を推奨。</td>
+</tr>
+<tr>
+<td><code>SerialSessionState</code></td>
+<td><strong>状態定数</strong> — エクスポートされる const object（例: <code>SerialSessionState.Connected</code>, <code>SerialSessionState.Idle</code>）。<code>state$</code> が emit する値と同じ。</td>
+</tr>
+<tr>
+<td><code>isConnected$</code></td>
+<td><strong>接続中かどうか</strong> — <code>state$</code> が <code>SerialSessionState.Connected</code> のときだけ <code>true</code>、それ以外は <code>false</code>（<code>state$</code> から <code>distinctUntilChanged</code> 付きで派生）。</td>
+</tr>
+<tr>
+<td><code>receive$</code></td>
+<td><strong>生のデコードチャンク</strong> — UTF-8 テキストを read pump が返すとおりに受け取る（行揃えではない。マルチバイト安全）。<code>\r</code> 等も保持。<strong>ターミナル風の表示</strong>や <code>\r</code> による上書き表示向け。</td>
+</tr>
+<tr>
+<td><code>terminalText$</code></td>
+<td><strong>ターミナル表示向けの累積テキスト</strong> — <code>receive$</code> 由来の表示用テキスト。<code>\r</code> による上書きを折りたたみつつ通常の改行挙動は維持するため、ターミナル風ビューへ 1 つの文字列をそのままバインドしたい場合に使います。</td>
+</tr>
+<tr>
+<td><code>lines$</code></td>
+<td><strong>行単位の受信</strong> — <code>\n</code> / <code>\r\n</code> / 内部の <code>\r</code> など実装に従い 1 行ずつ emit。<strong>ログ・1 行ごとの解析</strong>向け。<code>\r</code> をそのまま残す必要がある raw ターミナル表示には向かない。</td>
+</tr>
+<tr>
+<td><code>errors$</code></td>
+<td><strong>すべての <code>SerialError</code></strong>（接続・読み取り・書き込み・クローズ）の主チャネル。</td>
+</tr>
+<tr>
+<td><code>connect$()</code></td>
+<td>ポート選択 → オープン → 内部 read pump 開始。</td>
+</tr>
+<tr>
+<td><code>disconnect$()</code></td>
+<td>ポートを閉じ、pump を停止。</td>
+</tr>
+<tr>
+<td><code>send$(string | Uint8Array)</code></td>
+<td>送信を <strong>FIFO</strong> で直列化（並行 <code>send$</code> も呼び出し順）。</td>
+</tr>
+<tr>
+<td><code>isBrowserSupported()</code></td>
+<td><code>connect$</code> の前に使う、Web Serial 利用可否の同期的な <code>boolean</code>。</td>
+</tr>
+</tbody>
+</table>
+<h3 id="serialsessionstate（早見表）" class="tsd-anchor-link">SerialSessionState（早見表）<a href="#serialsessionstate（早見表）" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h3>
+<p><code>state$</code> が emit する文字列のユニオンです。コードでは <strong>const オブジェクト</strong>（例: <code>SerialSessionState.Connected</code> → <code>'connected'</code>）での比較を推奨します。有効な遷移・例外系の扱いの詳細は <a href="https://gurezo.github.io/web-serial-rxjs/variables/SerialSessionState.html">API リファレンスの SerialSessionState</a> および <a href="API_REFERENCE.ja.html#serialsessionstate">GitHub 上の表・図</a> を参照してください。</p>
+<table>
+<thead>
+<tr>
+<th>定数</th>
+<th>値</th>
+<th>意味</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>SerialSessionState.Idle</code></td>
+<td><code>'idle'</code></td>
+<td>ポート未接続。Web Serial 利用可能な場合の初期値。</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Connecting</code></td>
+<td><code>'connecting'</code></td>
+<td><code>connect$</code> 実行中。</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Connected</code></td>
+<td><code>'connected'</code></td>
+<td>ポートが開き、内部 read pump が動作中。</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Disconnecting</code></td>
+<td><code>'disconnecting'</code></td>
+<td><code>disconnect$</code> 実行中。</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Unsupported</code></td>
+<td><code>'unsupported'</code></td>
+<td>セッション生成時点で Web Serial が利用できない。</td>
+</tr>
+<tr>
+<td><code>SerialSessionState.Error</code></td>
+<td><code>'error'</code></td>
+<td>接続まわりの致命エラー。<code>disconnect$</code> か新しいセッションで復帰。</td>
+</tr>
+</tbody>
+</table>
+<p><strong><code>receive$</code> と <code>lines$</code>:</strong> 機器から来たバイト列を<strong>そのまま</strong>画面に反映する（シェル、<code>ls</code> のプログレス、<code>\r</code> で行を描き直す出力など）ときは <strong><code>receive$</code></strong> を使います。<strong>改行区切りのログ</strong>や<strong>1 行ずつ処理するプロトコル</strong>では <strong><code>lines$</code></strong> が適しています。ターミナル表示に <strong><code>lines$</code></strong> を繋ぐと、内部で <code>\r</code> を行境界として扱うため <strong>上書き表示が壊れる</strong>ことがあります。独自区切りは <strong><code>receive$</code> 上で RxJS を合成</strong>します（<a href="ADVANCED_USAGE.ja.html">高度な使用方法 — 行単位のフレーミング</a>）。</p>
+<p><strong><code>isConnected$</code>（UI 用）</strong> — 読み取り専用の <code>Observable&lt;boolean&gt;</code> です。<code>state$</code> を <code>SerialSessionState.Connected</code> と毎回比較しなくても接続有無の UI 分岐に使えます。独自ルールが必要な場合は、従来どおり <code>state$</code> から <code>map</code> で派生しても構いません。</p>
+<p><strong><code>lines$</code>（行区切り）</strong> — 組み込みの行分割。ターミナルのミラーや <code>\r</code> を保持したいときは <strong><code>receive$</code></strong> を購読します（<a href="ADVANCED_USAGE.ja.html">高度な使用方法 — 行単位のフレーミング</a>）。</p>
+<h3 id="最小サンプル" class="tsd-anchor-link">最小サンプル<a href="#最小サンプル" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h3>
+<pre><code class="typescript"><span class="hl-0">import</span><span class="hl-1"> { </span><span class="hl-2">createSerialSession</span><span class="hl-1">, </span><span class="hl-2">SerialSessionState</span><span class="hl-1"> } </span><span class="hl-0">from</span><span class="hl-1"> </span><span class="hl-3">&#39;@gurezo/web-serial-rxjs&#39;</span><span class="hl-1">;</span><br/><span class="hl-0">import</span><span class="hl-1"> { </span><span class="hl-2">filter</span><span class="hl-1"> } </span><span class="hl-0">from</span><span class="hl-1"> </span><span class="hl-3">&#39;rxjs&#39;</span><span class="hl-1">;</span><br/><br/><span class="hl-4">const</span><span class="hl-1"> </span><span class="hl-5">session</span><span class="hl-1"> = </span><span class="hl-6">createSerialSession</span><span class="hl-1">({ </span><span class="hl-2">baudRate:</span><span class="hl-1"> </span><span class="hl-7">115200</span><span class="hl-1"> });</span><br/><br/><span class="hl-0">if</span><span class="hl-1"> (!</span><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">isBrowserSupported</span><span class="hl-1">()) {</span><br/><span class="hl-1">  </span><span class="hl-0">throw</span><span class="hl-1"> </span><span class="hl-4">new</span><span class="hl-1"> </span><span class="hl-6">Error</span><span class="hl-1">(</span><span class="hl-3">&#39;このブラウザでは Web Serial を利用できません&#39;</span><span class="hl-1">);</span><br/><span class="hl-1">}</span><br/><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">lines$</span><span class="hl-1">.</span><span class="hl-6">subscribe</span><span class="hl-1">(</span><span class="hl-2">console</span><span class="hl-1">.</span><span class="hl-2">log</span><span class="hl-1">);</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">errors$</span><span class="hl-1">.</span><span class="hl-6">subscribe</span><span class="hl-1">(</span><span class="hl-2">console</span><span class="hl-1">.</span><span class="hl-2">error</span><span class="hl-1">);</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-2">state$</span><br/><span class="hl-1">  .</span><span class="hl-6">pipe</span><span class="hl-1">(</span><span class="hl-6">filter</span><span class="hl-1">((</span><span class="hl-2">s</span><span class="hl-1">) </span><span class="hl-4">=&gt;</span><span class="hl-1"> </span><span class="hl-2">s</span><span class="hl-1"> === </span><span class="hl-2">SerialSessionState</span><span class="hl-1">.</span><span class="hl-2">Connected</span><span class="hl-1">))</span><br/><span class="hl-1">  .</span><span class="hl-6">subscribe</span><span class="hl-1">(() </span><span class="hl-4">=&gt;</span><span class="hl-1"> {</span><br/><span class="hl-1">    </span><span class="hl-8">/* 例: ポートが開いてから有効化する UI */</span><br/><span class="hl-1">  });</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">connect$</span><span class="hl-1">().</span><span class="hl-6">subscribe</span><span class="hl-1">();</span><br/><span class="hl-2">session</span><span class="hl-1">.</span><span class="hl-6">send$</span><span class="hl-1">(</span><span class="hl-3">&#39;hello</span><span class="hl-9">\r\n</span><span class="hl-3">&#39;</span><span class="hl-1">).</span><span class="hl-6">subscribe</span><span class="hl-1">();</span>
+</code><button type="button">Copy</button></pre>
+
+<p>実アプリでは <code>connect$</code> / <code>send$</code> の <code>subscribe</code> で <code>error</code> も扱ってください（<code>errors$</code> にも流れます）。手順の全体は <a href="QUICK_START.ja.html">クイックスタート</a> を参照してください。</p>
+<h2 id="ドキュメント索引" class="tsd-anchor-link">ドキュメント索引<a href="#ドキュメント索引" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="../assets/icons.svg#icon-anchor"></use></svg></a></h2>
+<table>
+<thead>
+<tr>
+<th>ドキュメント</th>
+<th>用途</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>リポジトリ <a href="https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md">README</a></strong></td>
+<td>モノレポ全体の目次、サンプル索引、貢献の導線。</td>
+</tr>
+<tr>
+<td><strong><a href="QUICK_START.ja.html">クイックスタート</a></strong></td>
+<td>最短でポートを開いて購読するところまで。</td>
+</tr>
+<tr>
+<td><strong><a href="ADVANCED_USAGE.ja.html">高度な使用方法</a></strong></td>
+<td>行フレーミング、擬似リクエスト／レスポンス、リカバリ。</td>
+</tr>
+<tr>
+<td><strong><a href="https://gurezo.github.io/web-serial-rxjs/modules.html">API リファレンス</a></strong></td>
+<td>オプション、<code>SerialSessionState</code>、<code>SerialError</code> の詳細（TypeDoc）。表・図は <a href="API_REFERENCE.ja.html">GitHub</a> も参照。</td>
+</tr>
+<tr>
+<td><strong><a href="MIGRATION_V2.ja.html">v1 → v2 マイグレーション</a></strong>（<a href="MIGRATION_V2.html">English</a>）</td>
+<td>削除された v1 API からの対応表。</td>
+</tr>
+<tr>
+<td><strong><a href="archive_MIGRATION_PHASE5.ja.html">Phase 5（アーカイブ）</a></strong></td>
+<td>旧 v1 ドキュメントの参照用。</td>
+</tr>
+</tbody>
+</table>
+</div></div><div class="col-sidebar"><div class="page-menu"><div class="tsd-navigation settings"><details class="tsd-accordion"><summary class="tsd-accordion-summary"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-chevronDown"></use></svg><h3>Settings</h3></summary><div class="tsd-accordion-details"><div class="tsd-filter-visibility"><span class="settings-label">Member Visibility</span><ul id="tsd-filter-options"><li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-protected" name="protected"/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>Protected</span></label></li><li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-inherited" name="inherited" checked/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>Inherited</span></label></li><li class="tsd-filter-item"><label class="tsd-filter-input"><input type="checkbox" id="tsd-filter-external" name="external"/><svg width="32" height="32" viewBox="0 0 32 32" aria-hidden="true"><rect class="tsd-checkbox-background" width="30" height="30" x="1" y="1" rx="6" fill="none"></rect><path class="tsd-checkbox-checkmark" d="M8.35422 16.8214L13.2143 21.75L24.6458 10.25" stroke="none" stroke-width="3.5" stroke-linejoin="round" fill="none"></path></svg><span>External</span></label></li></ul></div><div class="tsd-theme-toggle"><label class="settings-label" for="tsd-theme">Theme</label><select id="tsd-theme"><option value="os">OS</option><option value="light">Light</option><option value="dark">Dark</option></select></div></div></details></div><details open class="tsd-accordion tsd-page-navigation"><summary class="tsd-accordion-summary"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><use href="../assets/icons.svg#icon-chevronDown"></use></svg><h3>On This Page</h3></summary><div class="tsd-accordion-details"><a href="#serialsession（v2）の概要"><span>Serial<wbr/>Session（v2）の概要</span></a><ul><li><a href="#目次"><span>目次</span></a></li><li><a href="#機能"><span>機能</span></a></li><li><a href="#対応フレームワーク"><span>対応フレームワーク</span></a></li><li><a href="#serialsession（v2）の全体像"><span>Serial<wbr/>Session（v2）の全体像</span></a></li><li><ul><li><a href="#serialsessionstate（早見表）"><span>Serial<wbr/>Session<wbr/>State（早見表）</span></a></li><li><a href="#最小サンプル"><span>最小サンプル</span></a></li></ul></li><li><a href="#ドキュメント索引"><span>ドキュメント索引</span></a></li></ul></div></details></div><div class="site-menu"><nav class="tsd-navigation"><a href="../modules.html">web-serial-rxjs API Documentation</a><ul class="tsd-small-nested-navigation" id="tsd-nav-container"><li>Loading...</li></ul></nav></div></div></div><footer></footer><div class="overlay"></div></body></html>

--- a/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
@@ -34,7 +34,7 @@
 
 ## SerialSession（v2）の全体像
 
-`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**ターミナルにそのまま出す出力**は **`receive$`**、**改行区切りのログや解析**は **`lines$`** が担当します。独自区切りが必要なときは **`receive$`** 上に RxJS で組み立てます（[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
+`createSerialSession` が返す **SerialSession** だけを使います。公開 API は意図的に小さく、**ターミナルにそのまま出す出力**は **`receive$`**、**改行区切りのログや解析**は **`lines$`** が担当します。独自区切りが必要なときは **`receive$`** 上に RxJS で組み立てます（[高度な使用方法](./ADVANCED_USAGE.ja.md)）。接続真偽は `isConnected$` も利用できます。
 
 | 公開面 | 役割 |
 | --- | --- |
@@ -52,7 +52,7 @@
 
 ### SerialSessionState（早見表）
 
-`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](https://gurezo.github.io/web-serial-rxjs/variables/SerialSessionState.html) および [GitHub 上の表・図](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md#serialsessionstate) を参照してください。
+`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](https://gurezo.github.io/web-serial-rxjs/variables/SerialSessionState.html) および [GitHub 上の表・図](./API_REFERENCE.ja.md#serialsessionstate) を参照してください。
 
 | 定数 | 値 | 意味 |
 | --- | --- | --- |
@@ -63,11 +63,11 @@
 | `SerialSessionState.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
 | `SerialSessionState.Error` | `'error'` | 接続まわりの致命エラー。`disconnect$` か新しいセッションで復帰。 |
 
-**`receive$` と `lines$`:** 機器から来たバイト列を**そのまま**画面に反映する（シェル、`ls` のプログレス、`\r` で行を描き直す出力など）ときは **`receive$`** を使います。**改行区切りのログ**や**1 行ずつ処理するプロトコル**では **`lines$`** が適しています。ターミナル表示に **`lines$`** を繋ぐと、内部で `\r` を行境界として扱うため **上書き表示が壊れる**ことがあります。独自区切りは **`receive$` 上で RxJS を合成**します（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
+**`receive$` と `lines$`:** 機器から来たバイト列を**そのまま**画面に反映する（シェル、`ls` のプログレス、`\r` で行を描き直す出力など）ときは **`receive$`** を使います。**改行区切りのログ**や**1 行ずつ処理するプロトコル**では **`lines$`** が適しています。ターミナル表示に **`lines$`** を繋ぐと、内部で `\r` を行境界として扱うため **上書き表示が壊れる**ことがあります。独自区切りは **`receive$` 上で RxJS を合成**します（[高度な使用方法 — 行単位のフレーミング](./ADVANCED_USAGE.ja.md)）。
 
 **`isConnected$`（UI 用）** — 読み取り専用の `Observable<boolean>` です。`state$` を `SerialSessionState.Connected` と毎回比較しなくても接続有無の UI 分岐に使えます。独自ルールが必要な場合は、従来どおり `state$` から `map` で派生しても構いません。
 
-**`lines$`（行区切り）** — 組み込みの行分割。ターミナルのミラーや `\r` を保持したいときは **`receive$`** を購読します（[高度な使用方法 — 行単位のフレーミング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)）。
+**`lines$`（行区切り）** — 組み込みの行分割。ターミナルのミラーや `\r` を保持したいときは **`receive$`** を購読します（[高度な使用方法 — 行単位のフレーミング](./ADVANCED_USAGE.ja.md)）。
 
 ### 最小サンプル
 
@@ -92,15 +92,15 @@ session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();
 ```
 
-実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md) を参照してください。
+実アプリでは `connect$` / `send$` の `subscribe` で `error` も扱ってください（`errors$` にも流れます）。手順の全体は [クイックスタート](./QUICK_START.ja.md) を参照してください。
 
 ## ドキュメント索引
 
 | ドキュメント | 用途 |
 | --- | --- |
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ全体の目次、サンプル索引、貢献の導線。 |
-| **[クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
-| **[高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
-| **[API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細（TypeDoc）。表・図は [GitHub](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md) も参照。 |
-| **[v1 → v2 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md)**（[English](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
-| **[Phase 5（アーカイブ）](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |
+| **[クイックスタート](./QUICK_START.ja.md)** | 最短でポートを開いて購読するところまで。 |
+| **[高度な使用方法](./ADVANCED_USAGE.ja.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
+| **[API リファレンス](https://gurezo.github.io/web-serial-rxjs/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細（TypeDoc）。表・図は [GitHub](./API_REFERENCE.ja.md) も参照。 |
+| **[v1 → v2 マイグレーション](./MIGRATION_V2.ja.md)**（[English](./MIGRATION_V2.md)） | 削除された v1 API からの対応表。 |
+| **[Phase 5（アーカイブ）](./archive/MIGRATION_PHASE5.ja.md)** | 旧 v1 ドキュメントの参照用。 |

--- a/packages/web-serial-rxjs/docs/OVERVIEW.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.md
@@ -34,7 +34,7 @@ This library is framework-agnostic and can be used with:
 
 ## SerialSession (v2) at a glance
 
-`createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; **`receive$`** is for **raw decoder output** (including terminals and `\r` redraws), **`lines$`** for **newline-delimited logs and parsers**. When you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)).
+`createSerialSession` returns a single **SerialSession**. All interaction goes through the fields below. The public API is intentionally small; **`receive$`** is for **raw decoder output** (including terminals and `\r` redraws), **`lines$`** for **newline-delimited logs and parsers**. When you need **custom** framing, compose plain RxJS on `receive$` (see [Advanced Usage](./ADVANCED_USAGE.md)).
 
 | Surface | Role |
 | --- | --- |
@@ -63,11 +63,11 @@ This library is framework-agnostic and can be used with:
 | `SerialSessionState.Unsupported` | `'unsupported'` | Web Serial was not available when the session was created. |
 | `SerialSessionState.Error` | `'error'` | Fatal I/O or lifecycle failure; call `disconnect$` or build a new session. |
 
-**`receive$` vs `lines$`:** use **`receive$`** when the UI must show **exactly** what the device sent (e.g. interactive shells, `ls` progress, any stream using `\r` to redraw a line). Use **`lines$`** for **newline-oriented** consumers—logs, one-line replies, parsers. Feeding **`lines$`** into a terminal widget can drop or split on `\r` and break redraw semantics. For custom delimiters beyond the built-in line buffer, compose on **`receive$`** ([Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing)).
+**`receive$` vs `lines$`:** use **`receive$`** when the UI must show **exactly** what the device sent (e.g. interactive shells, `ls` progress, any stream using `\r` to redraw a line). Use **`lines$`** for **newline-oriented** consumers—logs, one-line replies, parsers. Feeding **`lines$`** into a terminal widget can drop or split on `\r` and break redraw semantics. For custom delimiters beyond the built-in line buffer, compose on **`receive$`** ([Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
 
 **`isConnected$` (for simple UIs)** — a read-only `Observable<boolean>`. Use it for “port open?” toggles without comparing `state$` to `SerialSessionState.Connected` yourself. You can still derive your own boolean from `state$` with `map` if you need different rules.
 
-**`lines$` (newline framing)** — built-in line splitting; for non-line protocols or terminal mirrors, subscribe to **`receive$`** instead (recipes in [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md#line-framing)).
+**`lines$` (newline framing)** — built-in line splitting; for non-line protocols or terminal mirrors, subscribe to **`receive$`** instead (recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
 
 ### Minimal example
 
@@ -92,15 +92,15 @@ session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();
 ```
 
-In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscribe({ error })` (errors are also on `errors$`). A fuller walkthrough is in [Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md).
+In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscribe({ error })` (errors are also on `errors$`). A fuller walkthrough is in [Quick Start](./QUICK_START.md).
 
 ## Documentation index
 
 | Doc | Use it for |
 | --- | --- |
 | **Repository [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md)** | Monorepo overview, examples index, and contribution links. |
-| **[Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md)** | Shortest path to a working open port and subscriptions. |
-| **[Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md)** | Line framing, request/response-style flows, and recovery. |
-| **[API Reference](modules.html)** | Options, `SerialSessionState`, and `SerialError` details (generated TypeDoc); narrative tables also on [GitHub](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/API_REFERENCE.md). |
-| **[v1 → v2 Migration Guide](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/MIGRATION_V2.md)** | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
-| **[Phase 5 archive (legacy v1 doc)](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/archive/MIGRATION_PHASE5.md)** | Historical v1 context only. |
+| **[Quick Start](./QUICK_START.md)** | Shortest path to a working open port and subscriptions. |
+| **[Advanced Usage](./ADVANCED_USAGE.md)** | Line framing, request/response-style flows, and recovery. |
+| **[API Reference](modules.html)** | Options, `SerialSessionState`, and `SerialError` details (generated TypeDoc); narrative tables also on [GitHub](./API_REFERENCE.md). |
+| **[v1 → v2 Migration Guide](./MIGRATION_V2.md)** | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
+| **[Phase 5 archive (legacy v1 doc)](./archive/MIGRATION_PHASE5.md)** | Historical v1 context only. |


### PR DESCRIPTION
## Summary
- `packages/web-serial-rxjs/docs/OVERVIEW.md` と `OVERVIEW.ja.md` 内の `packages/web-serial-rxjs/docs` への GitHub 直リンクを相対パスへ統一しました。
- TypeDoc 内でドキュメント遷移が完結するようにし、Issue #318 の要件を満たします。
- 生成物として `docs/documents/OVERVIEW.html` / `OVERVIEW.ja.html` に反映しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #318
- Refs #316

## What changed?
- `OVERVIEW.md` の docs 配下リンクを `./...` 形式へ変更
- `OVERVIEW.ja.md` の docs 配下リンクを `./...` 形式へ変更
- TypeDoc 再生成で `docs/documents/OVERVIEW*.html` の内部リンク遷移を更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs:generate` を実行する
2. `docs/documents/OVERVIEW.html` / `docs/documents/OVERVIEW.ja.html` を開く
3. Quick Start / Advanced Usage / API Reference / Migration のリンクが GitHub ではなく TypeDoc 内ページへ遷移することを確認する

## Environment (if relevant)
- Browser: Chrome (version: latest)
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: ^7.8.2

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)