### PR TITLE
build(web-serial-rxjs): enable stricter TypeScript compiler options

### DIFF
--- a/packages/web-serial-rxjs/src/errors/serial-error.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error.ts
@@ -59,7 +59,9 @@ export class SerialError extends Error {
     super(message);
     this.name = 'SerialError';
     this.code = code;
-    this.originalError = originalError;
+    if (originalError !== undefined) {
+      this.originalError = originalError;
+    }
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -96,7 +96,6 @@ export function createSerialSession(
   const resolvedOptions = {
     ...DEFAULT_SERIAL_SESSION_OPTIONS,
     ...options,
-    filters: options?.filters,
     receiveReplay: resolveReceiveReplayOptions(options?.receiveReplay),
     terminalBuffer: {
       ...DEFAULT_SERIAL_SESSION_OPTIONS.terminalBuffer,

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -218,7 +218,6 @@ export const DEFAULT_SERIAL_SESSION_OPTIONS: Required<
   parity: 'none',
   bufferSize: 255,
   flowControl: 'none',
-  filters: undefined,
   receiveReplay: { ...DEFAULT_RECEIVE_REPLAY },
   terminalBuffer: { ...DEFAULT_TERMINAL_BUFFER_OPTIONS },
   lineBuffer: { ...DEFAULT_LINE_BUFFER_OPTIONS },

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -1142,7 +1142,11 @@ describe('createSerialSession', () => {
       await firstValueFrom(session.send$('ping\r\n'));
 
       expect(writes).toHaveLength(1);
-      expect(new TextDecoder().decode(writes[0])).toBe('ping\r\n');
+      const [write] = writes;
+      expect(write).toBeDefined();
+      if (write) {
+        expect(new TextDecoder().decode(write)).toBe('ping\r\n');
+      }
     });
 
     it('passes raw Uint8Array payloads straight through to the writer', async () => {
@@ -1158,7 +1162,11 @@ describe('createSerialSession', () => {
       await firstValueFrom(session.send$(payload));
 
       expect(writes).toHaveLength(1);
-      expect(Array.from(writes[0])).toEqual([0x01, 0x02, 0x03]);
+      const [write] = writes;
+      expect(write).toBeDefined();
+      if (write) {
+        expect(Array.from(write)).toEqual([0x01, 0x02, 0x03]);
+      }
     });
 
     it('guarantees FIFO order for concurrently subscribed send$ calls', async () => {
@@ -1243,8 +1251,12 @@ describe('createSerialSession', () => {
 
         expect(rejection).toBeInstanceOf(SerialError);
         expect(emissions).toHaveLength(1);
-        expect(emissions[0]).toBe(rejection);
-        expect(emissions[0].code).toBe(SerialErrorCode.PORT_OPEN_FAILED);
+        const [emission] = emissions;
+        expect(emission).toBeDefined();
+        expect(emission).toBe(rejection);
+        if (emission) {
+          expect(emission.code).toBe(SerialErrorCode.PORT_OPEN_FAILED);
+        }
       } finally {
         subscription.unsubscribe();
       }
@@ -1321,7 +1333,11 @@ describe('createSerialSession', () => {
         });
 
         expect(emissions).toHaveLength(1);
-        expect(emissions[0].code).toBe(SerialErrorCode.OPERATION_CANCELLED);
+        const [emission] = emissions;
+        expect(emission).toBeDefined();
+        if (emission) {
+          expect(emission.code).toBe(SerialErrorCode.OPERATION_CANCELLED);
+        }
       } finally {
         subscription.unsubscribe();
       }

--- a/packages/web-serial-rxjs/tests/session/read-pump.test.ts
+++ b/packages/web-serial-rxjs/tests/session/read-pump.test.ts
@@ -96,10 +96,14 @@ describe('createReadPump', () => {
     await flushMicrotasks();
 
     expect(onError).toHaveBeenCalledTimes(1);
-    const received = onError.mock.calls[0][0];
+    const call = onError.mock.calls[0];
+    expect(call).toBeDefined();
+    const received = call?.[0];
     expect(received).toBeInstanceOf(SerialError);
-    expect(received.code).toBe(SerialErrorCode.READ_FAILED);
-    expect(received.message).toContain('boom');
+    if (received instanceof SerialError) {
+      expect(received.code).toBe(SerialErrorCode.READ_FAILED);
+      expect(received.message).toContain('boom');
+    }
     expect(pump.isRunning).toBe(false);
   });
 
@@ -114,9 +118,13 @@ describe('createReadPump', () => {
     pump.start();
 
     expect(onError).toHaveBeenCalledTimes(1);
-    const received = onError.mock.calls[0][0];
+    const call = onError.mock.calls[0];
+    expect(call).toBeDefined();
+    const received = call?.[0];
     expect(received).toBeInstanceOf(SerialError);
-    expect(received.code).toBe(SerialErrorCode.CONNECTION_LOST);
+    if (received instanceof SerialError) {
+      expect(received.code).toBe(SerialErrorCode.CONNECTION_LOST);
+    }
     expect(pump.isRunning).toBe(false);
   });
 

--- a/packages/web-serial-rxjs/tsconfig.json
+++ b/packages/web-serial-rxjs/tsconfig.json
@@ -9,7 +9,8 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "noPropertyAccessFromIndexSignature": true,
-    "useUnknownInCatchVariables": true
+    "useUnknownInCatchVariables": true,
+    "exactOptionalPropertyTypes": true
   },
   "files": [],
   "include": [],

--- a/packages/web-serial-rxjs/tsconfig.json
+++ b/packages/web-serial-rxjs/tsconfig.json
@@ -10,7 +10,8 @@
     "noFallthroughCasesInSwitch": true,
     "noPropertyAccessFromIndexSignature": true,
     "useUnknownInCatchVariables": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "noUncheckedIndexedAccess": true
   },
   "files": [],
   "include": [],

--- a/packages/web-serial-rxjs/tsconfig.json
+++ b/packages/web-serial-rxjs/tsconfig.json
@@ -8,7 +8,8 @@
     "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "noPropertyAccessFromIndexSignature": true
+    "noPropertyAccessFromIndexSignature": true,
+    "useUnknownInCatchVariables": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
## Summary

Issue #392（親 #391 Phase A）に従い、`packages/web-serial-rxjs` の TypeScript compiler オプションを 3 段階で有効化しました。型の曖昧さを compiler で検出し、以降のリファクタリングの安全網とします。

レビューは **Commit 1 → 2 → 3** の順で見ると、オプションごとの差分が追いやすいです。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #392
- Relates to #391

## What changed?

| コミット | 有効化オプション | 主な修正箇所 | エラー件数 |
| --- | --- | --- | --- |
| 1 | `useUnknownInCatchVariables` | `tsconfig.json` のみ | 0（既存の `normalizeSerialError(error: unknown)` 設計で対応済み） |
| 2 | `exactOptionalPropertyTypes` | `serial-error.ts`, `serial-session-options.ts`, `create-serial-session.ts` | 3 |
| 3 | `noUncheckedIndexedAccess` | `create-serial-session.test.ts`, `read-pump.test.ts` | テスト数件 |

**既に有効だったオプション（今回変更なし）**: `strict`, `noImplicitOverride`, `noFallthroughCasesInSwitch`, `noImplicitReturns`, `noPropertyAccessFromIndexSignature`

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

ランタイム挙動は変更していません。`dist/index.d.ts` の optional プロパティ宣言（`SerialError.originalError?`, `SerialSessionOptions.filters?`）は維持しています。

## How to test

1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build`
3. `pnpm --filter @gurezo/web-serial-rxjs run verify:dist`
4. `pnpm test` / `pnpm exec nx run-many --target=lint --all`
5. `pnpm exec tsc -p apps/example-angular/tsconfig.app.json --noEmit`（path alias 経由の lib 型チェック）

## Environment (if relevant)

- Browser: N/A（compile-time のみの変更）
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: ^7.8.0

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)