### PR TITLE
refactor(workspace): extract shared serial session adapter for examples

### DIFF
--- a/.cursor/rules/nx/30-nx-project-scope.mdc
+++ b/.cursor/rules/nx/30-nx-project-scope.mdc
@@ -20,6 +20,7 @@ alwaysApply: false
 | `example-svelte` | `apps/example-svelte` | Svelte サンプル |
 | `example-vanilla-js` | `apps/example-vanilla-js` | Vanilla JS サンプル |
 | `example-vanilla-ts` | `apps/example-vanilla-ts` | Vanilla TS サンプル |
+| `examples-shared` | `libs/examples-shared` | example 用 shared adapter |
 | `workspace` | ルート設定・複数 project | `nx.json` / `tsconfig.base.json` / `.cursor/` 等 |
 | `docs` | ドキュメント全般 | README / CONTRIBUTING / docs 等 |
 | `readme` | README 単体 | |
@@ -41,7 +42,7 @@ libs/**/project.json
 packages/**/project.json
 ```
 
-`libs/` は現状未使用だが、将来追加された場合も `project.json` の `name` を scope として採用する。
+`libs/` の project も `project.json` の `name` を scope として採用する。
 
 ## scope 選択方針
 

--- a/.cursor/skills/conventional-commits/scopes.md
+++ b/.cursor/skills/conventional-commits/scopes.md
@@ -13,6 +13,7 @@ web-serial-rxjs で使用可能な scope の一覧と用途。`commitlint.config
 | `example-svelte` | `apps/example-svelte` | `example-svelte` | Svelte サンプル |
 | `example-vanilla-js` | `apps/example-vanilla-js` | `example-vanilla-js` | Vanilla JS サンプル |
 | `example-vanilla-ts` | `apps/example-vanilla-ts` | `example-vanilla-ts` | Vanilla TS サンプル |
+| `examples-shared` | `libs/examples-shared` | `examples-shared` | example 用 shared adapter |
 | `workspace` | リポジトリルート | (該当なし) | `package.json` / `nx.json` / `.husky/` / `commitlint.config.js` / `.cursor/` / README / CONTRIBUTING 等 |
 | `docs` | ドキュメント全般 | (該当なし) | ドキュメント横断 |
 | `readme` | README 単体 | (該当なし) | README のみ |
