### PR TITLE
feat(web-serial-rxjs): add type predicate to SerialError.is()

### DIFF
--- a/packages/web-serial-rxjs/src/errors/serial-error.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error.ts
@@ -75,19 +75,23 @@ export class SerialError extends Error {
    * Check if the error matches a specific error code.
    *
    * This is a convenience method for checking the error code without directly
-   * comparing the code property.
+   * comparing the code property. When this method returns `true`, TypeScript
+   * narrows `this.code` to the literal type of the provided `code` argument.
    *
    * @param code - The error code to check against
-   * @returns `true` if this error's code matches the provided code, `false` otherwise
+   * @returns Type predicate: `true` if this error's code matches the provided
+   *   code (and `this.code` is narrowed to that literal type), `false` otherwise
    *
    * @example
    * ```typescript
    * if (error.is(SerialErrorCode.PORT_NOT_OPEN)) {
-   *   // Handle port not open error
+   *   // error.code is narrowed to SerialErrorCode.PORT_NOT_OPEN
    * }
    * ```
    */
-  public is(code: SerialErrorCode): boolean {
+  public is<C extends SerialErrorCode>(
+    code: C,
+  ): this is SerialError & { readonly code: C } {
     return this.code === code;
   }
 }

--- a/packages/web-serial-rxjs/tests/errors/serial-error.test.ts
+++ b/packages/web-serial-rxjs/tests/errors/serial-error.test.ts
@@ -66,6 +66,20 @@ describe('SerialError', () => {
       expect(error.is(SerialErrorCode.PORT_ALREADY_OPEN)).toBe(false);
     });
 
+    it('should narrow error.code when is() returns true', () => {
+      const error = new SerialError(
+        SerialErrorCode.PORT_NOT_OPEN,
+        'Port is not open',
+      );
+
+      if (error.is(SerialErrorCode.PORT_NOT_OPEN)) {
+        const narrowed: SerialErrorCode.PORT_NOT_OPEN = error.code;
+        expect(narrowed).toBe(SerialErrorCode.PORT_NOT_OPEN);
+      } else {
+        expect.fail('is() should have returned true');
+      }
+    });
+
     it('should work with all error codes', () => {
       const codes = Object.values(SerialErrorCode);
 


### PR DESCRIPTION
## Summary
`SerialError.is()` に type predicate を追加し、`error.is(SerialErrorCode.X)` 呼び出し後に `error.code` が literal 型へ narrow されるようにしました。利用者が `error.code === ...` の二重チェックなしで分岐できるようになり、親 Issue #391 Phase A の DX 改善の一環です。

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Parent: #391
- Fixes #393

## What changed?
- `SerialError.is()` の戻り値を `boolean` から `this is SerialError & { readonly code: C }` に変更
- JSDoc `@returns` に type predicate の説明を追記
- 型 narrowing を検証するユニットテストを追加

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialError.is()` の TypeScript シグネチャのみ変更。runtime 挙動は同一。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. `pnpm exec nx run web-serial-rxjs:test` を実行し、全テストが pass することを確認
2. `pnpm exec nx run web-serial-rxjs:build` を実行し、ビルドが成功することを確認
3. 以下のコードで `error.code` が narrow されることを IDE / `tsc` で確認:
   ```typescript
   if (error instanceof SerialError && error.is(SerialErrorCode.PORT_NOT_OPEN)) {
     const code = error.code; // SerialErrorCode.PORT_NOT_OPEN
   }
   ```

## Environment (if relevant)
- 該当なし（型レベルの変更、runtime 挙動変更なし）

## Checklist
- [x] PR title follows Conventional Commits
- [x] Commit messages follow Conventional Commits
- [x] I ran tests locally
- [ ] I verified behavior on a Chromium-based browser (該当なし)
- [ ] I updated docs/README if needed（JSDoc のみ更新、README 変更不要）
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling（既存 API の型改善のみ）

Made with [Cursor](https://cursor.com)