### PR TITLE
chore(web-serial-rxjs): bump npm package version to 2.3.5

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Issue #350 に対応し、npm パッケージ `@gurezo/web-serial-rxjs` のバージョンを 2.3.4 から 2.3.5 に更新しました。#349（Nx v23.0.0 マイグレーション）の取り込み内容をリリース可能な状態にするためのバージョン更新です。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #350

## What changed?

- `packages/web-serial-rxjs/package.json` の `version` を `2.3.4` から `2.3.5` に更新
- `pnpm run publish:test`（dry-run）にて `2.3.5` として tarball が生成されることを確認

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `git checkout chore/web-serial-rxjs-bump-2-3-5`
2. `pnpm run publish:test`
3. 出力の Tarball Details で version が `2.3.5` であることを確認

## Environment (if relevant)

- Browser: N/A
- OS: macOS
- web-serial-rxjs version (for verification): 2.3.5
- RxJS version: ^7.8.0

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)