### PR TITLE
chore(web-serial-rxjs): bump package version to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs/workspace",
-  "version": "2.3.6",
+  "version": "2.4.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.3.6",
+  "version": "2.4.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## PR Title (Conventional Commits)
chore(web-serial-rxjs): bump package version to 2.4.0

## Summary
`@gurezo/web-serial-rxjs` とルート `package.json` のバージョンを 2.4.0 に bump する。#366 の接続ライフサイクル・メモリ管理・examples 保守性改善の取り込み内容をリリース可能な状態にするためのバージョン更新です。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #389

## What changed?
- `packages/web-serial-rxjs/package.json` の `version` を `2.3.6` → `2.4.0` に更新
- ルート `package.json` の `version` を `2.3.6` → `2.4.0` に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/package.json` とルート `package.json` の `version` が `2.4.0` であることを確認する
2. `pnpm run publish:test` で tarball の version が `2.4.0` であることを確認する
3. マージ後、`git tag -a v2.4.0 -m "Release v2.4.0" && git push origin v2.4.0` で release workflow が起動することを確認する

## Environment (if relevant)
- Browser: N/A (version bump only)
- OS: macOS
- web-serial-rxjs version (for verification): 2.4.0
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)