### PR TITLE
fix(web-serial-rxjs): cancel in-flight connect on disconnect during connecting

### DIFF
--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -98,7 +98,7 @@ Opens a user-selected serial port and starts the internal read pump. Completes o
 
 ### `disconnect$(): Observable<void>`
 
-Stops the read pump and closes the port. Safe to call when already idle. Transitions `connected → disconnecting → idle`. When called from `'error'` it still tears the port down and returns to `idle`.
+Stops the read pump and closes the port. Safe to call when already idle or while a disconnect is already in progress. When called during `'connecting'`, cancels the in-flight `connect$()` (closes any opened port) and returns to `'idle'` without reaching `'connected'`. Transitions `connected → disconnecting → idle`. When called from `'error'` it still tears the port down and returns to `idle`.
 
 ### `state$: Observable<SerialSessionState>`
 
@@ -138,7 +138,7 @@ Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a
 | `PORT_NOT_AVAILABLE`     | Requested port cannot be accessed.                                  |
 | `PORT_OPEN_FAILED`       | `port.open()` rejected.                                             |
 | `PORT_ALREADY_OPEN`      | `connect$` called while not in `'idle'` / `'error'`.                |
-| `PORT_NOT_OPEN`          | `send$` / `disconnect$` called in a state that disallows it.        |
+| `PORT_NOT_OPEN`          | `send$` called while not `'connected'`.                             |
 | `READ_FAILED`            | Internal read pump errored.                                         |
 | `WRITE_FAILED`           | `port.writable.getWriter().write()` rejected.                       |
 | `CONNECTION_LOST`        | `port.close()` failed or the port dropped mid-session.              |

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -156,6 +156,13 @@ export function createSerialSession(
 
   let activePort: SerialPort | null = null;
   let activePump: ReadPump | null = null;
+  let activeConnectCancel: (() => void) | null = null;
+
+  const clearActiveConnectCancel = (cancel: () => void): void => {
+    if (activeConnectCancel === cancel) {
+      activeConnectCancel = null;
+    }
+  };
 
   const setActivePort = (port: SerialPort | null): void => {
     activePort = port;
@@ -276,6 +283,13 @@ export function createSerialSession(
         }
 
         let cancelled = false;
+        const cancelInFlightConnect = (): void => {
+          cancelled = true;
+          if (machine.current === SerialSessionState.Connecting) {
+            machine.toIdle();
+          }
+        };
+        activeConnectCancel = cancelInFlightConnect;
         machine.toConnecting();
 
         const run = async (): Promise<void> => {
@@ -357,10 +371,8 @@ export function createSerialSession(
         void run();
 
         return () => {
-          cancelled = true;
-          if (machine.current === SerialSessionState.Connecting) {
-            machine.toIdle();
-          }
+          clearActiveConnectCancel(cancelInFlightConnect);
+          cancelInFlightConnect();
         };
       });
     },
@@ -370,8 +382,16 @@ export function createSerialSession(
 
         if (
           current === SerialSessionState.Idle ||
-          current === SerialSessionState.Unsupported
+          current === SerialSessionState.Unsupported ||
+          current === SerialSessionState.Disconnecting
         ) {
+          subscriber.next();
+          subscriber.complete();
+          return;
+        }
+
+        if (current === SerialSessionState.Connecting) {
+          activeConnectCancel?.();
           subscriber.next();
           subscriber.complete();
           return;

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -58,7 +58,8 @@ type ReportErrorSeverity = 'fatal' | 'non-fatal';
  * - `connect$()` opens a user-selected port, starts the internal read pump,
  *   and transitions `idle -> connecting -> connected`.
  * - `disconnect$()` stops the read pump, closes the port, and transitions
- *   `connected -> disconnecting -> idle`.
+ *   `connected -> disconnecting -> idle`. When called during `connecting`,
+ *   it cancels the in-flight `connect$()` and returns to `idle`.
  * - `receive$` emits UTF-8 decoded text chunks pushed by the pump. It is
  *   **not** subscription-lazy - the pump is started by `connect$` and
  *   decoded text is multicast to all subscribers; late subscribers see only

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -54,7 +54,10 @@ export interface SerialSession {
   /**
    * Close the active serial port and stop the internal read pump.
    *
-   * Safe to call when already disconnected.
+   * Safe to call when already disconnected or while a disconnect is already
+   * in progress. When called during `'connecting'`, cancels the in-flight
+   * `connect$()` (closes any opened port) and returns the session to
+   * `'idle'` without reaching `'connected'`.
    *
    * @returns An Observable that completes when the port is fully closed.
    */

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -348,6 +348,132 @@ describe('createSerialSession', () => {
       expect(port.close).toHaveBeenCalledTimes(1);
     });
 
+    it('returns to idle when disconnect$ is called before requestPort resolves', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+
+      let resolveRequestPort!: (value: MockPort) => void;
+      const requestPort = vi.fn().mockImplementation(
+        () =>
+          new Promise<MockPort>((resolve) => {
+            resolveRequestPort = resolve;
+          }),
+      );
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        writable: true,
+        value: { serial: { requestPort, getPorts: vi.fn() } },
+      });
+
+      const session = createSerialSession();
+      const stateAfterConnecting = firstValueFrom(session.state$.pipe(skip(1), take(1)));
+
+      session.connect$().subscribe({ error: () => undefined });
+      expect(await stateAfterConnecting).toBe<SerialSessionState>(S.Connecting);
+
+      await expect(firstValueFrom(session.disconnect$())).resolves.toBeUndefined();
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+
+      resolveRequestPort(port);
+      await flushMicrotasks();
+
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(port.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not reach connected after disconnect$ while connect$ is still in flight', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+
+      let resolveRequestPort!: (value: MockPort) => void;
+      const requestPort = vi.fn().mockImplementation(
+        () =>
+          new Promise<MockPort>((resolve) => {
+            resolveRequestPort = resolve;
+          }),
+      );
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        writable: true,
+        value: { serial: { requestPort, getPorts: vi.fn() } },
+      });
+
+      const session = createSerialSession();
+      const connectComplete = vi.fn();
+      const stateAfterConnecting = firstValueFrom(
+        session.state$.pipe(filter((s) => s === S.Connecting), take(1)),
+      );
+      session.connect$().subscribe({
+        next: connectComplete,
+        error: () => undefined,
+      });
+      await stateAfterConnecting;
+
+      await firstValueFrom(session.disconnect$());
+      resolveRequestPort(port);
+      await flushMicrotasks();
+
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(connectComplete).not.toHaveBeenCalled();
+      expect(port.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns to idle when disconnect$ is called after open resolves but before connect completes', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+
+      let resolveOpen!: () => void;
+      port.open.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveOpen = resolve;
+          }),
+      );
+      installNavigator(port);
+
+      const session = createSerialSession();
+      const connectComplete = vi.fn();
+      const stateAfterConnecting = firstValueFrom(
+        session.state$.pipe(filter((s) => s === S.Connecting), take(1)),
+      );
+      session.connect$().subscribe({
+        next: connectComplete,
+        error: () => undefined,
+      });
+      await stateAfterConnecting;
+
+      await firstValueFrom(session.disconnect$());
+      resolveOpen();
+      await flushMicrotasks();
+
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(connectComplete).not.toHaveBeenCalled();
+      expect(port.close).toHaveBeenCalledTimes(1);
+    });
+
+    it('completes immediately when disconnect$ is called while already disconnecting', async () => {
+      const { stream } = makeStream();
+      let resolveClose!: () => void;
+      const close = vi.fn().mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveClose = resolve;
+          }),
+      );
+      const port = makeMockPort(stream, close);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const firstDisconnect = firstValueFrom(session.disconnect$());
+      await expect(firstValueFrom(session.disconnect$())).resolves.toBeUndefined();
+
+      resolveClose();
+      await expect(firstDisconnect).resolves.toBeUndefined();
+      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+    });
+
     it('rejects connect$ with BROWSER_NOT_SUPPORTED when navigator.serial is missing', async () => {
       const session = createSerialSession();
 


### PR DESCRIPTION
## Summary
`connecting` 中に `disconnect$()` を呼んでも裏の `connect$()` が `connected` に進んでしまう race を修正しました。`disconnect$()` は進行中の connect をキャンセルし、port を close して `idle` に戻します。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #369
- Parent: #366

## What changed?
- `create-serial-session.ts` に in-flight connect キャンセルハンドルを追加
- `connecting` 中の `disconnect$()` をキャンセル処理に変更（`PORT_NOT_OPEN` を返さない）
- `disconnecting` 中の重複 `disconnect$()` を no-op 成功に統一
- 回帰テストを追加
- API リファレンスと JSDoc を更新

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `disconnect$()` の `connecting` 中の挙動が `PORT_NOT_OPEN` エラーから成功完了（connect キャンセル）に変わります。シグネチャは不変です。
- [ ] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. `npx nx test web-serial-rxjs` を実行し、新規・既存テストが通ることを確認
2. 追加した `connecting` 中 `disconnect$` の unit test が意図どおり pass することを確認
3. （任意）example アプリで connect 開始直後に disconnect を押し、`connected` にならないことを確認

## Environment (if relevant)
- Browser: Chrome / Edge など Chromium 系
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): ローカルブランチ
- RxJS version: 7.x

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)