### PR TITLE
refactor(web-serial-rxjs): share newline tokenizer between line and terminal buffers

### DIFF
--- a/packages/web-serial-rxjs/src/internal/newline-tokenizer.ts
+++ b/packages/web-serial-rxjs/src/internal/newline-tokenizer.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared CR/LF/CRLF scanner for {@link createLineBuffer} and
+ * {@link applyTerminalChunk}. Mode controls intentional semantic differences
+ * between line-delimited output and terminal display redraw.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/376 | Issue #376}
+ */
+export type NewlineTokenizerMode = 'line' | 'terminal';
+
+export type NewlineEvent =
+  | { type: 'line'; content: string }
+  | { type: 'carriage-return' };
+
+export interface NewlineTokenizer {
+  feed(chunk: string): NewlineEvent[];
+  clear(): void;
+  /** Incomplete tail retained across feeds (line mode may end with `\r`). */
+  getPendingText(): string;
+}
+
+/**
+ * Creates a streaming newline tokenizer.
+ *
+ * - **line**: interior lone `\r` completes a line (#237); trailing `\r` is
+ *   deferred until the next chunk disambiguates `\r` vs `\r\n`.
+ * - **terminal**: lone `\r` clears the current line (#275); trailing `\r`
+ *   applies immediately.
+ */
+export function createNewlineTokenizer(
+  mode: NewlineTokenizerMode,
+): NewlineTokenizer {
+  let pending = '';
+  let deferredTrailingCr = false;
+
+  const clear = (): void => {
+    pending = '';
+    deferredTrailingCr = false;
+  };
+
+  const feed = (chunk: string): NewlineEvent[] => {
+    const events: NewlineEvent[] = [];
+    let i = 0;
+
+    if (mode === 'line' && deferredTrailingCr) {
+      deferredTrailingCr = false;
+      if (chunk.length > 0 && chunk.charAt(0) === '\n') {
+        events.push({ type: 'line', content: pending });
+        pending = '';
+        i = 1;
+      } else {
+        events.push({ type: 'line', content: pending });
+        pending = '';
+      }
+    }
+
+    const len = chunk.length;
+    for (; i < len; i++) {
+      const c = chunk.charAt(i);
+      if (c === '\r') {
+        const next = i + 1 < len ? chunk.charAt(i + 1) : '';
+        if (next === '\n') {
+          events.push({ type: 'line', content: pending });
+          pending = '';
+          i++;
+          continue;
+        }
+
+        if (mode === 'line') {
+          if (next !== '') {
+            events.push({ type: 'line', content: pending });
+            pending = '';
+            continue;
+          }
+          deferredTrailingCr = true;
+          break;
+        }
+
+        events.push({ type: 'carriage-return' });
+        pending = '';
+        continue;
+      }
+
+      if (c === '\n') {
+        events.push({ type: 'line', content: pending });
+        pending = '';
+        continue;
+      }
+
+      pending += c;
+    }
+
+    return events;
+  };
+
+  return {
+    feed,
+    clear,
+    getPendingText: () => (deferredTrailingCr ? `${pending}\r` : pending),
+  };
+}

