### PR TITLE
build(web-serial-rxjs): Nx build と publish build の経路を統一する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,8 @@ jobs:
       - name: Run build
         run: pnpm exec nx run-many --target=build --all
 
+      - name: Verify publish dist artifacts
+        run: pnpm exec nx run web-serial-rxjs:verify-dist
+
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
-      - name: Verify npm package includes README files
+      - run: pnpm exec nx run web-serial-rxjs:verify-dist
+      - name: Verify npm package includes required files
         shell: bash
         run: |
           set -euo pipefail
@@ -39,7 +40,12 @@ jobs:
           node -e '
             const result = JSON.parse(process.argv[1]);
             const files = (result[0]?.files ?? []).map((file) => file.path);
-            const required = ["README.md", "README.ja.md"];
+            const required = [
+              "README.md",
+              "README.ja.md",
+              "dist/index.mjs",
+              "dist/index.d.ts",
+            ];
             const missing = required.filter((path) => !files.includes(path));
 
             if (missing.length > 0) {
@@ -47,7 +53,7 @@ jobs:
               process.exit(1);
             }
 
-            console.log("Verified npm pack includes README files.");
+            console.log("Verified npm pack includes required publish files.");
           ' "$PACK_RESULT"
 
       # リリース添付用の zip を作る（パッケージ単位）

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -75,7 +75,11 @@ pnpm run prepare
 
 これにより、コミット時に Conventional Commits に準拠しているかが自動的にチェックされます。
 
