### PR TITLE
refactor(web-serial-rxjs): add satisfies guards and assertNever helper

### DIFF
--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -58,6 +58,8 @@
  * ```
  */
 
+export { assertNever } from './internal/assert-never';
+
 export { createSerialSession, SerialSessionState, DEFAULT_LINE_BUFFER_OPTIONS } from './session';
 export type {
   SerialSession,

--- a/packages/web-serial-rxjs/src/internal/assert-never.ts
+++ b/packages/web-serial-rxjs/src/internal/assert-never.ts
@@ -1,0 +1,3 @@
+export function assertNever(value: never): never {
+  throw new Error(`Unexpected value: ${String(value)}`);
+}

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -609,5 +609,5 @@ export function createSerialSession(
     terminalText$,
     receiveReplay$,
     lines$,
-  };
+  } satisfies SerialSession;
 }

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -204,14 +204,16 @@ export function resolveReceiveReplayOptions(
  *
  * @internal
  */
-export const DEFAULT_SERIAL_SESSION_OPTIONS: Required<
+type DefaultSerialSessionOptions = Required<
   Omit<SerialSessionOptions, 'filters' | 'receiveReplay' | 'terminalBuffer' | 'lineBuffer'>
 > & {
   filters?: SerialPortFilter[];
   receiveReplay: Required<SerialSessionReceiveReplayOptions>;
   terminalBuffer: Required<TerminalBufferOptions>;
   lineBuffer: Required<LineBufferOptions>;
-} = {
+};
+
+export const DEFAULT_SERIAL_SESSION_OPTIONS = {
   baudRate: 9600,
   dataBits: 8,
   stopBits: 1,
@@ -221,4 +223,4 @@ export const DEFAULT_SERIAL_SESSION_OPTIONS: Required<
   receiveReplay: { ...DEFAULT_RECEIVE_REPLAY },
   terminalBuffer: { ...DEFAULT_TERMINAL_BUFFER_OPTIONS },
   lineBuffer: { ...DEFAULT_LINE_BUFFER_OPTIONS },
-};
+} satisfies DefaultSerialSessionOptions;

--- a/packages/web-serial-rxjs/tests/internal/assert-never.test.ts
+++ b/packages/web-serial-rxjs/tests/internal/assert-never.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { assertNever } from '../../src/internal/assert-never';
+
+describe('assertNever', () => {
+  it('throws with the unexpected value', () => {
+    expect(() => assertNever('x' as never)).toThrow('Unexpected value: x');
+  });
+});


### PR DESCRIPTION
## Summary
Phase A (#394) として、実装と公開 interface / 定数定義の drift をコンパイル時に検出する `satisfies` ガードと `assertNever` ヘルパーを追加しました。公開 API の挙動変更はありません。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Parent #391
- Closes #394

## What changed?
- `assertNever` ヘルパーを `src/internal/assert-never.ts` に追加し、公開 export
- `createSerialSession` の戻りオブジェクトに `satisfies SerialSession` を適用
- `DEFAULT_SERIAL_SESSION_OPTIONS` に `satisfies` ガードを適用
- `assertNever` のユニットテストを追加

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `assertNever` を新規公開 export（runtime 挙動の変更なし）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: なし

## How to test
1. `pnpm exec nx run web-serial-rxjs:test` が pass することを確認
2. `pnpm exec nx run web-serial-rxjs:build` / `verify:dist` が pass することを確認
3. （任意）`create-serial-session.ts` から `SerialSession` メンバーを一時削除し、`tsc` が失敗することを確認

## Environment (if relevant)
- 該当なし（compile-time の型安全性改善のみ）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)