### PR TITLE
docs(web-serial-rxjs): README/OVERVIEW のドキュメント導線を整理

### DIFF
--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -76,11 +76,13 @@ pnpm add rxjs
 
 - Full **v2 API map** (features, `SerialSession` table, `SerialSessionState`, minimal example): [SerialSession (v2) overview](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/OVERVIEW.md) ([日本語](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/OVERVIEW.ja.md))
 - Shortest path to an open port: [Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md)
+- Browse as one integrated site (TypeDoc): [web-serial-rxjs API Documentation](https://gurezo.github.io/web-serial-rxjs/)
 
 ## Documentation
 
 | Doc | Use it for |
 | --- | --- |
+| [TypeDoc top page](https://gurezo.github.io/web-serial-rxjs/) | Start from OVERVIEW and move to guides/API in one site |
 | [Overview](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/OVERVIEW.md) | Features and the v2 `SerialSession` / `SerialSessionState` map |
 | [Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/QUICK_START.md) | Open a port and wire subscriptions end-to-end |
 | [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md) | Line framing, request/response-style flows, recovery |

--- a/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
@@ -8,10 +8,20 @@
 
 ## 目次
 
+- [ドキュメント](#ドキュメント)
 - [機能](#機能)
 - [対応フレームワーク](#対応フレームワーク)
 - [SerialSession（v2）の全体像](#serialsessionv2の全体像)
 - [ドキュメント索引](#ドキュメント索引)
+
+## ドキュメント
+
+TypeDoc のトップページから、まず以下を参照してください。
+
+- [クイックスタート](./QUICK_START.ja.md)
+- [高度な使用方法](./ADVANCED_USAGE.ja.md)
+- [API の概念と設計メモ](./API_REFERENCE.ja.md)
+- [v1 から v2 への移行ガイド](./MIGRATION_V2.ja.md)
 
 ## 機能
 

--- a/packages/web-serial-rxjs/docs/OVERVIEW.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.md
@@ -8,10 +8,20 @@ This page is the **mental model** for the v2 public API: what each `SerialSessio
 
 ## Table of Contents
 
+- [Documentation](#documentation)
 - [Features](#features)
 - [Framework support](#framework-support)
 - [SerialSession (v2) at a glance](#serialsession-v2-at-a-glance)
 - [Documentation index](#documentation-index)
+
+## Documentation
+
+Start here from the TypeDoc top page:
+
+- [Quick Start](./QUICK_START.md)
+- [Advanced Usage](./ADVANCED_USAGE.md)
+- [API Concepts and design notes](./API_REFERENCE.md)
+- [v1 to v2 Migration Guide](./MIGRATION_V2.md)
 
 ## Features
 


### PR DESCRIPTION
## Summary
TypeDoc に統合された Markdown ドキュメントへ到達しやすくするため、OVERVIEW と README の導線を整理しました。
TypeDoc トップ（OVERVIEW）から主要ドキュメントへ 1 クリックで遷移できるようにしています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #319
- Related #316

## What changed?
- `packages/web-serial-rxjs/docs/OVERVIEW.md` に `Documentation` セクションを追加し、主要導線を先頭に明示
- `packages/web-serial-rxjs/README.md` に TypeDoc への導線を追加し、ドキュメント一覧の入口を統一
- `packages/web-serial-rxjs/docs/OVERVIEW.ja.md` にも同等の `ドキュメント` セクションを追加して日英で導線を同期

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs:generate` を実行する
2. 生成された TypeDoc のトップ（OVERVIEW）を開く
3. `Documentation` セクションから Quick Start / Advanced Usage / API Reference / Migration へ遷移できることを確認する

## Environment (if relevant)
- Browser: Chrome (version: latest)
- OS: macOS
- web-serial-rxjs version (for verification): workspace local
- RxJS version: ^7.8.0

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)