### PR TITLE
feat(web-serial-rxjs): add resolveSerialSessionOptions and resolved options type

### DIFF
--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -60,11 +60,12 @@
 
 export { assertNever } from './internal/assert-never';
 
-export { createSerialSession, SerialSessionState, DEFAULT_LINE_BUFFER_OPTIONS } from './session';
+export { createSerialSession, SerialSessionState, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions } from './session';
 export type {
   SerialSession,
   SerialSessionOptions,
   SerialSessionReceiveReplayOptions,
+  ResolvedSerialSessionOptions,
   LineBufferOptions,
 } from './session';
 

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -25,8 +25,7 @@ import { createReadPump, type ReadPump } from './read-pump';
 import { createSendQueue } from './send-queue';
 import type { SerialSession } from './serial-session';
 import {
-  DEFAULT_SERIAL_SESSION_OPTIONS,
-  resolveReceiveReplayOptions,
+  resolveSerialSessionOptions,
   type SerialSessionOptions,
 } from './serial-session-options';
 import { SerialSessionState } from './serial-session-state';
@@ -93,19 +92,7 @@ type ReportErrorSeverity = 'fatal' | 'non-fatal';
 export function createSerialSession(
   options?: SerialSessionOptions,
 ): SerialSession {
-  const resolvedOptions = {
-    ...DEFAULT_SERIAL_SESSION_OPTIONS,
-    ...options,
-    receiveReplay: resolveReceiveReplayOptions(options?.receiveReplay),
-    terminalBuffer: {
-      ...DEFAULT_SERIAL_SESSION_OPTIONS.terminalBuffer,
-      ...options?.terminalBuffer,
-    },
-    lineBuffer: {
-      ...DEFAULT_SERIAL_SESSION_OPTIONS.lineBuffer,
-      ...options?.lineBuffer,
-    },
-  };
+  const resolvedOptions = resolveSerialSessionOptions(options);
 
   const supported = hasWebSerialSupport();
   const machine = new SessionStateMachine(

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -3,7 +3,9 @@ export type { SerialSession } from './serial-session';
 export type {
   SerialSessionOptions,
   SerialSessionReceiveReplayOptions,
+  ResolvedSerialSessionOptions,
 } from './serial-session-options';
+export { resolveSerialSessionOptions } from './serial-session-options';
 export { SerialSessionState } from './serial-session-state';
 export {
   DEFAULT_LINE_BUFFER_OPTIONS,

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -200,11 +200,11 @@ export function resolveReceiveReplayOptions(
 }
 
 /**
- * Default values applied to omitted {@link SerialSessionOptions} fields.
- *
- * @internal
+ * Fully resolved session options after merging {@link SerialSessionOptions}
+ * with {@link DEFAULT_SERIAL_SESSION_OPTIONS}. All invariant fields are
+ * required; `filters` remains optional.
  */
-type DefaultSerialSessionOptions = Required<
+export type ResolvedSerialSessionOptions = Required<
   Omit<SerialSessionOptions, 'filters' | 'receiveReplay' | 'terminalBuffer' | 'lineBuffer'>
 > & {
   filters?: SerialPortFilter[];
@@ -213,6 +213,11 @@ type DefaultSerialSessionOptions = Required<
   lineBuffer: Required<LineBufferOptions>;
 };
 
+/**
+ * Default values applied to omitted {@link SerialSessionOptions} fields.
+ *
+ * @internal
+ */
 export const DEFAULT_SERIAL_SESSION_OPTIONS = {
   baudRate: 9600,
   dataBits: 8,
@@ -223,4 +228,29 @@ export const DEFAULT_SERIAL_SESSION_OPTIONS = {
   receiveReplay: { ...DEFAULT_RECEIVE_REPLAY },
   terminalBuffer: { ...DEFAULT_TERMINAL_BUFFER_OPTIONS },
   lineBuffer: { ...DEFAULT_LINE_BUFFER_OPTIONS },
-} satisfies DefaultSerialSessionOptions;
+} satisfies ResolvedSerialSessionOptions;
+
+/**
+ * Merge and validate {@link SerialSessionOptions} into a fully resolved
+ * options object for internal session use.
+ *
+ * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS}
+ *         when `receiveReplay` values are out of range.
+ */
+export function resolveSerialSessionOptions(
+  options?: SerialSessionOptions,
+): ResolvedSerialSessionOptions {
+  return {
+    ...DEFAULT_SERIAL_SESSION_OPTIONS,
+    ...options,
+    receiveReplay: resolveReceiveReplayOptions(options?.receiveReplay),
+    terminalBuffer: {
+      ...DEFAULT_SERIAL_SESSION_OPTIONS.terminalBuffer,
+      ...options?.terminalBuffer,
+    },
+    lineBuffer: {
+      ...DEFAULT_SERIAL_SESSION_OPTIONS.lineBuffer,
+      ...options?.lineBuffer,
+    },
+  };
+}

--- a/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
+++ b/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import {
+  DEFAULT_LINE_BUFFER_OPTIONS,
+} from '../../src/session/internal/line-buffer';
+import {
+  DEFAULT_SERIAL_SESSION_OPTIONS,
+  resolveSerialSessionOptions,
+} from '../../src/session/serial-session-options';
+import { DEFAULT_TERMINAL_BUFFER_OPTIONS } from '../../src/terminal/create-terminal-buffer';
+
+describe('resolveSerialSessionOptions', () => {
+  it('returns defaults when options are omitted', () => {
+    expect(resolveSerialSessionOptions()).toEqual(DEFAULT_SERIAL_SESSION_OPTIONS);
+  });
+
+  it('merges top-level partial options', () => {
+    expect(
+      resolveSerialSessionOptions({
+        baudRate: 115200,
+        dataBits: 7,
+        stopBits: 2,
+        parity: 'even',
+        bufferSize: 512,
+        flowControl: 'hardware',
+      }),
+    ).toEqual({
+      ...DEFAULT_SERIAL_SESSION_OPTIONS,
+      baudRate: 115200,
+      dataBits: 7,
+      stopBits: 2,
+      parity: 'even',
+      bufferSize: 512,
+      flowControl: 'hardware',
+    });
+  });
+
+  it('merges nested terminalBuffer options', () => {
+    expect(
+      resolveSerialSessionOptions({
+        terminalBuffer: { maxLines: 100 },
+      }),
+    ).toEqual({
+      ...DEFAULT_SERIAL_SESSION_OPTIONS,
+      terminalBuffer: {
+        ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
+        maxLines: 100,
+      },
+    });
+  });
+
+  it('merges nested lineBuffer options', () => {
+    expect(
+      resolveSerialSessionOptions({
+        lineBuffer: { maxChars: 2048 },
+      }),
+    ).toEqual({
+      ...DEFAULT_SERIAL_SESSION_OPTIONS,
+      lineBuffer: {
+        ...DEFAULT_LINE_BUFFER_OPTIONS,
+        maxChars: 2048,
+      },
+    });
+  });
+
+  it('passes through filters', () => {
+    const filters = [{ usbVendorId: 0x1234, usbProductId: 0x5678 }];
+    expect(resolveSerialSessionOptions({ filters })).toEqual({
+      ...DEFAULT_SERIAL_SESSION_OPTIONS,
+      filters,
+    });
+  });
+
+  it('merges receiveReplay options', () => {
+    expect(
+      resolveSerialSessionOptions({
+        receiveReplay: { enabled: true, bufferSize: 2, maxChars: 100 },
+      }),
+    ).toEqual({
+      ...DEFAULT_SERIAL_SESSION_OPTIONS,
+      receiveReplay: {
+        enabled: true,
+        bufferSize: 2,
+        maxChars: 100,
+      },
+    });
+  });
+
+  it('rejects invalid receiveReplay options', () => {
+    expect(() =>
+      resolveSerialSessionOptions({ receiveReplay: { bufferSize: 0 } }),
+    ).toThrow(SerialError);
+    try {
+      resolveSerialSessionOptions({ receiveReplay: { bufferSize: 0 } });
+    } catch (error) {
+      expect(error).toBeInstanceOf(SerialError);
+      expect((error as SerialError).code).toBe(
+        SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
SerialSessionOptions の merge を resolveSerialSessionOptions に集約し、
resolver 以降で全フィールドが必ず存在する ResolvedSerialSessionOptions 型を導入した。
Public API（SerialSessionOptions）は変更せず、内部の型安全性と保守性を向上させる。

## Type of change
- [x] New feature
- [ ] Breaking change

## Related issues
- Parent #391
- Closes #395

## What changed?
- ResolvedSerialSessionOptions 型を追加（旧 DefaultSerialSessionOptions を改名・公開）
- resolveSerialSessionOptions() を追加し、receiveReplay 検証を含む merge を集約
- createSerialSession が resolver を使用するようリファクタ
- 公開 API から型・関数を export
- 単体テストを追加

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: resolveSerialSessionOptions と ResolvedSerialSessionOptions を新規 export（既存 API の挙動変更なし）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. pnpm exec nx run web-serial-rxjs:test
2. pnpm exec nx run web-serial-rxjs:build
3. pnpm exec nx run web-serial-rxjs:verify-dist
4. dist/index.d.ts に新 export が含まれることを確認

## Checklist
- [x] PR title follows Conventional Commits
- [x] Commit messages follow Conventional Commits
- [x] I ran tests locally
- [ ] I verified behavior on a Chromium-based browser (該当なし — 型/refactor のみ)
- [ ] I updated docs/README if needed（API Reference 更新は #396 で対応予定）

Made with [Cursor](https://cursor.com)