### PR TITLE
fix(web-serial-rxjs): read-pump の done true 終了時に状態を解放する

### DIFF
--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -331,6 +331,21 @@ export function createSerialSession(
                 fallbackCode: SerialErrorCode.READ_FAILED,
                 messagePrefix: 'Read pump failed',
               }),
+            onDone: () => {
+              if (machine.current !== SerialSessionState.Connected) {
+                return;
+              }
+              reportError(
+                new SerialError(
+                  SerialErrorCode.CONNECTION_LOST,
+                  'Read pump ended unexpectedly: stream closed while connected',
+                ),
+                'fatal',
+                {
+                  fallbackCode: SerialErrorCode.CONNECTION_LOST,
+                },
+              );
+            },
           });
           activePump.start();
           sendQueue.clear();

--- a/packages/web-serial-rxjs/src/session/read-pump.ts
+++ b/packages/web-serial-rxjs/src/session/read-pump.ts
@@ -25,6 +25,14 @@ export type ReadPumpChunkHandler = (text: string) => void;
 export type ReadPumpErrorHandler = (error: SerialError) => void;
 
 /**
+ * Callback invoked when the read loop ends naturally (`reader.read()`
+ * resolved with `done: true`) while the pump is still active.
+ *
+ * @internal
+ */
+export type ReadPumpDoneHandler = () => void;
+
+/**
  * Options accepted by {@link createReadPump}.
  *
  * @internal
@@ -32,6 +40,7 @@ export type ReadPumpErrorHandler = (error: SerialError) => void;
 export interface ReadPumpOptions {
   onChunk: ReadPumpChunkHandler;
   onError: ReadPumpErrorHandler;
+  onDone?: ReadPumpDoneHandler;
 }
 
 /**
@@ -79,7 +88,7 @@ export interface ReadPump {
  */
 export function createReadPump(
   port: SerialPort,
-  { onChunk, onError }: ReadPumpOptions,
+  { onChunk, onError, onDone }: ReadPumpOptions,
 ): ReadPump {
   let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
   let running = false;
@@ -105,6 +114,9 @@ export function createReadPump(
       while (!stopped) {
         const { done, value } = await reader.read();
         if (done) {
+          if (!stopped) {
+            onDone?.();
+          }
           break;
         }
         if (value && value.byteLength > 0) {

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -525,6 +525,27 @@ describe('createSerialSession', () => {
         S.Error,
       );
     });
+
+    it('treats done:true stream completion as connection lost and leaves connected', async () => {
+      const { stream, controller } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const errorPromise = firstValueFrom(session.errors$);
+      controller.close();
+
+      const received = await errorPromise;
+      expect(received).toBeInstanceOf(SerialError);
+      expect(received.code).toBe(SerialErrorCode.CONNECTION_LOST);
+
+      await flushMicrotasks();
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
+        S.Error,
+      );
+    });
   });
 
   describe('receiveReplay$', () => {

--- a/packages/web-serial-rxjs/tests/session/read-pump.test.ts
+++ b/packages/web-serial-rxjs/tests/session/read-pump.test.ts
@@ -120,6 +120,27 @@ describe('createReadPump', () => {
     expect(pump.isRunning).toBe(false);
   });
 
+  it('notifies onDone when the stream ends with done:true', async () => {
+    const { stream, controller } = makeStream();
+    const port = makePort({ readable: stream });
+    const onDone = vi.fn();
+    const onError = vi.fn();
+
+    const pump = createReadPump(port, {
+      onChunk: vi.fn(),
+      onError,
+      onDone,
+    });
+    pump.start();
+
+    controller.close();
+    await flushMicrotasks();
+
+    expect(onDone).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(pump.isRunning).toBe(false);
+  });
+
   it('stop() cancels the reader and suppresses further onError emissions', async () => {
     const { stream, controller } = makeStream();
     const port = makePort({ readable: stream });


### PR DESCRIPTION
## Summary
`read-pump` が `done: true` で自然終了した際に `connected` が残る問題を修正し、意図しないストリーム終了をセッション側で正しく検知できるようにしました。
自然終了はエラー経路と分離しつつ、接続喪失として一貫した状態遷移とエラー通知になるように統合しています。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #368
- Refs #366

## What changed?
- `read-pump` に `done: true` の自然終了通知コールバック（`onDone`）を追加
- `createSerialSession` で `onDone` を受け、接続中の予期しないストリーム終了を `CONNECTION_LOST` として fatal 処理
- `read-pump` 単体テストに `done: true` 通知ケースを追加
- `createSerialSession` 統合テストに自然終了時の `errors$` / `state$` 挙動検証を追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm vitest run packages/web-serial-rxjs/tests/session/read-pump.test.ts packages/web-serial-rxjs/tests/session/create-serial-session.test.ts` を実行する
2. すべてのテストが成功することを確認する
3. 追加テストで、`done: true` 発生時に `CONNECTION_LOST` が `errors$` に流れ `state$` が `error` へ遷移することを確認する

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / etc. (version: any Chromium supporting Web Serial API)
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): @gurezo/web-serial-rxjs@2.3.5 相当
- RxJS version: rxjs@7.x

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)