### PR TITLE
refactor(web-serial-rxjs): strengthen session transition typing with satisfies

### DIFF
--- a/packages/web-serial-rxjs/src/session/session-runtime.ts
+++ b/packages/web-serial-rxjs/src/session/session-runtime.ts
@@ -108,7 +108,9 @@ export function isValidTransition(
   if (from === to) {
     return false;
   }
-  return ALLOWED_TRANSITIONS[from].includes(to);
+  return (ALLOWED_TRANSITIONS[from] as readonly SerialSessionState[]).includes(
+    to,
+  );
 }
 
 /** @internal */

--- a/packages/web-serial-rxjs/src/session/session-runtime.ts
+++ b/packages/web-serial-rxjs/src/session/session-runtime.ts
@@ -68,11 +68,14 @@ const S = SerialSessionState;
 /**
  * Allowed transitions for the internal SerialSession state machine.
  *
+ * `as const satisfies` keeps literal transition targets while ensuring every
+ * {@link SerialSessionState} key is present. Drift from the state union
+ * becomes a compile error.
+ *
  * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/398 | Issue #398}
  */
-export const ALLOWED_TRANSITIONS: Readonly<
-  Record<SerialSessionState, readonly SerialSessionState[]>
-> = {
+export const ALLOWED_TRANSITIONS = {
   [S.Idle]: [S.Connecting, S.Error, S.Disposed],
   [S.Connecting]: [S.Connected, S.Error, S.Idle, S.Disposed],
   [S.Connected]: [S.Disconnecting, S.Error, S.Disposed],
@@ -80,7 +83,17 @@ export const ALLOWED_TRANSITIONS: Readonly<
   [S.Error]: [S.Idle, S.Connecting, S.Disposed],
   [S.Unsupported]: [S.Disposed],
   [S.Disposed]: [],
-};
+} as const satisfies Readonly<
+  Record<SerialSessionState, readonly SerialSessionState[]>
+>;
+
+/**
+ * Valid target states when transitioning from {@link T}.
+ *
+ * @internal
+ */
+export type AllowedTransition<T extends SerialSessionState> =
+  (typeof ALLOWED_TRANSITIONS)[T][number];
 
 /** @internal */
 export function runtimeToSessionState(runtime: SessionRuntime): SerialSessionState {


### PR DESCRIPTION
## Summary
ALLOWED_TRANSITIONS を `as const satisfies` で型安全化し、各状態から遷移可能な先を `AllowedTransition` 型として導出できるようにする。公開 API は変更しない。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Parent #391
- Fixes #398

## What changed?
- `ALLOWED_TRANSITIONS` を `as const satisfies Readonly<Record<SerialSessionState, ...>>` に変更
- 内部型 `AllowedTransition<T>` を追加
- `SerialSessionState` 追加時にテーブル未更新だとコンパイルエラーになるよう担保
- `isValidTransition` を readonly transition table と型互換に調整

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx run web-serial-rxjs:test` が pass すること
2. `pnpm exec nx run web-serial-rxjs:build` が pass すること
3. （任意）`ALLOWED_TRANSITIONS` からキーを 1 つ削除し型エラーになることをローカルで確認後、差分を戻す

## Environment (if relevant)
- Browser: N/A（内部型変更のみ）
- OS: N/A
- web-serial-rxjs version (for verification): main ベース
- RxJS version: 既存依存のまま

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)