### PR TITLE
feat(web-serial-rxjs): typedocの外部リンクを新規タブで開く設定を追加

### DIFF
--- a/packages/web-serial-rxjs/typedoc.json
+++ b/packages/web-serial-rxjs/typedoc.json
@@ -22,5 +22,7 @@
   "gitRevision": "main",
   "projectDocuments": ["./docs/**/*.md"],
   "searchInDocuments": true,
+  "sourceLinkExternal": true,
+  "markdownLinkExternal": true,
   "plugin": ["typedoc-rhineai-theme"]
 }


### PR DESCRIPTION
## Summary
TypeDoc の外部リンクと内部リンクを区別するため、`sourceLinkExternal` と `markdownLinkExternal` を有効化しました。
これにより GitHub などの外部リンクは新規タブで開き、TypeDoc 内部リンクは同一タブ遷移のまま維持されます。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #320
- Parent #316

## What changed?
- `packages/web-serial-rxjs/typedoc.json` に `sourceLinkExternal: true` を追加
- `packages/web-serial-rxjs/typedoc.json` に `markdownLinkExternal: true` を追加
- `pnpm run docs:generate` 実行後、生成 HTML 上で外部リンクに `target="_blank"` が付与されることを確認

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs:generate` を実行する
2. `docs/functions/index.createSerialSession.html` などで GitHub リンクを確認する
3. 外部リンクが新規タブで開き、TypeDoc 内部リンクは同一タブ遷移であることを確認する

## Environment (if relevant)
- Browser: Chrome (latest)
- OS: macOS
- web-serial-rxjs version (for verification): workspace HEAD
- RxJS version: ^7.8.0

## Checklist
- [x] I ran tests locally (if available)
- [x] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)