@@ -32,7 +33,7 @@ libs/**/project.json
 packages/**/project.json
 ```
 
-`libs/` は現状未使用。追加時は `name` を scope にし、`commitlint.config.js` を更新する。
+`libs/` の project は `name` を scope にし、`commitlint.config.js` を更新する。
 
 ## scope 選択の考え方
 

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -1,99 +1,48 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import {
-  createSerialSession,
   type SerialError,
-  type SerialSession,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  type Observable,
-  ReplaySubject,
-  shareReplay,
-  switchMap,
-} from 'rxjs';
+import { createSerialSessionController } from '@gurezo/examples-shared';
+import { type Observable } from 'rxjs';
 
 /** v2 SerialSession を薄くラップ。表示は `terminalText$`、`receive$` は raw。 */
 @Injectable({ providedIn: 'root' })
 export class SerialClientService implements OnDestroy {
-  private readonly sessions$ = new ReplaySubject<SerialSession>(1);
-  private readonly terminalBufferEpoch$ = new BehaviorSubject(0);
-
-  private currentBaudRate = 9600;
-  private currentSession: SerialSession = createSerialSession({
-    baudRate: this.currentBaudRate,
+  private readonly controller = createSerialSessionController({
+    initialBaudRate: 9600,
   });
 
-  readonly state$: Observable<SerialSessionState>;
+  readonly state$: Observable<SerialSessionState> = this.controller.state$;
   /** デコード済み raw チャンク。textarea には `terminalText$` を参照。 */
-  readonly receive$: Observable<string>;
+  readonly receive$: Observable<string> = this.controller.receive$;
   /** `\r` を畳んだターミナル表示用テキスト（Issue #275 `createTerminalBuffer`）。 */
-  readonly terminalText$: Observable<string>;
-  readonly isConnected$: Observable<boolean>;
-  readonly errors$: Observable<SerialError>;
-
-  constructor() {
-    this.sessions$.next(this.currentSession);
-    this.state$ = this.sessions$.pipe(
-      switchMap((session) => session.state$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-    this.receive$ = this.sessions$.pipe(
-      switchMap((session) => session.receive$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-    this.terminalText$ = combineLatest([
-      this.sessions$,
-      this.terminalBufferEpoch$,
-    ]).pipe(
-      switchMap(([session]) => session.terminalText$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-    this.isConnected$ = this.sessions$.pipe(
-      switchMap((session) => session.isConnected$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-    this.errors$ = this.sessions$.pipe(
-      switchMap((session) => session.errors$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    );
-  }
+  readonly terminalText$: Observable<string> = this.controller.terminalText$;
+  readonly isConnected$: Observable<boolean> = this.controller.isConnected$;
+  readonly errors$: Observable<SerialError> = this.controller.errors$;
 
   ngOnDestroy(): void {
-    this.currentSession.dispose$().subscribe({ error: () => void 0 });
-    this.sessions$.complete();
-    this.terminalBufferEpoch$.complete();
+    this.controller.dispose();
   }
 
   isBrowserSupported(): boolean {
-    return this.currentSession.isBrowserSupported();
+    return this.controller.isBrowserSupported();
   }
 
   connect$(baudRate?: number): Observable<void> {
-    this.bumpTerminalBufferEpoch();
-    if (baudRate !== undefined && baudRate !== this.currentBaudRate) {
-      const previousSession = this.currentSession;
-      this.currentBaudRate = baudRate;
-      this.currentSession = createSerialSession({ baudRate });
-      this.sessions$.next(this.currentSession);
-      return previousSession
-        .dispose$()
-        .pipe(switchMap(() => this.currentSession.connect$()));
-    }
-    return this.currentSession.connect$();
+    return this.controller.connect$(baudRate);
   }
 
   disconnect$(): Observable<void> {
-    return this.currentSession.disconnect$();
+    return this.controller.disconnect$();
   }
 
   send$(data: string | Uint8Array): Observable<void> {
-    return this.currentSession.send$(data);
+    return this.controller.send$(data);
   }
 
   /** `terminalText$` の表示累積をリセットし、以降の受信のみ表示する（textarea クリア・再接続時）。 */
   bumpTerminalBufferEpoch(): void {
-    this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+    this.controller.resetTerminalBuffer();
   }
 }

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,19 +1,13 @@
 import {
-  createSerialSession,
-  type SerialSession,
   SerialSessionState,
   type SerialError,
 } from '@gurezo/web-serial-rxjs';
-import { useEffect, useRef, useState } from 'react';
 import {
-  BehaviorSubject,
-  combineLatest,
-  Observable,
-  ReplaySubject,
-  shareReplay,
-  Subscription,
-  switchMap,
-} from 'rxjs';
+  createSerialSessionController,
+  type SerialSessionController,
+} from '@gurezo/examples-shared';
+import { useEffect, useRef, useState } from 'react';
+import { type Observable, Subscription } from 'rxjs';
 
 /** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続時は世代でリセット）。 */
 export interface UseSerialSessionReturn {
@@ -31,30 +25,22 @@ export interface UseSerialSessionReturn {
 export function useSerialSession(
   initialBaudRate = 9600,
 ): UseSerialSessionReturn {
-  const sessionsRef = useRef<ReplaySubject<SerialSession> | null>(null);
-  const terminalBufferEpochRef = useRef<BehaviorSubject<number> | null>(null);
-  const currentBaudRateRef = useRef(initialBaudRate);
-  const sessionRef = useRef<SerialSession | null>(null);
+  const controllerRef = useRef<SerialSessionController | null>(null);
 
   // StrictMode の二重マウントでクリーンアップが ref を null に戻した後でも、
-  // useEffect の再 setup から呼び出されたときに subject / session を作り直す。
-  const ensureRefs = (baudRate: number) => {
-    if (sessionsRef.current === null) {
-      sessionsRef.current = new ReplaySubject<SerialSession>(1);
-    }
-    if (terminalBufferEpochRef.current === null) {
-      terminalBufferEpochRef.current = new BehaviorSubject(0);
-    }
-    if (sessionRef.current === null) {
-      sessionRef.current = createSerialSession({ baudRate });
-      sessionsRef.current.next(sessionRef.current);
+  // useEffect の再 setup から呼び出されたときに controller を作り直す。
+  const ensureController = (baudRate: number) => {
+    if (controllerRef.current === null) {
+      controllerRef.current = createSerialSessionController({
+        initialBaudRate: baudRate,
+      });
     }
   };
 
-  ensureRefs(initialBaudRate);
+  ensureController(initialBaudRate);
 
   const [browserSupported] = useState(() =>
-    (sessionRef.current as SerialSession).isBrowserSupported(),
+    (controllerRef.current as SerialSessionController).isBrowserSupported(),
   );
   const [state, setState] = useState<SerialSessionState>(SerialSessionState.Idle);
   const [isConnected, setIsConnected] = useState(false);
@@ -62,17 +48,11 @@ export function useSerialSession(
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    ensureRefs(currentBaudRateRef.current);
-    const sessions$ = sessionsRef.current as ReplaySubject<SerialSession>;
-    const terminalBufferEpoch$ = terminalBufferEpochRef.current as BehaviorSubject<number>;
+    ensureController(initialBaudRate);
+    const controller = controllerRef.current as SerialSessionController;
     const sub = new Subscription();
     sub.add(
-      sessions$
-        .pipe(
-          switchMap((session) => session.state$),
-          shareReplay({ bufferSize: 1, refCount: true }),
-        )
-        .subscribe((next) => {
+      controller.state$.subscribe((next) => {
         setState(next);
         if (
           next === SerialSessionState.Connected ||
@@ -81,72 +61,28 @@ export function useSerialSession(
           setErrorMessage(null);
       }),
     );
+    sub.add(controller.isConnected$.subscribe(setIsConnected));
+    sub.add(controller.terminalText$.subscribe(setReceivedData));
     sub.add(
-      sessions$
-        .pipe(
-          switchMap((session) => session.isConnected$),
-          shareReplay({ bufferSize: 1, refCount: true }),
-        )
-        .subscribe((next) => setIsConnected(next)),
-    );
-    sub.add(
-      combineLatest([sessions$, terminalBufferEpoch$])
-        .pipe(
-          switchMap(([session]) => session.terminalText$),
-          shareReplay({ bufferSize: 1, refCount: true }),
-        )
-        .subscribe(setReceivedData),
-    );
-    sub.add(
-      sessions$
-        .pipe(
-          switchMap((session) => session.errors$),
-          shareReplay({ bufferSize: 1, refCount: true }),
-        )
-        .subscribe((e: SerialError) => setErrorMessage(e.message)),
+      controller.errors$.subscribe((e: SerialError) => setErrorMessage(e.message)),
     );
     return () => {
       sub.unsubscribe();
-      if (sessionRef.current !== null) {
-        sessionRef.current.dispose$().subscribe({
-          error: () => void 0,
-        });
-      }
-      sessions$.complete();
-      terminalBufferEpoch$.complete();
-      sessionRef.current = null;
-      sessionsRef.current = null;
-      terminalBufferEpochRef.current = null;
+      controller.dispose();
+      controllerRef.current = null;
     };
   }, []);
 
   const connect$ = (baudRate?: number): Observable<void> => {
     setReceivedData('');
-    const terminalBufferEpoch$ = terminalBufferEpochRef.current as BehaviorSubject<number>;
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
-    if (
-      baudRate !== undefined &&
-      baudRate !== currentBaudRateRef.current
-    ) {
-      const previousSession = sessionRef.current as SerialSession;
-      currentBaudRateRef.current = baudRate;
-      sessionRef.current = createSerialSession({ baudRate });
-      (sessionsRef.current as ReplaySubject<SerialSession>).next(
-        sessionRef.current,
-      );
-      return previousSession
-        .dispose$()
-        .pipe(switchMap(() => (sessionRef.current as SerialSession).connect$()));
-    }
-    return (sessionRef.current as SerialSession).connect$();
+    return (controllerRef.current as SerialSessionController).connect$(baudRate);
   };
   const disconnect$ = (): Observable<void> =>
-    (sessionRef.current as SerialSession).disconnect$();
+    (controllerRef.current as SerialSessionController).disconnect$();
   const send$ = (data: string | Uint8Array): Observable<void> =>
-    (sessionRef.current as SerialSession).send$(data);
+    (controllerRef.current as SerialSessionController).send$(data);
   const clearReceivedData = (): void => {
-    const terminalBufferEpoch$ = terminalBufferEpochRef.current as BehaviorSubject<number>;
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
+    (controllerRef.current as SerialSessionController).resetTerminalBuffer();
     setReceivedData('');
   };
 

--- a/apps/example-react/tsconfig.app.json
+++ b/apps/example-react/tsconfig.app.json
@@ -1,7 +1,13 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "allowJs": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
     "types": [
       "node",
       "@nx/react/typings/cssmodule.d.ts",

--- a/apps/example-react/tsconfig.json
+++ b/apps/example-react/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "jsx": "react-jsx",
     "allowJs": false,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "types": ["vite/client", "vitest"]

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,18 +1,9 @@
 import {
-  createSerialSession,
   SerialSessionState,
   type SerialError,
-  type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  type Observable,
-  ReplaySubject,
-  shareReplay,
-  Subscription,
-  switchMap,
-} from 'rxjs';
+import { createSerialSessionController } from '@gurezo/examples-shared';
+import { type Observable, Subscription } from 'rxjs';
 import { onDestroy } from 'svelte';
 import { readable, writable, type Readable } from 'svelte/store';
 
@@ -32,100 +23,61 @@ export interface UseSerialSessionReturn {
 export function useSerialSession(
   initialBaudRate = 9600,
 ): UseSerialSessionReturn {
-  const sessions$ = new ReplaySubject<SerialSession>(1);
-  const terminalBufferEpoch$ = new BehaviorSubject(0);
-  let currentBaudRate = initialBaudRate;
-  let currentSession = createSerialSession({ baudRate: initialBaudRate });
-  sessions$.next(currentSession);
+  const controller = createSerialSessionController({
+    initialBaudRate,
+  });
 
-  const browserSupported = readable(currentSession.isBrowserSupported());
+  const browserSupported = readable(controller.isBrowserSupported());
 
   const state = readable<SerialSessionState>(SerialSessionState.Idle, (set) => {
-    const sub = sessions$
-      .pipe(
-        switchMap((session) => session.state$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((next) => set(next));
+    const sub = controller.state$.subscribe((next) => set(next));
     return () => sub.unsubscribe();
   });
 
   const isConnected = readable<boolean>(false, (set) => {
-    const sub = sessions$
-      .pipe(
-        switchMap((session) => session.isConnected$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((next) => set(next));
+    const sub = controller.isConnected$.subscribe((next) => set(next));
     return () => sub.unsubscribe();
   });
 
   const receivedData = writable('');
-  const terminalSub = combineLatest([sessions$, terminalBufferEpoch$])
-    .pipe(
-      switchMap(([session]) => session.terminalText$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    )
-    .subscribe((t) => {
+  const terminalSub = controller.terminalText$.subscribe((t) => {
     receivedData.set(t);
   });
 
   const errorMessage = readable<string | null>(null, (set) => {
     const subs = new Subscription();
     subs.add(
-      sessions$
-        .pipe(
-          switchMap((session) => session.errors$),
-          shareReplay({ bufferSize: 1, refCount: true }),
-        )
-        .subscribe((e: SerialError) => set(e.message)),
+      controller.errors$.subscribe((e: SerialError) => set(e.message)),
     );
     subs.add(
-      sessions$
-        .pipe(
-          switchMap((session) => session.state$),
-          shareReplay({ bufferSize: 1, refCount: true }),
+      controller.state$.subscribe((next) => {
+        if (
+          next === SerialSessionState.Connected ||
+          next === SerialSessionState.Idle
         )
-        .subscribe((next) => {
-          if (
-            next === SerialSessionState.Connected ||
-            next === SerialSessionState.Idle
-          )
-            set(null);
-        }),
+          set(null);
+      }),
     );
     return () => subs.unsubscribe();
   });
 
   onDestroy(() => {
     terminalSub.unsubscribe();
-    currentSession.dispose$().subscribe({ error: () => void 0 });
-    sessions$.complete();
-    terminalBufferEpoch$.complete();
+    controller.dispose();
   });
 
   const connect$ = (baudRate?: number): Observable<void> => {
     receivedData.set('');
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
-    if (baudRate !== undefined && baudRate !== currentBaudRate) {
-      const previousSession = currentSession;
-      currentBaudRate = baudRate;
-      currentSession = createSerialSession({ baudRate });
-      sessions$.next(currentSession);
-      return previousSession
-        .dispose$()
-        .pipe(switchMap(() => currentSession.connect$()));
-    }
-    return currentSession.connect$();
+    return controller.connect$(baudRate);
   };
 
-  const disconnect$ = (): Observable<void> => currentSession.disconnect$();
+  const disconnect$ = (): Observable<void> => controller.disconnect$();
 
   const send$ = (data: string | Uint8Array): Observable<void> =>
-    currentSession.send$(data);
+    controller.send$(data);
 
   const clearReceivedData = (): void => {
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
+    controller.resetTerminalBuffer();
     receivedData.set('');
   };
 

--- a/apps/example-svelte/tsconfig.app.json
+++ b/apps/example-svelte/tsconfig.app.json
@@ -1,7 +1,13 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "resolveJsonModule": true,
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
     "types": ["vite/client", "svelte"]
   },
   "exclude": [

--- a/apps/example-svelte/tsconfig.json
+++ b/apps/example-svelte/tsconfig.json
@@ -1,10 +1,9 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "moduleResolution": "node",
     "resolveJsonModule": true
   },
   "files": [],
@@ -12,6 +11,9 @@
   "references": [
     {
       "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ],
   "extends": "../../tsconfig.base.json"

--- a/apps/example-svelte/tsconfig.spec.json
+++ b/apps/example-svelte/tsconfig.spec.json
@@ -1,11 +1,11 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "jsx": "react-jsx",
-    "allowJs": false,
+    "allowJs": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
+    "resolveJsonModule": true,
     "outDir": "../../../dist/out-tsc",
     "moduleResolution": "bundler",
     "types": [
@@ -14,8 +14,7 @@
       "vite/client",
       "node",
       "vitest",
-      "@nx/react/typings/cssmodule.d.ts",
-      "@nx/react/typings/image.d.ts"
+      "svelte"
     ]
   },
   "include": [
@@ -25,12 +24,8 @@
     "vitest.config.mts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
-    "src/**/*.test.tsx",
-    "src/**/*.spec.tsx",
-    "src/**/*.test.js",
-    "src/**/*.spec.js",
-    "src/**/*.test.jsx",
-    "src/**/*.spec.jsx",
+    "src/**/*.test.svelte",
+    "src/**/*.spec.svelte",
     "src/**/*.d.ts"
   ]
 }

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,15 +1,6 @@
-import {
-  createSerialSession,
-  SerialSessionState,
-} from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  fromEvent,
-  ReplaySubject,
-  shareReplay,
-  switchMap,
-} from 'rxjs';
+import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { createSerialSessionController } from '@gurezo/examples-shared';
+import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 const UNSUPPORTED_MSG =
@@ -42,25 +33,16 @@ export class App {
     const sendInput = $('send-input');
     const sendBtn = $('send-btn');
     const receiveOutput = $('receive-output');
-    this.sessions$ = new ReplaySubject(1);
-    this.terminalBufferEpoch$ = new BehaviorSubject(0);
-    this.currentBaudRate = 9600;
-    this.currentSession = createSerialSession({ baudRate: this.currentBaudRate });
-    this.sessions$.next(this.currentSession);
+    this.controller = createSerialSessionController({ initialBaudRate: 9600 });
 
-    const supported = this.currentSession.isBrowserSupported();
+    const supported = this.controller.isBrowserSupported();
     setStatus(
       $('browser-support-status'),
       supported ? 'success' : 'error',
       supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
 
-    this.sessions$
-      .pipe(
-        switchMap((session) => session.state$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((state) => {
+    this.controller.state$.subscribe((state) => {
       const connected = state === SerialSessionState.Connected;
       const busy =
         state === SerialSessionState.Connecting ||
@@ -70,62 +52,35 @@ export class App {
       setStatus(status, ...STATUS[state]);
     });
 
-    this.sessions$
-      .pipe(
-        switchMap((session) => session.isConnected$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((isConnected) => {
-        disconnectBtn.disabled = !isConnected;
-        sendInput.disabled = sendBtn.disabled = !isConnected;
-      });
+    this.controller.isConnected$.subscribe((isConnected) => {
+      disconnectBtn.disabled = !isConnected;
+      sendInput.disabled = sendBtn.disabled = !isConnected;
+    });
 
-    combineLatest([this.sessions$, this.terminalBufferEpoch$])
-      .pipe(
-        switchMap(([session]) => session.terminalText$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((text) => {
-        receiveOutput.value = text;
-        receiveOutput.scrollTop = receiveOutput.scrollHeight;
-      });
+    this.controller.terminalText$.subscribe((text) => {
+      receiveOutput.value = text;
+      receiveOutput.scrollTop = receiveOutput.scrollHeight;
+    });
 
-    this.sessions$
-      .pipe(
-        switchMap((session) => session.errors$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((error) => {
-        setStatus(status, 'error', `エラー: ${error.message}`);
-        console.error('Serial port error:', error);
-      });
+    this.controller.errors$.subscribe((error) => {
+      setStatus(status, 'error', `エラー: ${error.message}`);
+      console.error('Serial port error:', error);
+    });
 
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
-      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
       receiveOutput.value = '';
-      if (baudRate !== this.currentBaudRate) {
-        const previousSession = this.currentSession;
-        this.currentBaudRate = baudRate;
-        this.currentSession = createSerialSession({ baudRate });
-        this.sessions$.next(this.currentSession);
-        previousSession
-          .dispose$()
-          .pipe(switchMap(() => this.currentSession.connect$()))
-          .subscribe({ error: () => void 0 });
-        return;
-      }
-      this.currentSession.connect$().subscribe({ error: () => void 0 });
+      this.controller.connect$(baudRate).subscribe({ error: () => void 0 });
     });
 
     fromEvent(disconnectBtn, 'click').subscribe(() =>
-      this.currentSession.disconnect$().subscribe({ error: () => void 0 }),
+      this.controller.disconnect$().subscribe({ error: () => void 0 }),
     );
 
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
-      this.currentSession.send$(`${text}\n`).subscribe({
+      this.controller.send$(`${text}\n`).subscribe({
         next: () => (sendInput.value = ''),
         error: () => void 0,
       });
@@ -140,7 +95,7 @@ export class App {
       });
 
     fromEvent($('clear-receive-btn'), 'click').subscribe(() => {
-      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+      this.controller.resetTerminalBuffer();
       receiveOutput.value = '';
     });
   }

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,16 +1,6 @@
-import {
-  createSerialSession,
-  SerialSessionState,
-  type SerialSession,
-} from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  fromEvent,
-  ReplaySubject,
-  shareReplay,
-  switchMap,
-} from 'rxjs';
+import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { createSerialSessionController } from '@gurezo/examples-shared';
+import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
 type StatusType = 'info' | 'success' | 'error';
@@ -39,11 +29,8 @@ const setStatus = (el: HTMLElement, type: StatusType, msg: string): void => {
 };
 
 export class App {
-  private readonly sessions$ = new ReplaySubject<SerialSession>(1);
-  private readonly terminalBufferEpoch$ = new BehaviorSubject(0);
-  private currentBaudRate = 9600;
-  private currentSession: SerialSession = createSerialSession({
-    baudRate: this.currentBaudRate,
+  private readonly controller = createSerialSessionController({
+    initialBaudRate: 9600,
   });
 
   constructor() {
@@ -54,21 +41,15 @@ export class App {
     const sendInput = $<HTMLInputElement>('send-input');
     const sendBtn = $<HTMLButtonElement>('send-btn');
     const receiveOutput = $<HTMLTextAreaElement>('receive-output');
-    this.sessions$.next(this.currentSession);
 
-    const supported = this.currentSession.isBrowserSupported();
+    const supported = this.controller.isBrowserSupported();
     setStatus(
       $<HTMLElement>('browser-support-status'),
       supported ? 'success' : 'error',
       supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
     );
 
-    this.sessions$
-      .pipe(
-        switchMap((session) => session.state$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((state) => {
+    this.controller.state$.subscribe((state) => {
       const connected = state === S.Connected;
       const busy = state === S.Connecting || state === S.Disconnecting;
       connectBtn.disabled = !supported || connected || busy;
@@ -76,62 +57,35 @@ export class App {
       setStatus(status, ...STATUS[state]);
     });
 
-    this.sessions$
-      .pipe(
-        switchMap((session) => session.isConnected$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((isConnected) => {
-        disconnectBtn.disabled = !isConnected;
-        sendInput.disabled = sendBtn.disabled = !isConnected;
-      });
+    this.controller.isConnected$.subscribe((isConnected) => {
+      disconnectBtn.disabled = !isConnected;
+      sendInput.disabled = sendBtn.disabled = !isConnected;
+    });
 
-    combineLatest([this.sessions$, this.terminalBufferEpoch$])
-      .pipe(
-        switchMap(([session]) => session.terminalText$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((text) => {
-        receiveOutput.value = text;
-        receiveOutput.scrollTop = receiveOutput.scrollHeight;
-      });
+    this.controller.terminalText$.subscribe((text) => {
+      receiveOutput.value = text;
+      receiveOutput.scrollTop = receiveOutput.scrollHeight;
+    });
 
-    this.sessions$
-      .pipe(
-        switchMap((session) => session.errors$),
-        shareReplay({ bufferSize: 1, refCount: true }),
-      )
-      .subscribe((error) => {
-        setStatus(status, 'error', `エラー: ${error.message}`);
-        console.error('Serial port error:', error);
-      });
+    this.controller.errors$.subscribe((error) => {
+      setStatus(status, 'error', `エラー: ${error.message}`);
+      console.error('Serial port error:', error);
+    });
 
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
-      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
       receiveOutput.value = '';
-      if (baudRate !== this.currentBaudRate) {
-        const previousSession = this.currentSession;
-        this.currentBaudRate = baudRate;
-        this.currentSession = createSerialSession({ baudRate });
-        this.sessions$.next(this.currentSession);
-        previousSession
-          .dispose$()
-          .pipe(switchMap(() => this.currentSession.connect$()))
-          .subscribe({ error: () => void 0 });
-        return;
-      }
-      this.currentSession.connect$().subscribe({ error: () => void 0 });
+      this.controller.connect$(baudRate).subscribe({ error: () => void 0 });
     });
 
     fromEvent(disconnectBtn, 'click').subscribe(() =>
-      this.currentSession.disconnect$().subscribe({ error: () => void 0 }),
+      this.controller.disconnect$().subscribe({ error: () => void 0 }),
     );
 
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
-      this.currentSession.send$(`${text}\n`).subscribe({
+      this.controller.send$(`${text}\n`).subscribe({
         next: () => (sendInput.value = ''),
         error: () => void 0,
       });
@@ -146,7 +100,7 @@ export class App {
       });
 
     fromEvent($<HTMLButtonElement>('clear-receive-btn'), 'click').subscribe(() => {
-      this.terminalBufferEpoch$.next(this.terminalBufferEpoch$.value + 1);
+      this.controller.resetTerminalBuffer();
       receiveOutput.value = '';
     });
   }

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,17 +1,9 @@
 import {
-  createSerialSession,
   SerialSessionState,
   type SerialError,
-  type SerialSession,
 } from '@gurezo/web-serial-rxjs';
-import {
-  BehaviorSubject,
-  combineLatest,
-  type Observable,
-  ReplaySubject,
-  shareReplay,
-  switchMap,
-} from 'rxjs';
+import { createSerialSessionController } from '@gurezo/examples-shared';
+import { type Observable } from 'rxjs';
 import { onUnmounted, ref, type Ref } from 'vue';
 
 /** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続時は世代でリセット）。 */
@@ -28,73 +20,41 @@ export interface UseSerialClientReturn {
 }
 
 export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
-  const sessions$ = new ReplaySubject<SerialSession>(1);
-  const terminalBufferEpoch$ = new BehaviorSubject(0);
-  let currentBaudRate = initialBaudRate;
-  let currentSession = createSerialSession({ baudRate: initialBaudRate });
-  sessions$.next(currentSession);
+  const controller = createSerialSessionController({
+    initialBaudRate,
+  });
 
-  const browserSupported = ref(currentSession.isBrowserSupported());
+  const browserSupported = ref(controller.isBrowserSupported());
   const state = ref<SerialSessionState>(SerialSessionState.Idle);
   const isConnected = ref(false);
   const receivedData = ref('');
   const errorMessage = ref<string | null>(null);
 
-  const stateSub = sessions$
-    .pipe(
-      switchMap((session) => session.state$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    )
-    .subscribe((next) => {
+  const stateSub = controller.state$.subscribe((next) => {
     state.value = next;
     if (next === SerialSessionState.Connected || next === SerialSessionState.Idle) {
       errorMessage.value = null;
     }
   });
-  const isConnectedSub = sessions$
-    .pipe(
-      switchMap((session) => session.isConnected$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    )
-    .subscribe((next) => {
-      isConnected.value = next;
-    });
-  const receiveSub = combineLatest([sessions$, terminalBufferEpoch$])
-    .pipe(
-      switchMap(([session]) => session.terminalText$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    )
-    .subscribe((text) => {
-      receivedData.value = text;
-    });
-  const errorsSub = sessions$
-    .pipe(
-      switchMap((session) => session.errors$),
-      shareReplay({ bufferSize: 1, refCount: true }),
-    )
-    .subscribe((error: SerialError) => {
-      errorMessage.value = error.message;
-    });
+  const isConnectedSub = controller.isConnected$.subscribe((next) => {
+    isConnected.value = next;
+  });
+  const receiveSub = controller.terminalText$.subscribe((text) => {
+    receivedData.value = text;
+  });
+  const errorsSub = controller.errors$.subscribe((error: SerialError) => {
+    errorMessage.value = error.message;
+  });
 
   const connect$ = (baudRate?: number): Observable<void> => {
     receivedData.value = '';
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
-    if (baudRate !== undefined && baudRate !== currentBaudRate) {
-      const previousSession = currentSession;
-      currentBaudRate = baudRate;
-      currentSession = createSerialSession({ baudRate });
-      sessions$.next(currentSession);
-      return previousSession
-        .dispose$()
-        .pipe(switchMap(() => currentSession.connect$()));
-    }
-    return currentSession.connect$();
+    return controller.connect$(baudRate);
   };
-  const disconnect$ = (): Observable<void> => currentSession.disconnect$();
+  const disconnect$ = (): Observable<void> => controller.disconnect$();
   const send$ = (data: string | Uint8Array): Observable<void> =>
-    currentSession.send$(data);
+    controller.send$(data);
   const clearReceivedData = (): void => {
-    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
+    controller.resetTerminalBuffer();
     receivedData.value = '';
   };
 
@@ -103,9 +63,7 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     isConnectedSub.unsubscribe();
     receiveSub.unsubscribe();
     errorsSub.unsubscribe();
-    currentSession.dispose$().subscribe({ error: () => void 0 });
-    sessions$.complete();
-    terminalBufferEpoch$.complete();
+    controller.dispose();
   });
 
   return {

--- a/apps/example-vue/tsconfig.app.json
+++ b/apps/example-vue/tsconfig.app.json
@@ -1,7 +1,15 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "resolveJsonModule": true,
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
     "types": ["vite/client"]
   },
   "exclude": [

--- a/apps/example-vue/tsconfig.json
+++ b/apps/example-vue/tsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "jsx": "preserve",
     "jsxImportSource": "vue",
-    "moduleResolution": "node",
     "resolveJsonModule": true
   },
   "files": [],
@@ -14,6 +13,9 @@
   "references": [
     {
       "path": "./tsconfig.app.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ],
   "extends": "../../tsconfig.base.json"

--- a/apps/example-vue/tsconfig.spec.json
+++ b/apps/example-vue/tsconfig.spec.json
@@ -1,7 +1,15 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "resolveJsonModule": true,
     "outDir": "../../../dist/out-tsc",
+    "moduleResolution": "bundler",
     "types": [
       "vitest/globals",
       "vitest/importMeta",

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -12,6 +12,7 @@ module.exports = {
         'example-svelte',
         'example-vanilla-js',
         'example-vanilla-ts',
+        'examples-shared',
         'workspace',
         'docs',
         'readme',

--- a/libs/examples-shared/README.md
+++ b/libs/examples-shared/README.md
@@ -1,0 +1,7 @@
+# examples-shared
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test examples-shared` to execute the unit tests via [Vitest](https://vitest.dev/).

--- a/libs/examples-shared/eslint.config.cjs
+++ b/libs/examples-shared/eslint.config.cjs
@@ -1,0 +1,3 @@
+const baseConfig = require('../../eslint.config.cjs');
+
+module.exports = [...baseConfig];

--- a/libs/examples-shared/project.json
+++ b/libs/examples-shared/project.json
@@ -1,0 +1,9 @@
+{
+  "name": "examples-shared",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "libs/examples-shared/src",
+  "projectType": "library",
+  "tags": ["type:lib", "scope:examples"],
+  "// targets": "to see all targets run: nx show project examples-shared --web",
+  "targets": {}
+}

--- a/libs/examples-shared/src/create-serial-session-controller.spec.ts
+++ b/libs/examples-shared/src/create-serial-session-controller.spec.ts
@@ -1,0 +1,215 @@
+import type {
+  SerialError,
+  SerialSession,
+  SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
+import {
+  BehaviorSubject,
+  of,
+  Subject,
+  throwError,
+} from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSerialSessionController } from './create-serial-session-controller';
+
+const SS = webSerialRxjs.SerialSessionState;
+
+interface MockCore {
+  session: SerialSession;
+  stateSubject: BehaviorSubject<SerialSessionState>;
+  receiveSubject: Subject<string>;
+  errorsSubject: Subject<SerialError>;
+  isConnectedSubject: BehaviorSubject<boolean>;
+  connect$: ReturnType<typeof vi.fn>;
+  disconnect$: ReturnType<typeof vi.fn>;
+  dispose$: ReturnType<typeof vi.fn>;
+  send$: ReturnType<typeof vi.fn>;
+  isBrowserSupported: ReturnType<typeof vi.fn>;
+}
+
+const createMockCore = (supported = true): MockCore => {
+  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const receiveSubject = new Subject<string>();
+  const errorsSubject = new Subject<SerialError>();
+  const isConnectedSubject = new BehaviorSubject(false);
+  const connect$ = vi.fn(() => of(undefined));
+  const disconnect$ = vi.fn(() => of(undefined));
+  const dispose$ = vi.fn(() => of(undefined));
+  const send$ = vi.fn(() => of(undefined));
+  const isBrowserSupported = vi.fn(() => supported);
+
+  const session: SerialSession = {
+    isBrowserSupported,
+    connect$,
+    disconnect$,
+    dispose$,
+    send$,
+    state$: stateSubject.asObservable(),
+    errors$: errorsSubject.asObservable(),
+    receive$: receiveSubject.asObservable(),
+    terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable())
+      .text$,
+    isConnected$: isConnectedSubject.asObservable(),
+  };
+
+  return {
+    session,
+    stateSubject,
+    receiveSubject,
+    errorsSubject,
+    isConnectedSubject,
+    connect$,
+    disconnect$,
+    dispose$,
+    send$,
+    isBrowserSupported,
+  };
+};
+
+let mockCores: MockCore[] = [];
+let nextSupported = true;
+
+vi.mock('@gurezo/web-serial-rxjs', async () => {
+  const actual =
+    await vi.importActual<typeof import('@gurezo/web-serial-rxjs')>(
+      '@gurezo/web-serial-rxjs',
+    );
+  return {
+    ...actual,
+    createSerialSession: vi.fn(() => {
+      const mock = createMockCore(nextSupported);
+      mockCores.push(mock);
+      return mock.session;
+    }),
+  };
+});
+
+const latestMock = (): MockCore => {
+  const mock = mockCores.at(-1);
+  if (!mock) throw new Error('createSerialSession was not called');
+  return mock;
+};
+
+describe('createSerialSessionController', () => {
+  beforeEach(() => {
+    mockCores = [];
+    nextSupported = true;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('createSerialSession に初期ボーレートを渡す', () => {
+    createSerialSessionController({ initialBaudRate: 9600 });
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenCalledWith({ baudRate: 9600 });
+  });
+
+  it('isBrowserSupported は session の結果を返す', () => {
+    nextSupported = false;
+    const controller = createSerialSessionController();
+    expect(controller.isBrowserSupported()).toBe(false);
+  });
+
+  it('state$ / terminalText$ / errors$ を配信する', () => {
+    const controller = createSerialSessionController();
+    const mock = latestMock();
+    const states: SerialSessionState[] = [];
+    const texts: string[] = [];
+    const errors: SerialError[] = [];
+
+    const stateSub = controller.state$.subscribe((v) => states.push(v));
+    const textSub = controller.terminalText$.subscribe((v) => texts.push(v));
+    const errorSub = controller.errors$.subscribe((v) => errors.push(v));
+
+    mock.stateSubject.next(SS.Connecting);
+    mock.receiveSubject.next('hello');
+    mock.errorsSubject.next({ message: 'boom' } as SerialError);
+
+    expect(states.at(-1)).toBe(SS.Connecting);
+    expect(texts.at(-1)).toBe('hello');
+    expect(errors.at(-1)?.message).toBe('boom');
+
+    stateSub.unsubscribe();
+    textSub.unsubscribe();
+    errorSub.unsubscribe();
+  });
+
+  it('connect$ / disconnect$ / send$ は session の対応メソッドへ委譲する', () => {
+    const controller = createSerialSessionController();
+    const mock = latestMock();
+
+    controller.connect$().subscribe();
+    expect(mock.connect$).toHaveBeenCalled();
+
+    controller.send$('ping').subscribe();
+    expect(mock.send$).toHaveBeenCalledWith('ping');
+
+    controller.disconnect$().subscribe();
+    expect(mock.disconnect$).toHaveBeenCalled();
+  });
+
+  it('connect$(baudRate) で新しいボーレートの session を作成する', () => {
+    const controller = createSerialSessionController({ initialBaudRate: 9600 });
+    const first = mockCores[0];
+
+    controller.connect$(115200).subscribe();
+
+    expect(first.dispose$).toHaveBeenCalledTimes(1);
+    expect(latestMock().connect$).toHaveBeenCalledWith();
+    expect(
+      vi.mocked(webSerialRxjs.createSerialSession),
+    ).toHaveBeenLastCalledWith({ baudRate: 115200 });
+  });
+
+  it('connect$(baudRate) 後は新 session の terminalText$ のみ反映する', () => {
+    const controller = createSerialSessionController({ initialBaudRate: 9600 });
+    const first = mockCores[0];
+    const texts: string[] = [];
+    const textSub = controller.terminalText$.subscribe((v) => texts.push(v));
+
+    first.receiveSubject.next('old');
+    expect(texts.at(-1)).toBe('old');
+
+    controller.connect$(115200).subscribe();
+    latestMock().receiveSubject.next('new');
+    expect(texts.at(-1)).toBe('new');
+
+    textSub.unsubscribe();
+  });
+
+  it('resetTerminalBuffer は購読中でも安全に呼び出せる', () => {
+    const controller = createSerialSessionController();
+    const mock = latestMock();
+    const texts: string[] = [];
+    const textSub = controller.terminalText$.subscribe((v) => texts.push(v));
+
+    mock.receiveSubject.next('data');
+    expect(() => controller.resetTerminalBuffer()).not.toThrow();
+    mock.receiveSubject.next('more');
+    expect(texts.at(-1)).toBe('more');
+
+    textSub.unsubscribe();
+  });
+
+  it('connect$ が失敗すると subscriber にエラーが渡る', () => {
+    const controller = createSerialSessionController();
+    const err = new Error('no port');
+    latestMock().connect$.mockReturnValueOnce(throwError(() => err));
+
+    const onError = vi.fn();
+    controller.connect$().subscribe({ error: onError });
+    expect(onError).toHaveBeenCalledWith(err);
+  });
+
+  it('dispose で dispose$ を呼ぶ', () => {
+    const controller = createSerialSessionController();
+    const mock = latestMock();
+
+    controller.dispose();
+    expect(mock.dispose$).toHaveBeenCalled();
+  });
+});

--- a/libs/examples-shared/src/create-serial-session-controller.ts
+++ b/libs/examples-shared/src/create-serial-session-controller.ts
@@ -1,0 +1,114 @@
+import {
+  createSerialSession,
+  type SerialError,
+  type SerialSession,
+  type SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+import {
+  BehaviorSubject,
+  combineLatest,
+  type Observable,
+  ReplaySubject,
+  shareReplay,
+  switchMap,
+} from 'rxjs';
+
+export interface SerialSessionControllerOptions {
+  initialBaudRate?: number;
+}
+
+export interface SerialSessionController {
+  readonly state$: Observable<SerialSessionState>;
+  readonly isConnected$: Observable<boolean>;
+  readonly terminalText$: Observable<string>;
+  readonly errors$: Observable<SerialError>;
+  readonly receive$: Observable<string>;
+  isBrowserSupported(): boolean;
+  connect$(baudRate?: number): Observable<void>;
+  disconnect$(): Observable<void>;
+  send$(data: string | Uint8Array): Observable<void>;
+  resetTerminalBuffer(): void;
+  dispose(): void;
+}
+
+export function createSerialSessionController(
+  options: SerialSessionControllerOptions = {},
+): SerialSessionController {
+  const initialBaudRate = options.initialBaudRate ?? 9600;
+  const sessions$ = new ReplaySubject<SerialSession>(1);
+  const terminalBufferEpoch$ = new BehaviorSubject(0);
+
+  let currentBaudRate = initialBaudRate;
+  let currentSession: SerialSession = createSerialSession({
+    baudRate: currentBaudRate,
+  });
+  let disposed = false;
+
+  sessions$.next(currentSession);
+
+  const state$ = sessions$.pipe(
+    switchMap((session) => session.state$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const isConnected$ = sessions$.pipe(
+    switchMap((session) => session.isConnected$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const receive$ = sessions$.pipe(
+    switchMap((session) => session.receive$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const terminalText$ = combineLatest([sessions$, terminalBufferEpoch$]).pipe(
+    switchMap(([session]) => session.terminalText$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+  const errors$ = sessions$.pipe(
+    switchMap((session) => session.errors$),
+    shareReplay({ bufferSize: 1, refCount: true }),
+  );
+
+  const resetTerminalBuffer = (): void => {
+    terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
+  };
+
+  const connect$ = (baudRate?: number): Observable<void> => {
+    resetTerminalBuffer();
+    if (baudRate !== undefined && baudRate !== currentBaudRate) {
+      const previousSession = currentSession;
+      currentBaudRate = baudRate;
+      currentSession = createSerialSession({ baudRate });
+      sessions$.next(currentSession);
+      return previousSession
+        .dispose$()
+        .pipe(switchMap(() => currentSession.connect$()));
+    }
+    return currentSession.connect$();
+  };
+
+  const disconnect$ = (): Observable<void> => currentSession.disconnect$();
+
+  const send$ = (data: string | Uint8Array): Observable<void> =>
+    currentSession.send$(data);
+
+  const dispose = (): void => {
+    if (disposed) return;
+    disposed = true;
+    currentSession.dispose$().subscribe({ error: () => void 0 });
+    sessions$.complete();
+    terminalBufferEpoch$.complete();
+  };
+
+  return {
+    state$,
+    isConnected$,
+    terminalText$,
+    errors$,
+    receive$,
+    isBrowserSupported: () => currentSession.isBrowserSupported(),
+    connect$,
+    disconnect$,
+    send$,
+    resetTerminalBuffer,
+    dispose,
+  };
+}

--- a/libs/examples-shared/src/index.ts
+++ b/libs/examples-shared/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/examples-shared';

--- a/libs/examples-shared/src/index.ts
+++ b/libs/examples-shared/src/index.ts
@@ -1,1 +1,5 @@
-export * from './lib/examples-shared';
+export {
+  createSerialSessionController,
+  type SerialSessionController,
+  type SerialSessionControllerOptions,
+} from './create-serial-session-controller';

--- a/libs/examples-shared/src/lib/examples-shared.spec.ts
+++ b/libs/examples-shared/src/lib/examples-shared.spec.ts
@@ -1,0 +1,7 @@
+import { examplesShared } from './examples-shared';
+
+describe('examplesShared', () => {
+  it('should work', () => {
+    expect(examplesShared()).toEqual('examples-shared');
+  });
+});

--- a/libs/examples-shared/src/lib/examples-shared.spec.ts
+++ b/libs/examples-shared/src/lib/examples-shared.spec.ts
@@ -1,7 +1,0 @@
-import { examplesShared } from './examples-shared';
-
-describe('examplesShared', () => {
-  it('should work', () => {
-    expect(examplesShared()).toEqual('examples-shared');
-  });
-});

--- a/libs/examples-shared/src/lib/examples-shared.ts
+++ b/libs/examples-shared/src/lib/examples-shared.ts
@@ -1,0 +1,3 @@
+export function examplesShared(): string {
+  return 'examples-shared';
+}

--- a/libs/examples-shared/src/lib/examples-shared.ts
+++ b/libs/examples-shared/src/lib/examples-shared.ts
@@ -1,3 +1,0 @@
-export function examplesShared(): string {
-  return 'examples-shared';
-}

--- a/libs/examples-shared/tsconfig.json
+++ b/libs/examples-shared/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "importHelpers": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/examples-shared/tsconfig.lib.json
+++ b/libs/examples-shared/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx"
+  ]
+}

--- a/libs/examples-shared/tsconfig.spec.json
+++ b/libs/examples-shared/tsconfig.spec.json
@@ -1,0 +1,28 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ]
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ]
+}

--- a/libs/examples-shared/vitest.config.mts
+++ b/libs/examples-shared/vitest.config.mts
@@ -1,0 +1,21 @@
+import { defineConfig } from 'vitest/config';
+import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/libs/examples-shared',
+  plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  test: {
+    name: 'examples-shared',
+    watch: false,
+    globals: true,
+    environment: 'node',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: '../../coverage/libs/examples-shared',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "paths": {
-      "@gurezo/web-serial-rxjs": ["./packages/web-serial-rxjs/src/index.ts"]
+      "@gurezo/web-serial-rxjs": ["./packages/web-serial-rxjs/src/index.ts"],
+      "@gurezo/examples-shared": ["./libs/examples-shared/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "declaration": false,
     "moduleResolution": "bundler",
+    "esModuleInterop": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "importHelpers": true,

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,0 +1,4 @@
+export default [
+  '**/vite.config.{mjs,js,ts,mts}',
+  '**/vitest.config.{mjs,js,ts,mts}',
+];


### PR DESCRIPTION
## Summary
example アプリ 6 つに重複していた `ReplaySubject<SerialSession>` + `switchMap` 配線を `libs/examples-shared` の `createSerialSessionController` に抽出しました。baud rate 変更時の旧 session `dispose$()` も controller 側に集約し、各 framework は state バインディングに集中できる構成にしました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Parent #366
- Fixes #375

## What changed?
- `libs/examples-shared` を新設し `createSerialSessionController` を追加
- React / Svelte / Vue / Angular / Vanilla JS / Vanilla TS の adapter 層を shared controller 利用に置き換え
- baud rate 変更時の session 差し替えと terminal buffer リセットを controller に集約
- `commitlint` scope に `examples-shared` を追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. `pnpm nx affected -t test,lint --base=main` が通ることを確認
2. 各 example を `pnpm nx serve <project>` で起動し、接続・送信・受信・切断が動作することを確認
3. 接続前に baud rate を変更して接続し、旧 session が dispose され新 baud rate で接続できることを確認
4. Clear / 再接続時に terminal 表示がリセットされることを確認

## Environment (if relevant)
- Browser: Chrome / Edge 等 Chromium ベース
- OS: macOS / Windows / Linux

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)