-### 5. Cursor を使う場合（任意）
+### 5. AI アシスタント（MCP）— 任意
+
+このプロジェクトには、AI 支援開発向けの MCP（Model Context Protocol）サーバー設定が含まれています。利用可能なサーバー（Nx、Angular CLI、Svelte）と設定の詳細は、README の [AI アシスタント（MCP）](README.ja.md#ai-アシスタントmcp) セクションを参照してください。
+
+### 6. Cursor Rules / Skills — 任意
 
 [Cursor](https://www.cursor.com/) でこのリポジトリを開くと、以下の Rules / Skills が自動的に適用され、AI が Conventional Commits 準拠の commit message / PR タイトルを生成できるようになります。
 
@@ -380,12 +384,17 @@ nx test web-serial-rxjs --watch
 # すべてのプロジェクトをビルド
 nx run-many --target=build --all
 
-# 特定のパッケージをビルド
+# 特定のパッケージをビルド（packages/web-serial-rxjs の package scripts に委譲）
 nx build web-serial-rxjs
+
+# package.json exports が参照する配布用 dist 成果物を検証
+nx run web-serial-rxjs:verify-dist
 
 # 特定のアプリをビルド
 nx build example-angular
 ```
+
+`nx build web-serial-rxjs` は、npm publish が `prepublishOnly` 経由で使うのと同じ `pnpm run build` パイプライン（`tsc` + `esbuild`）を実行するため、CI と release は同じ `dist/index.mjs` と `dist/index.d.ts` を検証します。
 
 PRを提出する前に、コードが正常にビルドされることを確認してください。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -382,12 +382,17 @@ nx test web-serial-rxjs --watch
 # Build all projects
 nx run-many --target=build --all
 
-# Build a specific package
+# Build a specific package (delegates to packages/web-serial-rxjs package scripts)
 nx build web-serial-rxjs
+
+# Verify publish dist artifacts referenced by package.json exports
+nx run web-serial-rxjs:verify-dist
 
 # Build a specific app
 nx build example-angular
 ```
+
+`nx build web-serial-rxjs` runs the same `pnpm run build` pipeline (`tsc` + `esbuild`) that npm publish uses via `prepublishOnly`, so CI and release validate the same `dist/index.mjs` and `dist/index.d.ts` artifacts.
 
 Ensure your code builds successfully before submitting a PR.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,7 @@ Web Serial API を最小限の Session 指向 RxJS API でラップする TypeSc
 - [ドキュメント](#ドキュメント)
 - [サンプル](#サンプル)
 - [プロジェクトアイコンについて](#プロジェクトアイコンについて)
+- [AI アシスタント（MCP）](#ai-アシスタントmcp)
 - [貢献](#貢献)
 - [ライセンス](#ライセンス)
 - [リンク](#リンク)
@@ -122,6 +123,31 @@ Web Serial を表すシリアルコネクタのモチーフを組み合わせた
 
 本プロジェクトは **[ReactiveX](http://reactivex.io/) / [RxJS](https://rxjs.dev/) 公式とは関係のない独立したオープンソースプロジェクト** であり、
 公式な提携・承認・スポンサー関係はありません。
+
+## AI アシスタント（MCP）
+
+このプロジェクトには、AI 支援開発向けの [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) サーバー設定が含まれています。利用可能な MCP サーバーは次のとおりです。
+
+| サーバー | 用途 |
+| -------- | ---- |
+| **nx-mcp** | Nx ワークスペース分析、プロジェクトグラフ、CI 監視、ドキュメント |
+| **angular-cli** | example-angular 向け Angular CLI ツール（コード生成、ドキュメント、ベストプラクティス） |
+| **svelte** | example-svelte 向け Svelte / SvelteKit ドキュメントとコード分析 |
+
+**設定ファイル:**
+
+- `.mcp.json` — 標準 MCP 設定（Cursor、VS Code、Claude など）
+- `.cursor/mcp.json` — Cursor 専用設定
+
+Cursor では `.cursor/mcp.json` から設定が自動的に読み込まれます。VS Code では MCP 拡張機能を追加し `.mcp.json` を使うか、MCP 設定にサーバー定義を追加してください。
+
+### Cursor rules と agents
+
+このリポジトリには `.cursor/rules/` 配下に [Cursor](https://www.cursor.com/) 用ルールも同梱されています（トピック別: Conventional Commits と PR タイトル用の `commits/`、`typescript/`、`rxjs/`、`angular/`、Nx ワークスペースタスクと **commit scope** ガイドを含む `nx/`、`examples/`、`workflow/`）。ルールは責務ごとに小さな `.mdc` ファイルへ分割し、重複を減らしてプロンプトを絞り込んでいます。
+
+- `.cursor/agents/ci-monitor-subagent.md` — Nx Cloud CI 監視が有効な場合に `/monitor-ci` および Nx MCP の `ci_information` / `update_self_healing_fix` ツールと併用する任意の CI ヘルパー
+
+commit scope の表は `commitlint.config.js` と整合します。例と scope 一覧は `.cursor/skills/conventional-commits/` を参照してください。
 
 ## 開発とリリース戦略
 

--- a/RELEASING.ja.md
+++ b/RELEASING.ja.md
@@ -19,13 +19,14 @@
 
 1. **すべての変更が `main` にマージされている**: リリースは最新の `main` ブランチに基づくべきです
 2. **テストが通過する**: ローカルで `pnpm test` を実行してすべてが動作することを確認
-3. **ビルドが成功する**: `pnpm exec nx build web-serial-rxjs` を実行してビルドを確認
-4. **バージョン番号**: [セマンティックバージョニング](https://semver.org/)に従って適切なバージョン番号を決定
+3. **ビルドが成功する**: `pnpm exec nx build web-serial-rxjs` を実行してビルドを確認。この Nx target は `packages/web-serial-rxjs` の package scripts（`tsc` + `esbuild`）に委譲され、npm publish で使うのと同じ `dist/index.mjs` と `dist/index.d.ts` を生成します。
+4. **dist 検証**: `pnpm exec nx run web-serial-rxjs:verify-dist` を実行し、`package.json` の exports とビルド成果物が一致することを確認
+5. **バージョン番号**: [セマンティックバージョニング](https://semver.org/)に従って適切なバージョン番号を決定
    - **MAJOR** (例: `1.0.0` → `2.0.0`): 破壊的変更
    - **MINOR** (例: `1.0.0` → `1.1.0`): 新機能（後方互換性あり）
    - **PATCH** (例: `1.0.0` → `1.0.1`): バグ修正（後方互換性あり）
-5. **package.json のバージョン**: `packages/web-serial-rxjs/package.json` のバージョンをタグと一致させる
-6. **ドキュメント**: メンテナンスされている場合は `CHANGELOG.md` を更新（任意）
+6. **package.json のバージョン**: `packages/web-serial-rxjs/package.json` のバージョンをタグと一致させる
+7. **ドキュメント**: メンテナンスされている場合は `CHANGELOG.md` を更新（任意）
 
 ## リリース手順
 
@@ -90,11 +91,12 @@ git push origin v1.0.0
 1. ✅ タグ付けされたコミットでコードをチェックアウト
 2. ✅ 依存関係をインストール（`pnpm install --frozen-lockfile`）
 3. ✅ テストを実行（`pnpm test`）
-4. ✅ パッケージをビルド（`pnpm exec nx build web-serial-rxjs`）
-5. ✅ リリース用 zip ファイルを作成
-6. ✅ Trusted Publishing (OIDC) を使用して npm に公開 - トークン不要！
-7. ✅ 自動生成されたリリースノート付きの GitHub リリースを作成
-8. ✅ GitHub リリースにリリース zip を添付
+4. ✅ パッケージをビルド（`pnpm exec nx build web-serial-rxjs`）— npm publish と同じ package scripts 経由
+5. ✅ 配布用 dist 成果物（`dist/index.mjs`, `dist/index.d.ts`）と npm pack 内容を検証
+6. ✅ リリース用 zip ファイルを作成
+7. ✅ Trusted Publishing (OIDC) を使用して npm に公開 - トークン不要！
+8. ✅ 自動生成されたリリースノート付きの GitHub リリースを作成
+9. ✅ GitHub リリースにリリース zip を添付
 
 進行状況は GitHub の [Actions タブ](https://github.com/gurezo/web-serial-rxjs/actions) で確認できます。
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,13 +19,14 @@ Before releasing, ensure the following:
 
 1. **All changes are merged to `main`**: The release should be based on the latest `main` branch
 2. **Tests pass**: Run `pnpm test` locally to ensure everything works
-3. **Build succeeds**: Run `pnpm exec nx build web-serial-rxjs` to verify the build
-4. **Version number**: Determine the appropriate version number following [Semantic Versioning](https://semver.org/)
+3. **Build succeeds**: Run `pnpm exec nx build web-serial-rxjs` to verify the build. This Nx target delegates to `packages/web-serial-rxjs` package scripts (`tsc` + `esbuild`) and produces the same `dist/index.mjs` and `dist/index.d.ts` artifacts used for npm publish.
+4. **Dist verification**: Run `pnpm exec nx run web-serial-rxjs:verify-dist` to confirm `package.json` exports match built artifacts.
+5. **Version number**: Determine the appropriate version number following [Semantic Versioning](https://semver.org/)
    - **MAJOR** (e.g., `1.0.0` → `2.0.0`): Breaking changes
    - **MINOR** (e.g., `1.0.0` → `1.1.0`): New features (backward compatible)
    - **PATCH** (e.g., `1.0.0` → `1.0.1`): Bug fixes (backward compatible)
-5. **package.json version**: Update the version in `packages/web-serial-rxjs/package.json` to match the tag
-6. **Documentation**: Update `CHANGELOG.md` if maintained (optional)
+6. **package.json version**: Update the version in `packages/web-serial-rxjs/package.json` to match the tag
+7. **Documentation**: Update `CHANGELOG.md` if maintained (optional)
 
 ## Release Steps
 
@@ -90,11 +91,12 @@ Once you push the tag, GitHub Actions automatically:
 1. ✅ Checks out the code at the tagged commit
 2. ✅ Installs dependencies (`pnpm install --frozen-lockfile`)
 3. ✅ Runs tests (`pnpm test`)
-4. ✅ Builds the package (`pnpm exec nx build web-serial-rxjs`)
-5. ✅ Creates a release zip file
-6. ✅ Publishes to npm using Trusted Publishing (OIDC) - no tokens needed!
-7. ✅ Creates a GitHub Release with auto-generated release notes
-8. ✅ Attaches the release zip to the GitHub Release
+4. ✅ Builds the package (`pnpm exec nx build web-serial-rxjs`) via the same package scripts used for npm publish
+5. ✅ Verifies publish dist artifacts (`dist/index.mjs`, `dist/index.d.ts`) and npm pack contents
+6. ✅ Creates a release zip file
+7. ✅ Publishes to npm using Trusted Publishing (OIDC) - no tokens needed!
+8. ✅ Creates a GitHub Release with auto-generated release notes
+9. ✅ Attaches the release zip to the GitHub Release
 
 You can monitor the progress in the [Actions tab](https://github.com/gurezo/web-serial-rxjs/actions) on GitHub.
 

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -26,6 +26,7 @@
     "build:bundle": "node esbuild.config.mjs",
     "build:copy-files": "cp ../../LICENSE . 2>/dev/null || true",
     "build:cleanup": "rm -rf dist/packages dist/package.json 2>/dev/null || true",
+    "verify:dist": "node scripts/verify-dist.mjs",
     "clean": "rm -rf dist",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/web-serial-rxjs/project.json
+++ b/packages/web-serial-rxjs/project.json
@@ -15,6 +15,13 @@
     },
     "lint": {
       "executor": "@nx/eslint:lint"
+    },
+    "verify-dist": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run verify:dist",
+        "cwd": "packages/web-serial-rxjs"
+      }
     }
   }
 }

--- a/packages/web-serial-rxjs/project.json
+++ b/packages/web-serial-rxjs/project.json
@@ -6,14 +6,11 @@
   "tags": [],
   "targets": {
     "build": {
-      "executor": "@nx/esbuild:esbuild",
-      "outputs": ["{options.outputPath}"],
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist"],
       "options": {
-        "outputPath": "packages/web-serial-rxjs/dist",
-        "main": "packages/web-serial-rxjs/src/index.ts",
-        "tsConfig": "packages/web-serial-rxjs/tsconfig.lib.json",
-        "format": ["esm"],
-        "generatePackageJson": false
+        "command": "pnpm run build",
+        "cwd": "packages/web-serial-rxjs"
       }
     },
     "lint": {

--- a/packages/web-serial-rxjs/scripts/verify-dist.mjs
+++ b/packages/web-serial-rxjs/scripts/verify-dist.mjs
@@ -1,0 +1,57 @@
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '..');
+const require = createRequire(import.meta.url);
+const packageJson = require(join(packageRoot, 'package.json'));
+
+function collectReferencedPaths() {
+  const paths = new Set();
+
+  if (typeof packageJson.module === 'string') {
+    paths.add(packageJson.module);
+  }
+
+  if (typeof packageJson.types === 'string') {
+    paths.add(packageJson.types);
+  }
+
+  const exportsField = packageJson.exports;
+  if (exportsField && typeof exportsField === 'object') {
+    for (const value of Object.values(exportsField)) {
+      if (typeof value === 'string') {
+        paths.add(value);
+        continue;
+      }
+
+      if (value && typeof value === 'object') {
+        for (const subpath of Object.values(value)) {
+          if (typeof subpath === 'string') {
+            paths.add(subpath);
+          }
+        }
+      }
+    }
+  }
+
+  return [...paths]
+    .filter((path) => path.startsWith('./'))
+    .map((path) => join(packageRoot, path.replace(/^\.\//, '')));
+}
+
+const referencedPaths = collectReferencedPaths();
+const missing = referencedPaths.filter((path) => !existsSync(path));
+
+if (missing.length > 0) {
+  console.error('Missing dist artifacts referenced by package.json:');
+  for (const path of missing) {
+    console.error(`  - ${path}`);
+  }
+  process.exit(1);
+}
+
+console.log('Verified dist artifacts referenced by package.json exports.');


### PR DESCRIPTION
## Summary
CI と npm publish で別々だった `web-serial-rxjs` のビルド経路を、package scripts（`tsc` + `esbuild`）に統一しました。あわせて `dist/index.mjs` / `dist/index.d.ts` の存在と `package.json` exports の整合を CI / release で検証するようにしました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #377
- Parent: #366

## What changed?
- Nx `build` target を `pnpm run build` に委譲し、CI / release / `prepublishOnly` が同一パイプラインを通るようにした
- `scripts/verify-dist.mjs` と `verify-dist` Nx target を追加し、`package.json` の `module` / `types` / `exports` 参照先ファイルの存在を検証
- `ci.yml` と `release.yml` に dist 成果物検証を追加し、release の `npm pack --dry-run` で `dist/index.mjs` / `dist/index.d.ts` も確認
- `RELEASING.md` / `CONTRIBUTING.md` に統一 build 方針を追記

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx build web-serial-rxjs` を実行し、`dist/index.mjs` と `dist/index.d.ts` が生成されることを確認
2. `pnpm exec nx run web-serial-rxjs:verify-dist` が成功することを確認
3. `pnpm publish:test` で tarball に `dist/index.mjs` / `dist/index.d.ts` が含まれることを確認

## Environment (if relevant)
- Browser: N/A（ビルド・CI 変更のみ）
- OS: macOS
- web-serial-rxjs version (for verification): 2.3.6
- RxJS version: ^7.8.0

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)