### PR TITLE
refactor(web-serial-rxjs): add LineBuffer interface for createLineBuffer

### DIFF
--- a/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
+++ b/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
@@ -28,6 +28,16 @@ export interface LineBufferFeedResult {
 }
 
 /**
+ * Handle returned by {@link createLineBuffer}.
+ *
+ * @internal
+ */
+export interface LineBuffer {
+  feed(chunk: string): LineBufferFeedResult;
+  clear(): void;
+}
+
+/**
  * Streaming UTF-16 text to newline-delimited lines for {@link createSerialSession}.
  * Supports `\r\n` and `\n` per #237; a lone `\r` that is not the last character
  * in the buffer is treated as a line end (compatibility with some devices). A
@@ -36,10 +46,7 @@ export interface LineBufferFeedResult {
  *
  * @internal
  */
-export function createLineBuffer(options?: LineBufferOptions): {
-  feed(chunk: string): LineBufferFeedResult;
-  clear(): void;
-} {
+export function createLineBuffer(options?: LineBufferOptions): LineBuffer {
   const limits: Required<LineBufferOptions> = {
     ...DEFAULT_LINE_BUFFER_OPTIONS,
     ...options,


### PR DESCRIPTION
## Summary
`createLineBuffer` の戻り値を inline object 型から named `LineBuffer` interface に統一した。`ReadPump` / `SendQueue` / `ReceiveReplayBuffer` と同様の内部 API パターンに揃え、挙動変更はない。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #400
- Parent: #391

## What changed?
- `session/internal/line-buffer.ts` に `@internal` の `LineBuffer` interface を追加
- `createLineBuffer` の戻り値型を `LineBuffer` に変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build`
3. 既存の `line-buffer.test.ts` / `crlf-fixtures.test.ts` が pass することを確認

## Environment (if relevant)
- Browser: N/A（ユニットテストのみ）
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: workspace

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)