### PR TITLE
fix(workspace): dispose old session before swap in examples

### DIFF
--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -20,6 +20,7 @@ interface MockCore {
   isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
@@ -33,6 +34,7 @@ const createMockCore = (): MockCore => {
   const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
+  const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
 
@@ -40,6 +42,7 @@ const createMockCore = (): MockCore => {
     isBrowserSupported,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
@@ -56,6 +59,7 @@ const createMockCore = (): MockCore => {
     isConnectedSubject,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     isBrowserSupported,
   };
@@ -131,7 +135,10 @@ describe('SerialClientService', () => {
   });
 
   it('should recreate session when baud rate changes', async () => {
+    const first = mockSessions[0];
     await firstValueFrom(service.connect$(115200));
+    expect(first.connect$).not.toHaveBeenCalled();
+    expect(first.dispose$).toHaveBeenCalledTimes(1);
     expect(latestMock().connect$).toHaveBeenCalledWith();
     expect(vi.mocked(webSerialRxjs.createSerialSession)).toHaveBeenLastCalledWith({
       baudRate: 115200,
@@ -194,8 +201,8 @@ describe('SerialClientService', () => {
     await expect(pending).resolves.toBe(error);
   });
 
-  it('should disconnect session on destroy', () => {
+  it('should dispose session on destroy', () => {
     service.ngOnDestroy();
-    expect(latestMock().disconnect$).toHaveBeenCalledTimes(1);
+    expect(latestMock().dispose$).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -61,7 +61,7 @@ export class SerialClientService implements OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this.currentSession.disconnect$().subscribe({ error: () => void 0 });
+    this.currentSession.dispose$().subscribe({ error: () => void 0 });
     this.sessions$.complete();
     this.terminalBufferEpoch$.complete();
   }
@@ -73,9 +73,13 @@ export class SerialClientService implements OnDestroy {
   connect$(baudRate?: number): Observable<void> {
     this.bumpTerminalBufferEpoch();
     if (baudRate !== undefined && baudRate !== this.currentBaudRate) {
+      const previousSession = this.currentSession;
       this.currentBaudRate = baudRate;
       this.currentSession = createSerialSession({ baudRate });
       this.sessions$.next(this.currentSession);
+      return previousSession
+        .dispose$()
+        .pipe(switchMap(() => this.currentSession.connect$()));
     }
     return this.currentSession.connect$();
   }

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -20,6 +20,7 @@ interface MockSession {
   errorsSubject: Subject<SerialError>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
@@ -35,6 +36,7 @@ const createMockSession = (): MockSession => {
   );
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
+  const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
   const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
@@ -43,6 +45,7 @@ const createMockSession = (): MockSession => {
     isBrowserSupported,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
@@ -64,6 +67,7 @@ const createMockSession = (): MockSession => {
     errorsSubject,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     isBrowserSupported,
   };

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -25,6 +25,7 @@ interface MockCore {
   isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
@@ -36,6 +37,7 @@ const createMockCore = (supported = true): MockCore => {
   const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
+  const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => supported);
 
@@ -43,6 +45,7 @@ const createMockCore = (supported = true): MockCore => {
     isBrowserSupported,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
@@ -59,6 +62,7 @@ const createMockCore = (supported = true): MockCore => {
     isConnectedSubject,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     isBrowserSupported,
   };
@@ -191,6 +195,7 @@ describe('useSerialSession', () => {
       result.current.connect$(115200).subscribe();
     });
     expect(first.connect$).not.toHaveBeenCalled();
+    expect(first.dispose$).toHaveBeenCalledTimes(1);
     expect(latestMock().connect$).toHaveBeenCalledWith();
     expect(
       vi.mocked(webSerialRxjs.createSerialSession),
@@ -224,11 +229,11 @@ describe('useSerialSession', () => {
     expect(onError).toHaveBeenCalledWith(err);
   });
 
-  it('unmount 時に disconnect$ を呼ぶ', () => {
+  it('unmount 時に dispose$ を呼ぶ', () => {
     const { unmount } = renderHook(() => useSerialSession());
     const mock = latestMock();
     unmount();
-    expect(mock.disconnect$).toHaveBeenCalled();
+    expect(mock.dispose$).toHaveBeenCalled();
   });
 
   it('StrictMode の二重マウントでも例外なくセッションを購読できる (issue #328)', () => {

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -108,7 +108,7 @@ export function useSerialSession(
     return () => {
       sub.unsubscribe();
       if (sessionRef.current !== null) {
-        sessionRef.current.disconnect$().subscribe({
+        sessionRef.current.dispose$().subscribe({
           error: () => void 0,
         });
       }
@@ -128,11 +128,15 @@ export function useSerialSession(
       baudRate !== undefined &&
       baudRate !== currentBaudRateRef.current
     ) {
+      const previousSession = sessionRef.current as SerialSession;
       currentBaudRateRef.current = baudRate;
       sessionRef.current = createSerialSession({ baudRate });
       (sessionsRef.current as ReplaySubject<SerialSession>).next(
         sessionRef.current,
       );
+      return previousSession
+        .dispose$()
+        .pipe(switchMap(() => (sessionRef.current as SerialSession).connect$()));
     }
     return (sessionRef.current as SerialSession).connect$();
   };

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -24,6 +24,7 @@ interface MockCore {
   isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
@@ -35,6 +36,7 @@ const createMockCore = (supported = true): MockCore => {
   const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
+  const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => supported);
 
@@ -42,6 +44,7 @@ const createMockCore = (supported = true): MockCore => {
     isBrowserSupported,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
@@ -58,6 +61,7 @@ const createMockCore = (supported = true): MockCore => {
     isConnectedSubject,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     isBrowserSupported,
   };
@@ -206,6 +210,7 @@ describe('useSerialSession', () => {
     const unsub = s.state.subscribe(() => void 0);
     s.connect$(115200).subscribe();
     expect(first.connect$).not.toHaveBeenCalled();
+    expect(first.dispose$).toHaveBeenCalledTimes(1);
     expect(latestMock().connect$).toHaveBeenCalledWith();
     expect(
       vi.mocked(webSerialRxjs.createSerialSession),
@@ -226,13 +231,13 @@ describe('useSerialSession', () => {
     expect(onError).toHaveBeenCalledWith(err);
   });
 
-  it('onDestroy で session.disconnect$ が呼ばれる', () => {
+  it('onDestroy で session.dispose$ が呼ばれる', () => {
     useSerialSession();
     const mock = latestMock();
     const cleanup = (
       globalThis as unknown as { __svelteCleanup?: () => void }
     ).__svelteCleanup;
     cleanup?.();
-    expect(mock.disconnect$).toHaveBeenCalled();
+    expect(mock.dispose$).toHaveBeenCalled();
   });
 });

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -99,7 +99,7 @@ export function useSerialSession(
 
   onDestroy(() => {
     terminalSub.unsubscribe();
-    currentSession.disconnect$().subscribe({ error: () => void 0 });
+    currentSession.dispose$().subscribe({ error: () => void 0 });
     sessions$.complete();
     terminalBufferEpoch$.complete();
   });
@@ -108,9 +108,13 @@ export function useSerialSession(
     receivedData.set('');
     terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
     if (baudRate !== undefined && baudRate !== currentBaudRate) {
+      const previousSession = currentSession;
       currentBaudRate = baudRate;
       currentSession = createSerialSession({ baudRate });
       sessions$.next(currentSession);
+      return previousSession
+        .dispose$()
+        .pipe(switchMap(() => currentSession.connect$()));
     }
     return currentSession.connect$();
   };

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -105,9 +105,15 @@ export class App {
       this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
       receiveOutput.value = '';
       if (baudRate !== this.currentBaudRate) {
+        const previousSession = this.currentSession;
         this.currentBaudRate = baudRate;
         this.currentSession = createSerialSession({ baudRate });
         this.sessions$.next(this.currentSession);
+        previousSession
+          .dispose$()
+          .pipe(switchMap(() => this.currentSession.connect$()))
+          .subscribe({ error: () => void 0 });
+        return;
       }
       this.currentSession.connect$().subscribe({ error: () => void 0 });
     });

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -1,10 +1,9 @@
 import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
+import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { App } from './app.js';
 
-vi.mock('@gurezo/web-serial-rxjs', async () => {
-  const actual = await vi.importActual('@gurezo/web-serial-rxjs');
+const createMockSession = () => {
   const state$ = new BehaviorSubject('idle');
   const receive$ = new Subject();
   const errors$ = new Subject();
@@ -12,10 +11,11 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     map((s) => s === 'connected'),
     distinctUntilChanged(),
   );
-  const core = {
+  return {
     isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
     disconnect$: vi.fn(() => of(undefined)),
+    dispose$: vi.fn(() => of(undefined)),
     send$: vi.fn(() => of(undefined)),
     state$,
     receive$,
@@ -23,9 +23,19 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     errors$,
     isConnected$,
   };
+};
+
+let mockSessions = [];
+
+vi.mock('@gurezo/web-serial-rxjs', async () => {
+  const actual = await vi.importActual('@gurezo/web-serial-rxjs');
   return {
     ...actual,
-    createSerialSession: vi.fn(() => core),
+    createSerialSession: vi.fn(() => {
+      const mock = createMockSession();
+      mockSessions.push(mock);
+      return mock;
+    }),
   };
 });
 
@@ -34,6 +44,8 @@ describe('App', () => {
   let container;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessions = [];
     container = document.createElement('div');
     container.innerHTML = `
       <div id="browser-support-status"></div>
@@ -67,7 +79,9 @@ describe('App', () => {
 
   it('should create serial session on init', () => {
     app = new App();
-    expect(createSerialSession).toHaveBeenCalled();
+    expect(webSerialRxjs.createSerialSession).toHaveBeenCalledWith({
+      baudRate: 9600,
+    });
   });
 
   it('should render browser support status based on session.isBrowserSupported', () => {
@@ -83,5 +97,20 @@ describe('App', () => {
     expect(document.getElementById('disconnect-btn')).not.toBeNull();
     expect(document.getElementById('send-input')).not.toBeNull();
     expect(document.getElementById('receive-output')).not.toBeNull();
+  });
+
+  it('should dispose previous session when baud rate changes on connect', () => {
+    app = new App();
+    const first = mockSessions[0];
+    const connectBtn = document.getElementById('connect-btn');
+    connectBtn.click();
+
+    expect(first.dispose$).toHaveBeenCalledTimes(1);
+    expect(first.connect$).not.toHaveBeenCalled();
+    expect(mockSessions).toHaveLength(2);
+    expect(mockSessions[1].connect$).toHaveBeenCalledTimes(1);
+    expect(webSerialRxjs.createSerialSession).toHaveBeenLastCalledWith({
+      baudRate: 115200,
+    });
   });
 });

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -1,12 +1,22 @@
 import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
+import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { App } from './app.js';
 
-vi.mock('@gurezo/web-serial-rxjs', async () => {
-  const actual = await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
-    '@gurezo/web-serial-rxjs',
-  );
+interface MockSession {
+  isBrowserSupported: ReturnType<typeof vi.fn>;
+  connect$: ReturnType<typeof vi.fn>;
+  disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
+  send$: ReturnType<typeof vi.fn>;
+  state$: BehaviorSubject<string>;
+  receive$: Subject<string>;
+  terminalText$: Subject<string>;
+  errors$: Subject<{ message: string }>;
+  isConnected$: ReturnType<typeof map>;
+}
+
+const createMockSession = (): MockSession => {
   const state$ = new BehaviorSubject<string>('idle');
   const receive$ = new Subject<string>();
   const errors$ = new Subject<{ message: string }>();
@@ -14,10 +24,11 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     map((s) => s === 'connected'),
     distinctUntilChanged(),
   );
-  const core = {
+  return {
     isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
     disconnect$: vi.fn(() => of(undefined)),
+    dispose$: vi.fn(() => of(undefined)),
     send$: vi.fn(() => of(undefined)),
     state$,
     receive$,
@@ -25,9 +36,21 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     errors$,
     isConnected$,
   };
+};
+
+let mockSessions: MockSession[] = [];
+
+vi.mock('@gurezo/web-serial-rxjs', async () => {
+  const actual = await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
+    '@gurezo/web-serial-rxjs',
+  );
   return {
     ...actual,
-    createSerialSession: vi.fn(() => core),
+    createSerialSession: vi.fn(() => {
+      const mock = createMockSession();
+      mockSessions.push(mock);
+      return mock;
+    }),
   };
 });
 
@@ -36,6 +59,8 @@ describe('App', () => {
   let container: HTMLDivElement | null = null;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockSessions = [];
     container = document.createElement('div');
     container.innerHTML = `
       <div id="browser-support-status"></div>
@@ -69,7 +94,9 @@ describe('App', () => {
 
   it('should create serial session on init', () => {
     app = new App();
-    expect(createSerialSession).toHaveBeenCalled();
+    expect(webSerialRxjs.createSerialSession).toHaveBeenCalledWith({
+      baudRate: 9600,
+    });
   });
 
   it('should render browser support status based on session.isBrowserSupported', () => {
@@ -85,5 +112,20 @@ describe('App', () => {
     expect(document.getElementById('disconnect-btn')).not.toBeNull();
     expect(document.getElementById('send-input')).not.toBeNull();
     expect(document.getElementById('receive-output')).not.toBeNull();
+  });
+
+  it('should dispose previous session when baud rate changes on connect', () => {
+    app = new App();
+    const first = mockSessions[0];
+    const connectBtn = document.getElementById('connect-btn') as HTMLButtonElement;
+    connectBtn.click();
+
+    expect(first.dispose$).toHaveBeenCalledTimes(1);
+    expect(first.connect$).not.toHaveBeenCalled();
+    expect(mockSessions).toHaveLength(2);
+    expect(mockSessions[1].connect$).toHaveBeenCalledTimes(1);
+    expect(webSerialRxjs.createSerialSession).toHaveBeenLastCalledWith({
+      baudRate: 115200,
+    });
   });
 });

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -111,9 +111,15 @@ export class App {
       this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
       receiveOutput.value = '';
       if (baudRate !== this.currentBaudRate) {
+        const previousSession = this.currentSession;
         this.currentBaudRate = baudRate;
         this.currentSession = createSerialSession({ baudRate });
         this.sessions$.next(this.currentSession);
+        previousSession
+          .dispose$()
+          .pipe(switchMap(() => this.currentSession.connect$()))
+          .subscribe({ error: () => void 0 });
+        return;
       }
       this.currentSession.connect$().subscribe({ error: () => void 0 });
     });

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -20,6 +20,7 @@ interface MockSession {
   errorsSubject: Subject<SerialError>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
@@ -43,6 +44,7 @@ const createMockSession = (): MockSession => {
     stateSubject.next(SS.Idle);
     return of(undefined);
   });
+  const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
   const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
@@ -51,6 +53,7 @@ const createMockSession = (): MockSession => {
     isBrowserSupported,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
@@ -72,6 +75,7 @@ const createMockSession = (): MockSession => {
     errorsSubject,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     isBrowserSupported,
   };

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -24,6 +24,7 @@ interface MockCore {
   isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
   isBrowserSupported: ReturnType<typeof vi.fn>;
 }
@@ -35,6 +36,7 @@ const createMockCore = (supported = true): MockCore => {
   const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
+  const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => supported);
 
@@ -42,6 +44,7 @@ const createMockCore = (supported = true): MockCore => {
     isBrowserSupported,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     state$: stateSubject.asObservable(),
     errors$: errorsSubject.asObservable(),
@@ -58,6 +61,7 @@ const createMockCore = (supported = true): MockCore => {
     isConnectedSubject,
     connect$,
     disconnect$,
+    dispose$,
     send$,
     isBrowserSupported,
   };
@@ -176,6 +180,7 @@ describe('useSerialClient', () => {
     api.connect$(115200).subscribe();
 
     expect(first.connect$).not.toHaveBeenCalled();
+    expect(first.dispose$).toHaveBeenCalledTimes(1);
     expect(latestMock().connect$).toHaveBeenCalledWith();
     expect(
       vi.mocked(webSerialRxjs.createSerialSession),
@@ -246,12 +251,12 @@ describe('useSerialClient', () => {
     expect(api.receivedData.value).toBe('');
   });
 
-  it('should disconnect session on unmount', () => {
+  it('should dispose session on unmount', () => {
     const { wrapper } = mountHarness();
     const mock = latestMock();
 
     wrapper.unmount();
 
-    expect(mock.disconnect$).toHaveBeenCalledTimes(1);
+    expect(mock.dispose$).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -80,9 +80,13 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     receivedData.value = '';
     terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
     if (baudRate !== undefined && baudRate !== currentBaudRate) {
+      const previousSession = currentSession;
       currentBaudRate = baudRate;
       currentSession = createSerialSession({ baudRate });
       sessions$.next(currentSession);
+      return previousSession
+        .dispose$()
+        .pipe(switchMap(() => currentSession.connect$()));
     }
     return currentSession.connect$();
   };
@@ -99,7 +103,7 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     isConnectedSub.unsubscribe();
     receiveSub.unsubscribe();
     errorsSub.unsubscribe();
-    currentSession.disconnect$().subscribe({ error: () => void 0 });
+    currentSession.dispose$().subscribe({ error: () => void 0 });
     sessions$.complete();
     terminalBufferEpoch$.complete();
   });


### PR DESCRIPTION
## Summary

全 framework / vanilla examples で、baud rate 変更による `SerialSession` 差し替え前に旧 session を `dispose$()` で明示的に破棄するよう修正した。コンポーネント unmount 時も `disconnect$()` から `dispose$()` に変更し、セッションの完全 teardown を徹底する。ユーザー操作の「切断」ボタンは再利用可能な `disconnect$()` のまま維持する。

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #374
- Parent: #366

## What changed?

- baud rate 変更時: 旧 session に `dispose$()` → 新 session の `connect$()` を `switchMap` で直列実行
- unmount / destroy 時: `disconnect$()` → `dispose$()` に変更（framework examples）
- 全 example の unit test に `dispose$` mock と呼び出し検証を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. 任意の example app を起動（例: `npx nx serve example-react`）
2. シリアルポートに接続
3. baud rate を変更して再接続 — 正常に接続できること
4. 「切断」ボタンで切断 — 同一 session で再接続できること
5. `npx nx run-many -t test -p example-react,example-vue,example-angular,example-svelte,example-vanilla-ts,example-vanilla-js` が通ること

## Environment (if relevant)

- Browser: Chrome / Edge など Chromium 系（Web Serial API 対応）
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): main ブランチ（`dispose$` API 含む）
- RxJS version: 7.x

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)