### PR TITLE
fix(example-react): StrictMode 下のシリアルセッション初期化エラーを修正 (#328)

### DIFF
--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '@gurezo/web-serial-rxjs';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { act, renderHook } from '@testing-library/react';
+import { createElement, StrictMode, type ReactNode } from 'react';
 import {
   BehaviorSubject,
   of,
@@ -228,5 +229,19 @@ describe('useSerialSession', () => {
     const mock = latestMock();
     unmount();
     expect(mock.disconnect$).toHaveBeenCalled();
+  });
+
+  it('StrictMode の二重マウントでも例外なくセッションを購読できる (issue #328)', () => {
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(StrictMode, null, children);
+
+    // StrictMode 配下では effect が「setup → cleanup → setup」と二重実行される。
+    // renderHook 自体が throw しないこと（pipe を null 参照しないこと）を確認する。
+    const { result } = renderHook(() => useSerialSession(), { wrapper });
+
+    // StrictMode の再 setup で active な subscription は最後の mock セッション側に
+    // 切り替わるため、その state$ を更新したらフックの state に反映される。
+    act(() => latestMock().stateSubject.next(SS.Connecting));
+    expect(result.current.state).toBe(SS.Connecting);
   });
 });

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -36,16 +36,22 @@ export function useSerialSession(
   const currentBaudRateRef = useRef(initialBaudRate);
   const sessionRef = useRef<SerialSession | null>(null);
 
-  if (sessionsRef.current === null) {
-    sessionsRef.current = new ReplaySubject<SerialSession>(1);
-  }
-  if (terminalBufferEpochRef.current === null) {
-    terminalBufferEpochRef.current = new BehaviorSubject(0);
-  }
-  if (sessionRef.current === null) {
-    sessionRef.current = createSerialSession({ baudRate: initialBaudRate });
-    sessionsRef.current.next(sessionRef.current);
-  }
+  // StrictMode の二重マウントでクリーンアップが ref を null に戻した後でも、
+  // useEffect の再 setup から呼び出されたときに subject / session を作り直す。
+  const ensureRefs = (baudRate: number) => {
+    if (sessionsRef.current === null) {
+      sessionsRef.current = new ReplaySubject<SerialSession>(1);
+    }
+    if (terminalBufferEpochRef.current === null) {
+      terminalBufferEpochRef.current = new BehaviorSubject(0);
+    }
+    if (sessionRef.current === null) {
+      sessionRef.current = createSerialSession({ baudRate });
+      sessionsRef.current.next(sessionRef.current);
+    }
+  };
+
+  ensureRefs(initialBaudRate);
 
   const [browserSupported] = useState(() =>
     (sessionRef.current as SerialSession).isBrowserSupported(),
@@ -56,6 +62,7 @@ export function useSerialSession(
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
+    ensureRefs(currentBaudRateRef.current);
     const sessions$ = sessionsRef.current as ReplaySubject<SerialSession>;
     const terminalBufferEpoch$ = terminalBufferEpochRef.current as BehaviorSubject<number>;
     const sub = new Subscription();
@@ -100,9 +107,11 @@ export function useSerialSession(
     );
     return () => {
       sub.unsubscribe();
-      (sessionRef.current as SerialSession).disconnect$().subscribe({
-        error: () => void 0,
-      });
+      if (sessionRef.current !== null) {
+        sessionRef.current.disconnect$().subscribe({
+          error: () => void 0,
+        });
+      }
       sessions$.complete();
       terminalBufferEpoch$.complete();
       sessionRef.current = null;


### PR DESCRIPTION
## Summary
React StrictMode の二重マウントにより `useSerialSession` の `useEffect` が再 setup された際、ref が null のままで `sessions$.pipe(...)` が TypeError になっていた問題を修正します。`ensureRefs` ヘルパで `ReplaySubject` / `BehaviorSubject` / `SerialSession` を必要なタイミングで再生成するようにし、StrictMode 下でも安全にセッションを購読できます。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #328

## What changed?
- `apps/example-react/src/hooks/useSerialSession.ts` に `ensureRefs(baudRate)` を追加し、関数本体と `useEffect` の双方から呼び出して ref を必要に応じて再生成する。
- `useEffect` クリーンアップで `disconnect$()` を呼ぶ前に `sessionRef.current` の null チェックを追加し、StrictMode の二重クリーンアップでも安全に動作させる。
- `apps/example-react/src/hooks/useSerialSession.test.ts` に StrictMode を `wrapper` として渡した renderHook テストを追加し、二重マウントでも TypeError にならず `state$` の購読が成立することを確認。

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: なし。`useSerialSession` のシグネチャ / 戻り値の形は変更なし。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx test example-react` を実行し、25 件のテスト（うち追加 1 件）が全て通ることを確認する。
2. `pnpm exec nx lint example-react` でリンタが通ることを確認する。
3. `pnpm exec nx build example-react` でビルドが通ることを確認する。
4. `pnpm exec nx serve example-react` を起動し、`http://localhost:4210` を Chromium 系ブラウザで開き、DevTools コンソールに `Cannot read properties of null (reading 'pipe')` が出ないことを確認する。

## Environment (if relevant)
- Browser: Chrome v148.0.7778.168
- OS: macOS
- web-serial-rxjs version (for verification): @gurezo/web-serial-rxjs@2.3.1
- RxJS version: rxjs@7.8.x

## Checklist
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

## Notes
- Issue で報告された 2 番目のエラー `A listener indicated an asynchronous response by returning true, but the message channel closed before a response was received` は Chrome 拡張機能（React DevTools 等）由来の既知警告であり、本アプリのコードに起因しないため対象外としています。
- 同等の構造を持つ `example-svelte` / `example-vue` / `example-angular` には本不具合は再現しないため、修正は `example-react` のみに限定しています。

Made with [Cursor](https://cursor.com)