--- a/packages/web-serial-rxjs/src/internal/newline-tokenizer.ts
+++ b/packages/web-serial-rxjs/src/internal/newline-tokenizer.ts
@@ -15,8 +15,15 @@ export type NewlineEvent =
 export interface NewlineTokenizer {
   feed(chunk: string): NewlineEvent[];
   clear(): void;
+  /** Replaces the incomplete tail (used when folding external state in). */
+  restorePending(text: string): void;
   /** Incomplete tail retained across feeds (line mode may end with `\r`). */
   getPendingText(): string;
+  /**
+   * Discards leading characters when pending text exceeds `maxChars`.
+   * @returns `true` when trimming occurred.
+   */
+  trimPending(maxChars: number): boolean;
 }
 
 /**
@@ -35,6 +42,11 @@ export function createNewlineTokenizer(
 
   const clear = (): void => {
     pending = '';
+    deferredTrailingCr = false;
+  };
+
+  const restorePending = (text: string): void => {
+    pending = text;
     deferredTrailingCr = false;
   };
 
@@ -93,9 +105,32 @@ export function createNewlineTokenizer(
     return events;
   };
 
+  const trimPending = (maxChars: number): boolean => {
+    if (maxChars <= 0) {
+      return false;
+    }
+
+    const text = deferredTrailingCr ? `${pending}\r` : pending;
+    if (text.length <= maxChars) {
+      return false;
+    }
+
+    const trimmed = text.slice(text.length - maxChars);
+    if (trimmed.endsWith('\r')) {
+      pending = trimmed.slice(0, -1);
+      deferredTrailingCr = true;
+    } else {
+      pending = trimmed;
+      deferredTrailingCr = false;
+    }
+    return true;
+  };
+
   return {
     feed,
     clear,
+    restorePending,
     getPendingText: () => (deferredTrailingCr ? `${pending}\r` : pending),
+    trimPending,
   };
 }

--- a/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
+++ b/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
@@ -1,3 +1,5 @@
+import { createNewlineTokenizer } from '../../internal/newline-tokenizer';
+
 /**
  * Options for {@link createLineBuffer}.
  *
@@ -43,59 +45,23 @@ export function createLineBuffer(options?: LineBufferOptions): {
     ...options,
   };
 
-  let buffer = '';
+  const tokenizer = createNewlineTokenizer('line');
 
   const clear = (): void => {
-    buffer = '';
-  };
-
-  const trimIncompleteTail = (): boolean => {
-    if (limits.maxChars <= 0 || buffer.length <= limits.maxChars) {
-      return false;
-    }
-    buffer = buffer.slice(buffer.length - limits.maxChars);
-    return true;
+    tokenizer.clear();
   };
 
   const feed = (chunk: string): LineBufferFeedResult => {
-    buffer += chunk;
-    let overflowed = false;
+    const events = tokenizer.feed(chunk);
     const out: string[] = [];
 
-    for (;;) {
-      const crlf = buffer.indexOf('\r\n');
-      if (crlf >= 0) {
-        out.push(buffer.slice(0, crlf));
-        buffer = buffer.slice(crlf + 2);
-        continue;
+    for (const event of events) {
+      if (event.type === 'line') {
+        out.push(event.content);
       }
-
-      // Lone \r (not the last character) is a line end so we must not let
-      // a later \n in the same buffer be matched first (e.g. "a\rb\n").
-      const cr = buffer.indexOf('\r');
-      if (cr >= 0 && cr + 1 < buffer.length && buffer[cr + 1] !== '\n') {
-        out.push(buffer.slice(0, cr));
-        buffer = buffer.slice(cr + 1);
-        continue;
-      }
-
-      const nl = buffer.indexOf('\n');
-      if (nl >= 0) {
-        out.push(buffer.slice(0, nl));
-        buffer = buffer.slice(nl + 1);
-        continue;
-      }
-
-      if (cr >= 0 && cr + 1 === buffer.length) {
-        break;
-      }
-
-      break;
     }
 
-    if (trimIncompleteTail()) {
-      overflowed = true;
-    }
+    const overflowed = tokenizer.trimPending(limits.maxChars);
 
     return { lines: out, overflowed };
   };

--- a/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
+++ b/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
@@ -1,4 +1,5 @@
 import { type Observable, map, scan, shareReplay } from 'rxjs';
+import { createNewlineTokenizer } from '../internal/newline-tokenizer';
 
 /** @internal Folded state between {@link createTerminalBuffer} emissions. */
 export interface TerminalBufferState {
@@ -17,29 +18,21 @@ export function applyTerminalChunk(
   state: TerminalBufferState,
   chunk: string,
 ): TerminalBufferState {
-  let { completed, currentLine } = state;
-  const len = chunk.length;
+  const tokenizer = createNewlineTokenizer('terminal');
+  tokenizer.restorePending(state.currentLine);
+  const events = tokenizer.feed(chunk);
 
-  for (let i = 0; i < len; i++) {
-    const c = chunk.charAt(i);
-    if (c === '\r') {
-      const next = i + 1 < len ? chunk.charAt(i + 1) : '';
-      if (next === '\n') {
-        completed += currentLine + '\n';
-        currentLine = '';
-        i++;
-      } else {
-        currentLine = '';
-      }
-    } else if (c === '\n') {
-      completed += currentLine + '\n';
-      currentLine = '';
-    } else {
-      currentLine += c;
+  let { completed } = state;
+  for (const event of events) {
+    if (event.type === 'line') {
+      completed += event.content + '\n';
     }
   }
 
-  return { completed, currentLine };
+  return {
+    completed,
+    currentLine: tokenizer.getPendingText(),
+  };
 }
 
 /** @internal */

--- a/packages/web-serial-rxjs/tests/internal/crlf-fixtures.test.ts
+++ b/packages/web-serial-rxjs/tests/internal/crlf-fixtures.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { createLineBuffer } from '../../src/session/internal/line-buffer';
+import {
+  applyTerminalChunk,
+  terminalDisplayText,
+  type TerminalBufferState,
+} from '../../src/terminal/create-terminal-buffer';
+import { CRLF_FIXTURES } from './crlf-fixtures';
+
+const emptyTerminal: TerminalBufferState = { completed: '', currentLine: '' };
+
+describe('CRLF fixtures (line buffer)', () => {
+  it.each(CRLF_FIXTURES)('$id', ({ chunks, line }) => {
+    const buffer = createLineBuffer();
+
+    chunks.forEach((chunk, index) => {
+      const result = buffer.feed(chunk);
+      expect(result.lines).toEqual(line.linesPerFeed[index]);
+      expect(result.overflowed).toBe(false);
+    });
+  });
+});
+
+describe('CRLF fixtures (terminal buffer)', () => {
+  it.each(CRLF_FIXTURES)('$id', ({ chunks, terminal }) => {
+    let state = emptyTerminal;
+
+    for (const chunk of chunks) {
+      state = applyTerminalChunk(state, chunk);
+    }
+
+    expect(terminalDisplayText(state)).toBe(terminal);
+  });
+});

--- a/packages/web-serial-rxjs/tests/internal/crlf-fixtures.ts
+++ b/packages/web-serial-rxjs/tests/internal/crlf-fixtures.ts
@@ -1,0 +1,76 @@
+/**
+ * Shared CR/LF regression fixtures for line-buffer and terminal-buffer.
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/376 | Issue #376}
+ */
+export type CrlfFixture = {
+  id: string;
+  chunks: string[];
+  line: { linesPerFeed: string[][] };
+  terminal: string;
+};
+
+export const CRLF_FIXTURES: CrlfFixture[] = [
+  {
+    id: 'lf-single',
+    chunks: ['a\n'],
+    line: { linesPerFeed: [['a']] },
+    terminal: 'a\n',
+  },
+  {
+    id: 'crlf-single',
+    chunks: ['a\r\n'],
+    line: { linesPerFeed: [['a']] },
+    terminal: 'a\n',
+  },
+  {
+    id: 'crlf-split',
+    chunks: ['a\r', '\n'],
+    line: { linesPerFeed: [[], ['a']] },
+    terminal: '\n',
+  },
+  {
+    id: 'interior-cr',
+    chunks: ['A\rB\n'],
+    line: { linesPerFeed: [['A', 'B']] },
+    terminal: 'B\n',
+  },
+  {
+    id: 'interior-cr-split',
+    chunks: ['a\r', 'b\n'],
+    line: { linesPerFeed: [[], ['a', 'b']] },
+    terminal: 'b\n',
+  },
+  {
+    id: 'cr-redraw',
+    chunks: ['A\rB'],
+    line: { linesPerFeed: [['A']] },
+    terminal: 'B',
+  },
+  {
+    id: 'cr-redraw-split',
+    chunks: ['A', '\rB'],
+    line: { linesPerFeed: [[], ['A']] },
+    terminal: 'B',
+  },
+  {
+    id: 'cr-then-lf-not-crlf',
+    chunks: ['a\r', '\nb'],
+    line: { linesPerFeed: [[], ['a']] },
+    terminal: '\nb',
+  },
+  {
+    id: 'multi-lf',
+    chunks: ['a\nb\n'],
+    line: { linesPerFeed: [['a', 'b']] },
+    terminal: 'a\nb\n',
+  },
+  {
+    id: 'mixed-stream',
+    chunks: ['line1\n', 'x\r\ny\r', 'z\n'],
+    line: {
+      linesPerFeed: [['line1'], ['x'], ['y', 'z']],
+    },
+    terminal: 'line1\nx\nz\n',
+  },
+];

--- a/packages/web-serial-rxjs/tests/internal/newline-tokenizer.test.ts
+++ b/packages/web-serial-rxjs/tests/internal/newline-tokenizer.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { createNewlineTokenizer } from '../../src/internal/newline-tokenizer';
+
+describe('createNewlineTokenizer (line mode)', () => {
+  it('emits a line on LF', () => {
+    const t = createNewlineTokenizer('line');
+    expect(t.feed('a\n')).toEqual([{ type: 'line', content: 'a' }]);
+    expect(t.getPendingText()).toBe('');
+  });
+
+  it('emits a line on CRLF', () => {
+    const t = createNewlineTokenizer('line');
+    expect(t.feed('a\r\n')).toEqual([{ type: 'line', content: 'a' }]);
+  });
+
+  it('defers trailing CR until the next chunk', () => {
+    const t = createNewlineTokenizer('line');
+    expect(t.feed('a\r')).toEqual([]);
+    expect(t.getPendingText()).toBe('a\r');
+    expect(t.feed('\n')).toEqual([{ type: 'line', content: 'a' }]);
+  });
+
+  it('treats interior CR as a line end', () => {
+    const t = createNewlineTokenizer('line');
+    expect(t.feed('A\rB\n')).toEqual([
+      { type: 'line', content: 'A' },
+      { type: 'line', content: 'B' },
+    ]);
+  });
+
+  it('resolves interior CR split across feeds', () => {
+    const t = createNewlineTokenizer('line');
+    expect(t.feed('a\r')).toEqual([]);
+    expect(t.feed('b\n')).toEqual([
+      { type: 'line', content: 'a' },
+      { type: 'line', content: 'b' },
+    ]);
+  });
+
+  it('clears pending state', () => {
+    const t = createNewlineTokenizer('line');
+    t.feed('partial\r');
+    t.clear();
+    expect(t.getPendingText()).toBe('');
+    expect(t.feed('x\n')).toEqual([{ type: 'line', content: 'x' }]);
+  });
+});
+
+describe('createNewlineTokenizer (terminal mode)', () => {
+  it('emits carriage-return on lone CR', () => {
+    const t = createNewlineTokenizer('terminal');
+    expect(t.feed('A\rB')).toEqual([{ type: 'carriage-return' }]);
+    expect(t.getPendingText()).toBe('B');
+  });
+
+  it('applies trailing CR immediately', () => {
+    const t = createNewlineTokenizer('terminal');
+    expect(t.feed('a\r')).toEqual([{ type: 'carriage-return' }]);
+    expect(t.getPendingText()).toBe('');
+  });
+
+  it('emits a line on CRLF', () => {
+    const t = createNewlineTokenizer('terminal');
+    expect(t.feed('a\r\nb')).toEqual([{ type: 'line', content: 'a' }]);
+    expect(t.getPendingText()).toBe('b');
+  });
+
+  it('resolves a\\r then \\nb across chunks', () => {
+    const t = createNewlineTokenizer('terminal');
+    expect(t.feed('a\r')).toEqual([{ type: 'carriage-return' }]);
+    expect(t.feed('\nb')).toEqual([
+      { type: 'line', content: '' },
+    ]);
+    expect(t.getPendingText()).toBe('b');
+  });
+});

--- a/packages/web-serial-rxjs/tests/session/line-buffer.test.ts
+++ b/packages/web-serial-rxjs/tests/session/line-buffer.test.ts
@@ -2,36 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { createLineBuffer } from '../../src/session/internal/line-buffer';
 
 describe('createLineBuffer', () => {
-  it('splits on LF', () => {
-    const b = createLineBuffer();
-    expect(b.feed('a\nb')).toEqual({ lines: ['a'], overflowed: false });
-  });
-
-  it('splits on CRLF', () => {
-    const b = createLineBuffer();
-    expect(b.feed('a\r\nb')).toEqual({ lines: ['a'], overflowed: false });
-  });
-
-  it('accumulates across feeds until a delimiter completes', () => {
-    const b = createLineBuffer();
-    expect(b.feed('a\r')).toEqual({ lines: [], overflowed: false });
-    expect(b.feed('\n')).toEqual({ lines: ['a'], overflowed: false });
-  });
-
-  it('emits all complete lines in one feed', () => {
-    const b = createLineBuffer();
-    expect(b.feed('a\nb\n')).toEqual({
-      lines: ['a', 'b'],
-      overflowed: false,
-    });
-  });
-
-  it('resolves interior CR and LF when split across two feeds', () => {
-    const b = createLineBuffer();
-    expect(b.feed('a\r')).toEqual({ lines: [], overflowed: false });
-    expect(b.feed('b\n')).toEqual({ lines: ['a', 'b'], overflowed: false });
-  });
-
   it('clears buffer state', () => {
     const b = createLineBuffer();
     b.feed('partial');

--- a/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
+++ b/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
@@ -13,36 +13,11 @@ const empty: TerminalBufferState = { completed: '', currentLine: '' };
 
 /** Issue #290: terminal 表示の再発防止用テストケース群 */
 describe('applyTerminalChunk', () => {
-  // #290: A\rB
-  it('issue #290: A\\rB を同一チャンクで B に畳み込む', () => {
-    const s = applyTerminalChunk(empty, 'A\rB');
-    expect(terminalDisplayText(s)).toBe('B');
-  });
-
   it('issue #290: A\\rB を分割チャンクでも B に畳み込む', () => {
     let s = applyTerminalChunk(empty, 'A');
     expect(terminalDisplayText(s)).toBe('A');
     s = applyTerminalChunk(s, '\rB');
     expect(terminalDisplayText(s)).toBe('B');
-  });
-
-  // #290: A\r\nB
-  it('issue #290: A\\r\\nB を通常改行として扱う', () => {
-    const s = applyTerminalChunk(empty, 'a\r\nb');
-    expect(terminalDisplayText(s)).toBe('a\nb');
-  });
-
-  // #290: A\nB
-  it('issue #290: A\\nB を2行表示として扱う', () => {
-    const s = applyTerminalChunk(empty, 'a\nb');
-    expect(terminalDisplayText(s)).toBe('a\nb');
-  });
-
-  it('resolves a\\r then \\nb across chunks', () => {
-    let s = applyTerminalChunk(empty, 'a\r');
-    expect(terminalDisplayText(s)).toBe('');
-    s = applyTerminalChunk(s, '\nb');
-    expect(terminalDisplayText(s)).toBe('\nb');
   });
 });
 
@@ -100,27 +75,6 @@ describe('trimCompletedByMaxLines', () => {
 });
 
 describe('createTerminalBuffer', () => {
-  // #290: A\rB
-  it('issue #290: text$ でも A\\rB を B に畳み込む', () => {
-    const receive$ = new Subject<string>();
-    const { text$ } = createTerminalBuffer(receive$);
-    const out: string[] = [];
-    text$.subscribe((t) => out.push(t));
-    receive$.next('A\rB');
-    expect(out.at(-1)).toBe('B');
-  });
-
-  it('handles mixed newlines in streamed chunks', () => {
-    const receive$ = new Subject<string>();
-    const { text$ } = createTerminalBuffer(receive$);
-    const out: string[] = [];
-    text$.subscribe((t) => out.push(t));
-    receive$.next('line1\n');
-    receive$.next('x\r\ny\r');
-    receive$.next('z\n');
-    expect(out.at(-1)).toBe('line1\nx\nz\n');
-  });
-
   // #290: ls -la 形式
   it('issue #290: ls -la 形式の同一行 redraw で古い行を残さない', () => {
     const receive$ = new Subject<string>();


### PR DESCRIPTION
## Summary
line-buffer と create-terminal-buffer の CR/LF/CRLF/chunk 境界処理を共有 newline tokenizer に統合し、共通 fixture テストで drift を防止しました。公開 API と既存挙動は維持しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #376
- Parent: #366

## What changed?
- `packages/web-serial-rxjs/src/internal/newline-tokenizer.ts` を追加
- `line-buffer` と `applyTerminalChunk` を共有 tokenizer 利用にリファクタ
- CR/LF 共通 fixture テストを追加し、既存重複ケースを整理

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. `pnpm nx test web-serial-rxjs`
2. `newline-tokenizer` / `line-buffer` / `create-terminal-buffer` の CR/LF 系テストが pass することを確認
3. （任意）Chromium で example アプリの serial 受信表示を確認

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)