### PR TITLE
feat(web-serial-rxjs): export SerialPayload and SerialConnectionOptions types

### DIFF
--- a/libs/examples-shared/src/create-serial-session-controller.ts
+++ b/libs/examples-shared/src/create-serial-session-controller.ts
@@ -1,6 +1,8 @@
 import {
   createSerialSession,
+  type SerialConnectionOptions,
   type SerialError,
+  type SerialPayload,
   type SerialSession,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
@@ -14,7 +16,7 @@ import {
 } from 'rxjs';
 
 export interface SerialSessionControllerOptions {
-  initialBaudRate?: number;
+  initialBaudRate?: SerialConnectionOptions['baudRate'];
 }
 
 export interface SerialSessionController {
@@ -24,9 +26,9 @@ export interface SerialSessionController {
   readonly errors$: Observable<SerialError>;
   readonly receive$: Observable<string>;
   isBrowserSupported(): boolean;
-  connect$(baudRate?: number): Observable<void>;
+  connect$(baudRate?: SerialConnectionOptions['baudRate']): Observable<void>;
   disconnect$(): Observable<void>;
-  send$(data: string | Uint8Array): Observable<void>;
+  send$(data: SerialPayload): Observable<void>;
   resetTerminalBuffer(): void;
   dispose(): void;
 }
@@ -71,7 +73,7 @@ export function createSerialSessionController(
     terminalBufferEpoch$.next(terminalBufferEpoch$.value + 1);
   };
 
-  const connect$ = (baudRate?: number): Observable<void> => {
+  const connect$ = (baudRate?: SerialConnectionOptions['baudRate']): Observable<void> => {
     resetTerminalBuffer();
     if (baudRate !== undefined && baudRate !== currentBaudRate) {
       const previousSession = currentSession;
@@ -87,7 +89,7 @@ export function createSerialSessionController(
 
   const disconnect$ = (): Observable<void> => currentSession.disconnect$();
 
-  const send$ = (data: string | Uint8Array): Observable<void> =>
+  const send$ = (data: SerialPayload): Observable<void> =>
     currentSession.send$(data);
 
   const dispose = (): void => {

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -62,7 +62,7 @@
 
 export { assertNever } from './internal/assert-never';
 
-export { createSerialSession, SerialSessionState, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions } from './session';
+export { createSerialSession, SerialSessionState, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions, MAX_RECEIVE_REPLAY_BUFFER_SIZE, MAX_RECEIVE_REPLAY_MAX_CHARS } from './session';
 export type {
   SerialSession,
   SerialSessionOptions,

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -19,6 +19,8 @@
  * - {@link LineBufferOptions} - memory limits for lines$ incomplete line tail
  * - {@link SerialSession} - the runtime interface
  * - {@link SerialSessionOptions} - connection options
+ * - {@link SerialPayload} - payload accepted by {@link SerialSession.send$}
+ * - {@link SerialConnectionOptions} - `port.open` connection parameters (excluding filters)
  * - {@link SerialSessionState} - `state$` payload values (const + type)
  * - {@link SerialError} / {@link SerialErrorCode} - unified error surface
  *
@@ -66,6 +68,8 @@ export type {
   SerialSessionOptions,
   SerialSessionReceiveReplayOptions,
   ResolvedSerialSessionOptions,
+  SerialPayload,
+  SerialConnectionOptions,
   LineBufferOptions,
 } from './session';
 

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -10,6 +10,7 @@ import {
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
+import type { SerialPayload } from '../types';
 import { buildRequestOptions } from './internal/build-request-options';
 import { hasWebSerialSupport } from './internal/has-web-serial-support';
 import { createLineBuffer } from './internal/line-buffer';
@@ -562,7 +563,7 @@ export function createSerialSession(
     },
     dispose$,
     destroy$: dispose$,
-    send$(data: string | Uint8Array): Observable<void> {
+    send$(data: SerialPayload): Observable<void> {
       if (disposed) {
         return new Observable<void>((subscriber) => {
           subscriber.error(createDisposedError());

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -6,6 +6,10 @@ export type {
   ResolvedSerialSessionOptions,
 } from './serial-session-options';
 export { resolveSerialSessionOptions } from './serial-session-options';
+export {
+  MAX_RECEIVE_REPLAY_BUFFER_SIZE,
+  MAX_RECEIVE_REPLAY_MAX_CHARS,
+} from './serial-session-options';
 export type { SerialPayload, SerialConnectionOptions } from '../types';
 export { SerialSessionState } from './serial-session-state';
 export {

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -6,6 +6,7 @@ export type {
   ResolvedSerialSessionOptions,
 } from './serial-session-options';
 export { resolveSerialSessionOptions } from './serial-session-options';
+export type { SerialPayload, SerialConnectionOptions } from '../types';
 export { SerialSessionState } from './serial-session-state';
 export {
   DEFAULT_LINE_BUFFER_OPTIONS,

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -1,5 +1,6 @@
 import type { Observable } from 'rxjs';
 import type { SerialError } from '../errors/serial-error';
+import type { SerialPayload } from '../types';
 import type { SerialSessionState } from './serial-session-state';
 
 /**
@@ -249,5 +250,5 @@ export interface SerialSession {
    *
    * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/203 | Issue #203}
    */
-  send$(data: string | Uint8Array): Observable<void>;
+  send$(data: SerialPayload): Observable<void>;
 }

--- a/packages/web-serial-rxjs/src/types.ts
+++ b/packages/web-serial-rxjs/src/types.ts
@@ -1,0 +1,20 @@
+import type { SerialSessionOptions } from './session/serial-session-options';
+
+/**
+ * Payload accepted by {@link SerialSession.send$}.
+ *
+ * Strings are UTF-8 encoded via a shared `TextEncoder`; `Uint8Array` values
+ * are passed through unchanged.
+ */
+export type SerialPayload = string | Uint8Array;
+
+/**
+ * Connection parameters passed to `port.open` when opening a serial port.
+ *
+ * Excludes {@link SerialSessionOptions.filters}, which apply only to
+ * `navigator.serial.requestPort`.
+ */
+export type SerialConnectionOptions = Pick<
+  SerialSessionOptions,
+  'baudRate' | 'dataBits' | 'stopBits' | 'parity' | 'bufferSize' | 'flowControl'
+>;


### PR DESCRIPTION
## Summary
利用者と examples がライブラリ定義の utility type を再利用できるよう、`SerialPayload` と `SerialConnectionOptions` を公開 API に追加した。`send$` の payload 型を `SerialPayload` に統一し、examples-shared のインライン型定義を除去した。

## Type of change
- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #396
- Parent: #391

## What changed?
- `SerialPayload`（`string | Uint8Array`）を追加・公開
- `SerialConnectionOptions`（`SerialSessionOptions` から filters 等を除いた Pick）を追加・公開
- `SerialSession.send$` シグネチャを `SerialPayload` に統一
- `MAX_RECEIVE_REPLAY_BUFFER_SIZE` / `MAX_RECEIVE_REPLAY_MAX_CHARS` を公開
- examples-shared が `SerialPayload` / `SerialConnectionOptions['baudRate']` を参照

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialPayload`、`SerialConnectionOptions`、receive replay 上限定数を新規 export。`send$` の引数型は意味的に同一（non-breaking）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. `pnpm exec nx run web-serial-rxjs:build && pnpm exec nx run web-serial-rxjs:verify-dist`
2. `grep SerialPayload packages/web-serial-rxjs/dist/index.d.ts` で公開型を確認
3. `pnpm exec nx run examples-shared:test` で examples-shared の回帰確認

## Environment (if relevant)
- N/A（型追加のみ、runtime 挙動変更なし）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)