### PR TITLE
refactor(web-serial-rxjs): split createSerialSession into focused modules

### DIFF
--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -3,9 +3,7 @@ import {
   distinctUntilChanged,
   map,
   Observable,
-  share,
   Subject,
-  switchMap,
 } from 'rxjs';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
@@ -13,15 +11,10 @@ import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
 import type { SerialPayload } from '../types';
 import { buildRequestOptions } from './internal/build-request-options';
 import { hasWebSerialSupport } from './internal/has-web-serial-support';
+import { createReceivePipeline } from './internal/receive-pipeline';
 import { createSessionErrorReporter } from './internal/session-error-reporter';
-import { createLineBuffer } from './internal/line-buffer';
-import {
-  createReceiveReplayBuffer,
-  type ReceiveReplayBuffer,
-} from './internal/receive-replay-buffer';
 import {
   normalizeSerialError,
-  type NormalizeSerialErrorOptions,
 } from './normalize-serial-error';
 import { createReadPump, type ReadPump } from './read-pump';
 import { createSendQueue } from './send-queue';
@@ -102,15 +95,25 @@ export function createSerialSession(
     createInitialRuntime(supported),
   );
   const errorsSubject = new Subject<SerialError>();
-  const receiveSubject = new Subject<string>();
-  const linesSubject = new Subject<string>();
   const sendQueue = createSendQueue();
   const textEncoder = new TextEncoder();
-  const lineBuffer = createLineBuffer(resolvedOptions.lineBuffer);
+
+  const errorReporterRef: {
+    reportError?: (
+      error: unknown,
+      options: Parameters<typeof normalizeSerialError>[1],
+    ) => SerialError;
+  } = {};
+
+  const receivePipeline = createReceivePipeline({
+    resolvedOptions,
+    reportError: (error, options) =>
+      errorReporterRef.reportError!(error, options),
+  });
+
+  const { receive$, lines$, receiveReplay$ } = receivePipeline;
 
   const errors$ = errorsSubject.asObservable();
-  const receive$ = receiveSubject.asObservable();
-  const lines$ = linesSubject.asObservable();
   const terminalText$ = createTerminalBuffer(
     receive$,
     resolvedOptions.terminalBuffer,
@@ -124,41 +127,6 @@ export function createSerialSession(
   const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
   const portInfo$ = portInfoSubject.asObservable();
 
-  const receiveReplayStream$ = resolvedOptions.receiveReplay.enabled
-    ? new BehaviorSubject<Observable<string>>(receive$)
-    : null;
-  let activeReceiveReplay: ReceiveReplayBuffer | null = null;
-
-  const clearLiveReceiveReplay = (): void => {
-    if (receiveReplayStream$) {
-      if (activeReceiveReplay) {
-        activeReceiveReplay.complete();
-        activeReceiveReplay = null;
-      }
-      receiveReplayStream$.next(receive$);
-    }
-  };
-
-  const startLiveReceiveReplay = (): void => {
-    if (!receiveReplayStream$) {
-      return;
-    }
-    if (activeReceiveReplay) {
-      activeReceiveReplay.complete();
-      activeReceiveReplay = null;
-    }
-    const buffer = createReceiveReplayBuffer({
-      bufferSize: resolvedOptions.receiveReplay.bufferSize,
-      maxChars: resolvedOptions.receiveReplay.maxChars,
-    });
-    activeReceiveReplay = buffer;
-    receiveReplayStream$.next(buffer.asObservable());
-  };
-
-  const receiveReplay$ = receiveReplayStream$
-    ? receiveReplayStream$.pipe(switchMap((inner) => inner), share())
-    : receive$;
-
   const isDisposed = (): boolean =>
     controller.status === SerialSessionState.Disposed;
 
@@ -167,8 +135,8 @@ export function createSerialSession(
   };
 
   const teardownPump = async (pump: ReadPump | null): Promise<void> => {
-    clearLiveReceiveReplay();
-    lineBuffer.clear();
+    receivePipeline.clearReplay();
+    receivePipeline.clearLineBuffer();
     if (pump) {
       await pump.stop();
     }
@@ -208,16 +176,14 @@ export function createSerialSession(
       updatePortInfo(null);
     }
 
-    lineBuffer.clear();
+    receivePipeline.clearLineBuffer();
   };
 
   const completeSubjects = (): void => {
     controller.complete();
     errorsSubject.complete();
-    receiveSubject.complete();
-    linesSubject.complete();
+    receivePipeline.complete();
     portInfoSubject.complete();
-    receiveReplayStream$?.complete();
   };
 
   const dispose$ = (): Observable<void> =>
@@ -258,6 +224,7 @@ export function createSerialSession(
     teardownPump,
     closePortSafely,
   });
+  errorReporterRef.reportError = reportError;
 
   const writeToPort = async (payload: Uint8Array): Promise<void> => {
     const runtime = controller.runtime;
@@ -365,41 +332,12 @@ export function createSerialSession(
             return;
           }
 
-          lineBuffer.clear();
+          receivePipeline.clearLineBuffer();
           if (resolvedOptions.receiveReplay.enabled) {
-            startLiveReceiveReplay();
+            receivePipeline.startLiveReceiveReplay();
           }
           const pump = createReadPump(selectedPort, {
-            onChunk: (text) => {
-              receiveSubject.next(text);
-              if (activeReceiveReplay) {
-                const { overflowed } = activeReceiveReplay.next(text);
-                if (overflowed) {
-                  reportError(
-                    new SerialError(
-                      SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
-                      `Receive replay buffer exceeded configured limits; oldest chunks were discarded`,
-                    ),
-                    {
-                      fallbackCode: SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
-                    },
-                  );
-                }
-              }
-              const { lines, overflowed } = lineBuffer.feed(text);
-              if (overflowed) {
-                reportError(
-                  new SerialError(
-                    SerialErrorCode.LINE_BUFFER_OVERFLOW,
-                    `Line buffer exceeded maxChars (${resolvedOptions.lineBuffer.maxChars}); leading data was discarded`,
-                  ),
-                  { fallbackCode: SerialErrorCode.LINE_BUFFER_OVERFLOW },
-                );
-              }
-              for (const line of lines) {
-                linesSubject.next(line);
-              }
-            },
+            onChunk: receivePipeline.handleChunk,
             onError: (pumpError) =>
               reportError(pumpError, {
                 fallbackCode: SerialErrorCode.READ_FAILED,

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -9,14 +9,11 @@ import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
 import type { SerialPayload } from '../types';
-import { buildRequestOptions } from './internal/build-request-options';
 import { hasWebSerialSupport } from './internal/has-web-serial-support';
 import { createReceivePipeline } from './internal/receive-pipeline';
 import { createSessionErrorReporter } from './internal/session-error-reporter';
-import {
-  normalizeSerialError,
-} from './normalize-serial-error';
-import { createReadPump, type ReadPump } from './read-pump';
+import { createSessionLifecycle } from './internal/session-lifecycle';
+import { normalizeSerialError } from './normalize-serial-error';
 import { createSendQueue } from './send-queue';
 import type { SerialSession } from './serial-session';
 import {
@@ -25,16 +22,9 @@ import {
 } from './serial-session-options';
 import { SerialSessionState } from './serial-session-state';
 import {
-  createConnectedRuntime,
-  createConnectingRuntime,
-  createDisconnectingRuntime,
-  createDisposedRuntime,
-  createIdleRuntime,
   createInitialRuntime,
   createSessionRuntimeController,
   getRuntimePort,
-  getRuntimePump,
-  type SessionRuntime,
 } from './session-runtime';
 
 /**
@@ -84,25 +74,30 @@ import {
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/204 | Issue #204}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/397 | Issue #397}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/399 | Issue #399}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/401 | Issue #401}
  */
 export function createSerialSession(
   options?: SerialSessionOptions,
 ): SerialSession {
   const resolvedOptions = resolveSerialSessionOptions(options);
 
-  const supported = hasWebSerialSupport();
   const controller = createSessionRuntimeController(
-    createInitialRuntime(supported),
+    createInitialRuntime(hasWebSerialSupport()),
   );
   const errorsSubject = new Subject<SerialError>();
   const sendQueue = createSendQueue();
   const textEncoder = new TextEncoder();
+  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
+
+  const isDisposed = (): boolean =>
+    controller.status === SerialSessionState.Disposed;
 
   const errorReporterRef: {
     reportError?: (
       error: unknown,
       options: Parameters<typeof normalizeSerialError>[1],
     ) => SerialError;
+    createDisposedError?: () => SerialError;
   } = {};
 
   const receivePipeline = createReceivePipeline({
@@ -111,356 +106,51 @@ export function createSerialSession(
       errorReporterRef.reportError!(error, options),
   });
 
-  const { receive$, lines$, receiveReplay$ } = receivePipeline;
-
-  const errors$ = errorsSubject.asObservable();
-  const terminalText$ = createTerminalBuffer(
-    receive$,
-    resolvedOptions.terminalBuffer,
-  ).text$;
-
-  const isConnected$ = controller.state$.pipe(
-    map((state) => state === SerialSessionState.Connected),
-    distinctUntilChanged(),
-  );
-
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
-  const portInfo$ = portInfoSubject.asObservable();
-
-  const isDisposed = (): boolean =>
-    controller.status === SerialSessionState.Disposed;
-
-  const updatePortInfo = (port: SerialPort | null): void => {
-    portInfoSubject.next(port ? port.getInfo() : null);
-  };
-
-  const teardownPump = async (pump: ReadPump | null): Promise<void> => {
-    receivePipeline.clearReplay();
-    receivePipeline.clearLineBuffer();
-    if (pump) {
-      await pump.stop();
-    }
-  };
-
-  const closePortSafely = async (port: SerialPort | null): Promise<void> => {
-    if (!port) {
-      return;
-    }
-    try {
-      await port.close();
-    } catch {
-      // The read pump may already have errored the stream, which makes
-      // close() reject. We ignore it here because disconnect$ has a
-      // dedicated error path for close failures initiated by the user.
-    }
-  };
-
-  const teardownFromSnapshot = async (
-    snapshot: SessionRuntime,
-  ): Promise<void> => {
-    if (snapshot.status === SerialSessionState.Connecting) {
-      snapshot.cancel();
-    }
-
-    sendQueue.clear();
-
-    if (
-      snapshot.status === SerialSessionState.Connected ||
-      snapshot.status === SerialSessionState.Disconnecting ||
-      snapshot.status === SerialSessionState.Error
-    ) {
-      const portToClose = getRuntimePort(snapshot);
-      const pump = getRuntimePump(snapshot);
-      await teardownPump(pump);
-      await closePortSafely(portToClose);
-      updatePortInfo(null);
-    }
-
-    receivePipeline.clearLineBuffer();
-  };
-
-  const completeSubjects = (): void => {
-    controller.complete();
-    errorsSubject.complete();
-    receivePipeline.complete();
-    portInfoSubject.complete();
-  };
-
-  const dispose$ = (): Observable<void> =>
-    new Observable<void>((subscriber) => {
-      if (isDisposed()) {
-        subscriber.next();
-        subscriber.complete();
-        return;
-      }
-
-      const snapshot = controller.runtime;
-      controller.transition(createDisposedRuntime());
-
-      const run = async (): Promise<void> => {
-        try {
-          await teardownFromSnapshot(snapshot);
-          completeSubjects();
-          subscriber.next();
-          subscriber.complete();
-        } catch (error) {
-          const serialError = normalizeSerialError(error, {
-            fallbackCode: SerialErrorCode.UNKNOWN,
-            messagePrefix: 'Unexpected dispose failure',
-          });
-          subscriber.error(serialError);
-        }
-      };
-
-      void run();
-    });
+  const lifecycle = createSessionLifecycle({
+    controller,
+    resolvedOptions,
+    sendQueue,
+    receivePipeline,
+    portInfoSubject,
+    errorsSubject,
+    isDisposed,
+    reportError: (error, options) =>
+      errorReporterRef.reportError!(error, options),
+    createDisposedError: () => errorReporterRef.createDisposedError!(),
+  });
 
   const { reportError, createDisposedError } = createSessionErrorReporter({
     controller,
     errorsSubject,
     sendQueue,
     isDisposed,
-    updatePortInfo,
-    teardownPump,
-    closePortSafely,
+    updatePortInfo: lifecycle.updatePortInfo,
+    teardownPump: lifecycle.teardownPump,
+    closePortSafely: lifecycle.closePortSafely,
   });
   errorReporterRef.reportError = reportError;
+  errorReporterRef.createDisposedError = createDisposedError;
 
-  const writeToPort = async (payload: Uint8Array): Promise<void> => {
-    const runtime = controller.runtime;
-    if (
-      runtime.status !== SerialSessionState.Connected ||
-      !runtime.port.writable
-    ) {
-      throw new SerialError(
-        SerialErrorCode.PORT_NOT_OPEN,
-        'Cannot send data while session is not connected',
-      );
-    }
-    const writer = runtime.port.writable.getWriter();
-    try {
-      await writer.write(payload);
-    } finally {
-      try {
-        writer.releaseLock();
-      } catch {
-        // releaseLock throws when the stream is already errored; the real
-        // failure is surfaced through the write() rejection above so we
-        // intentionally swallow this secondary error.
-      }
-    }
-  };
+  const { receive$, lines$, receiveReplay$ } = receivePipeline;
+  const errors$ = errorsSubject.asObservable();
+  const terminalText$ = createTerminalBuffer(
+    receive$,
+    resolvedOptions.terminalBuffer,
+  ).text$;
+  const isConnected$ = controller.state$.pipe(
+    map((state) => state === SerialSessionState.Connected),
+    distinctUntilChanged(),
+  );
+  const portInfo$ = portInfoSubject.asObservable();
 
   return {
     isBrowserSupported(): boolean {
       return hasWebSerialSupport();
     },
-    connect$(): Observable<void> {
-      return new Observable<void>((subscriber) => {
-        if (isDisposed()) {
-          subscriber.error(createDisposedError());
-          return;
-        }
-
-        if (!hasWebSerialSupport()) {
-          const error = reportError(
-            new SerialError(
-              SerialErrorCode.BROWSER_NOT_SUPPORTED,
-              'Web Serial API is not supported in this environment',
-            ),
-            { fallbackCode: SerialErrorCode.BROWSER_NOT_SUPPORTED },
-          );
-          subscriber.error(error);
-          return;
-        }
-
-        const current = controller.status;
-        if (
-          current !== SerialSessionState.Idle &&
-          current !== SerialSessionState.Error
-        ) {
-          const error = reportError(
-            new SerialError(
-              SerialErrorCode.PORT_ALREADY_OPEN,
-              `Cannot connect while session state is '${current}'`,
-            ),
-            { fallbackCode: SerialErrorCode.PORT_ALREADY_OPEN },
-          );
-          subscriber.error(error);
-          return;
-        }
-
-        let cancelled = false;
-        const cancelInFlightConnect = (): void => {
-          cancelled = true;
-          if (controller.status === SerialSessionState.Connecting) {
-            controller.transition(createIdleRuntime());
-          }
-        };
-        controller.transition(createConnectingRuntime(cancelInFlightConnect));
-
-        const run = async (): Promise<void> => {
-          let selectedPort: SerialPort | null = null;
-          try {
-            selectedPort = await navigator.serial.requestPort(
-              buildRequestOptions(resolvedOptions),
-            );
-            await selectedPort.open({
-              baudRate: resolvedOptions.baudRate,
-              dataBits: resolvedOptions.dataBits,
-              stopBits: resolvedOptions.stopBits,
-              parity: resolvedOptions.parity,
-              bufferSize: resolvedOptions.bufferSize,
-              flowControl: resolvedOptions.flowControl,
-            });
-          } catch (error) {
-            if (selectedPort) {
-              await closePortSafely(selectedPort);
-            }
-            const serialError = reportError(error, {
-              fallbackCode: SerialErrorCode.PORT_OPEN_FAILED,
-              messagePrefix: 'Failed to open port',
-            });
-            if (!cancelled) {
-              subscriber.error(serialError);
-            }
-            return;
-          }
-
-          if (cancelled || isDisposed()) {
-            await closePortSafely(selectedPort);
-            return;
-          }
-
-          receivePipeline.clearLineBuffer();
-          if (resolvedOptions.receiveReplay.enabled) {
-            receivePipeline.startLiveReceiveReplay();
-          }
-          const pump = createReadPump(selectedPort, {
-            onChunk: receivePipeline.handleChunk,
-            onError: (pumpError) =>
-              reportError(pumpError, {
-                fallbackCode: SerialErrorCode.READ_FAILED,
-                messagePrefix: 'Read pump failed',
-              }),
-            onDone: () => {
-              if (controller.status !== SerialSessionState.Connected) {
-                return;
-              }
-              reportError(
-                new SerialError(
-                  SerialErrorCode.CONNECTION_LOST,
-                  'Read pump ended unexpectedly: stream closed while connected',
-                ),
-                {
-                  fallbackCode: SerialErrorCode.CONNECTION_LOST,
-                },
-              );
-            },
-          });
-          pump.start();
-          sendQueue.clear();
-          if (isDisposed()) {
-            await teardownPump(pump);
-            await closePortSafely(selectedPort);
-            return;
-          }
-          controller.transition(createConnectedRuntime(selectedPort, pump));
-          updatePortInfo(selectedPort);
-          subscriber.next();
-          subscriber.complete();
-        };
-
-        void run();
-
-        return () => {
-          cancelInFlightConnect();
-        };
-      });
-    },
-    disconnect$(): Observable<void> {
-      return new Observable<void>((subscriber) => {
-        if (isDisposed()) {
-          subscriber.next();
-          subscriber.complete();
-          return;
-        }
-
-        const runtime = controller.runtime;
-
-        if (
-          runtime.status === SerialSessionState.Idle ||
-          runtime.status === SerialSessionState.Unsupported ||
-          runtime.status === SerialSessionState.Disconnecting
-        ) {
-          subscriber.next();
-          subscriber.complete();
-          return;
-        }
-
-        if (runtime.status === SerialSessionState.Connecting) {
-          runtime.cancel();
-          subscriber.next();
-          subscriber.complete();
-          return;
-        }
-
-        if (
-          runtime.status !== SerialSessionState.Connected &&
-          runtime.status !== SerialSessionState.Error
-        ) {
-          const error = reportError(
-            new SerialError(
-              SerialErrorCode.PORT_NOT_OPEN,
-              `Cannot disconnect while session state is '${runtime.status}'`,
-            ),
-            { fallbackCode: SerialErrorCode.PORT_NOT_OPEN },
-          );
-          subscriber.error(error);
-          return;
-        }
-
-        const portToClose = getRuntimePort(runtime);
-        controller.transition(createDisconnectingRuntime(portToClose));
-        sendQueue.clear();
-
-        const run = async (): Promise<void> => {
-          try {
-            const pump = getRuntimePump(controller.runtime);
-            await teardownPump(pump);
-            if (portToClose) {
-              try {
-                await portToClose.close();
-              } catch (error) {
-                updatePortInfo(null);
-                const serialError = reportError(error, {
-                  fallbackCode: SerialErrorCode.CONNECTION_LOST,
-                  messagePrefix: 'Failed to close port',
-                });
-                subscriber.error(serialError);
-                return;
-              }
-            }
-            updatePortInfo(null);
-            if (!isDisposed()) {
-              controller.transition(createIdleRuntime());
-            }
-            subscriber.next();
-            subscriber.complete();
-          } catch (error) {
-            const serialError = reportError(error, {
-              fallbackCode: SerialErrorCode.UNKNOWN,
-              messagePrefix: 'Unexpected disconnect failure',
-            });
-            subscriber.error(serialError);
-          }
-        };
-
-        void run();
-      });
-    },
-    dispose$,
-    destroy$: dispose$,
+    connect$: lifecycle.connect$,
+    disconnect$: lifecycle.disconnect$,
+    dispose$: lifecycle.dispose$,
+    destroy$: lifecycle.dispose$,
     send$(data: SerialPayload): Observable<void> {
       if (isDisposed()) {
         return new Observable<void>((subscriber) => {
@@ -472,7 +162,7 @@ export function createSerialSession(
         const payload =
           typeof data === 'string' ? textEncoder.encode(data) : data;
         try {
-          await writeToPort(payload);
+          await lifecycle.writeToPort(payload);
         } catch (error) {
           throw reportError(error, {
             fallbackCode: SerialErrorCode.WRITE_FAILED,

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -12,8 +12,8 @@ import { SerialErrorCode } from '../errors/serial-error-code';
 import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
 import type { SerialPayload } from '../types';
 import { buildRequestOptions } from './internal/build-request-options';
-import { resolveErrorSeverity } from './internal/error-severity';
 import { hasWebSerialSupport } from './internal/has-web-serial-support';
+import { createSessionErrorReporter } from './internal/session-error-reporter';
 import { createLineBuffer } from './internal/line-buffer';
 import {
   createReceiveReplayBuffer,
@@ -36,7 +36,6 @@ import {
   createConnectingRuntime,
   createDisconnectingRuntime,
   createDisposedRuntime,
-  createErrorRuntime,
   createIdleRuntime,
   createInitialRuntime,
   createSessionRuntimeController,
@@ -163,12 +162,6 @@ export function createSerialSession(
   const isDisposed = (): boolean =>
     controller.status === SerialSessionState.Disposed;
 
-  const createDisposedError = (): SerialError =>
-    new SerialError(
-      SerialErrorCode.SESSION_DISPOSED,
-      'SerialSession has been disposed',
-    );
-
   const updatePortInfo = (port: SerialPort | null): void => {
     portInfoSubject.next(port ? port.getInfo() : null);
   };
@@ -256,44 +249,15 @@ export function createSerialSession(
       void run();
     });
 
-  /**
-   * Single entry point for every error that should reach `errors$`.
-   *
-   * Responsibilities:
-   *
-   * 1. Normalise the input through {@link normalizeSerialError} so every
-   *    emission is a well-formed {@link SerialError}.
-   * 2. Multiplex the normalised error on `errors$`.
-   * 3. Resolve severity from the normalised {@link SerialError.code} via
-   *    {@link resolveErrorSeverity} (see `ERROR_SEVERITY` in
-   *    `error-severity.ts`).
-   * 4. For fatal severities, drive `state$` to `'error'`, clear the send
-   *    queue so pending writes fail fast, and tear down the live pump +
-   *    port off the hot path.
-   *
-   * Returning the normalised error keeps call sites terse: they can hand
-   * the result straight to `subscriber.error(...)` without re-normalising.
-   */
-  const reportError = (
-    error: unknown,
-    options: NormalizeSerialErrorOptions,
-  ): SerialError => {
-    const serialError = normalizeSerialError(error, options);
-    if (isDisposed()) {
-      return serialError;
-    }
-    errorsSubject.next(serialError);
-    if (resolveErrorSeverity(serialError.code) === 'fatal') {
-      const runtime = controller.runtime;
-      const portToClose = getRuntimePort(runtime);
-      const pump = getRuntimePump(runtime);
-      controller.transition(createErrorRuntime());
-      sendQueue.clear();
-      updatePortInfo(null);
-      void teardownPump(pump).then(() => closePortSafely(portToClose));
-    }
-    return serialError;
-  };
+  const { reportError, createDisposedError } = createSessionErrorReporter({
+    controller,
+    errorsSubject,
+    sendQueue,
+    isDisposed,
+    updatePortInfo,
+    teardownPump,
+    closePortSafely,
+  });
 
   const writeToPort = async (payload: Uint8Array): Promise<void> => {
     const runtime = controller.runtime;

--- a/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
+++ b/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
@@ -1,0 +1,149 @@
+import {
+  BehaviorSubject,
+  type Observable,
+  share,
+  Subject,
+  switchMap,
+} from 'rxjs';
+import { SerialError } from '../../errors/serial-error';
+import { SerialErrorCode } from '../../errors/serial-error-code';
+import { createLineBuffer, type LineBuffer } from './line-buffer';
+import {
+  createReceiveReplayBuffer,
+  type ReceiveReplayBuffer,
+} from './receive-replay-buffer';
+import type { NormalizeSerialErrorOptions } from '../normalize-serial-error';
+import type { ResolvedSerialSessionOptions } from '../serial-session-options';
+
+/**
+ * Dependencies for {@link createReceivePipeline}.
+ *
+ * @internal
+ */
+export interface ReceivePipelineDeps {
+  resolvedOptions: ResolvedSerialSessionOptions;
+  reportError: (
+    error: unknown,
+    options: NormalizeSerialErrorOptions,
+  ) => SerialError;
+}
+
+/**
+ * Receive-side stream wiring for {@link createSerialSession}.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/401 | Issue #401}
+ */
+export interface ReceivePipeline {
+  receive$: Observable<string>;
+  lines$: Observable<string>;
+  receiveReplay$: Observable<string>;
+  clearReplay: () => void;
+  startLiveReceiveReplay: () => void;
+  clearLineBuffer: () => void;
+  handleChunk: (text: string) => void;
+  complete: () => void;
+}
+
+/**
+ * @internal
+ */
+export function createReceivePipeline(
+  deps: ReceivePipelineDeps,
+): ReceivePipeline {
+  const { resolvedOptions, reportError } = deps;
+
+  const receiveSubject = new Subject<string>();
+  const linesSubject = new Subject<string>();
+  const lineBuffer: LineBuffer = createLineBuffer(resolvedOptions.lineBuffer);
+
+  const receive$ = receiveSubject.asObservable();
+  const lines$ = linesSubject.asObservable();
+
+  const receiveReplayStream$ = resolvedOptions.receiveReplay.enabled
+    ? new BehaviorSubject<Observable<string>>(receive$)
+    : null;
+  let activeReceiveReplay: ReceiveReplayBuffer | null = null;
+
+  const clearReplay = (): void => {
+    if (receiveReplayStream$) {
+      if (activeReceiveReplay) {
+        activeReceiveReplay.complete();
+        activeReceiveReplay = null;
+      }
+      receiveReplayStream$.next(receive$);
+    }
+  };
+
+  const startLiveReceiveReplay = (): void => {
+    if (!receiveReplayStream$) {
+      return;
+    }
+    if (activeReceiveReplay) {
+      activeReceiveReplay.complete();
+      activeReceiveReplay = null;
+    }
+    const buffer = createReceiveReplayBuffer({
+      bufferSize: resolvedOptions.receiveReplay.bufferSize,
+      maxChars: resolvedOptions.receiveReplay.maxChars,
+    });
+    activeReceiveReplay = buffer;
+    receiveReplayStream$.next(buffer.asObservable());
+  };
+
+  const receiveReplay$ = receiveReplayStream$
+    ? receiveReplayStream$.pipe(switchMap((inner) => inner), share())
+    : receive$;
+
+  const clearLineBuffer = (): void => {
+    lineBuffer.clear();
+  };
+
+  const handleChunk = (text: string): void => {
+    receiveSubject.next(text);
+    if (activeReceiveReplay) {
+      const { overflowed } = activeReceiveReplay.next(text);
+      if (overflowed) {
+        reportError(
+          new SerialError(
+            SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
+            `Receive replay buffer exceeded configured limits; oldest chunks were discarded`,
+          ),
+          {
+            fallbackCode: SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
+          },
+        );
+      }
+    }
+    const { lines, overflowed } = lineBuffer.feed(text);
+    if (overflowed) {
+      reportError(
+        new SerialError(
+          SerialErrorCode.LINE_BUFFER_OVERFLOW,
+          `Line buffer exceeded maxChars (${resolvedOptions.lineBuffer.maxChars}); leading data was discarded`,
+        ),
+        { fallbackCode: SerialErrorCode.LINE_BUFFER_OVERFLOW },
+      );
+    }
+    for (const line of lines) {
+      linesSubject.next(line);
+    }
+  };
+
+  const complete = (): void => {
+    receiveSubject.complete();
+    linesSubject.complete();
+    receiveReplayStream$?.complete();
+  };
+
+  return {
+    receive$,
+    lines$,
+    receiveReplay$,
+    clearReplay,
+    startLiveReceiveReplay,
+    clearLineBuffer,
+    handleChunk,
+    complete,
+  };
+}

--- a/packages/web-serial-rxjs/src/session/internal/session-error-reporter.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-error-reporter.ts
@@ -1,0 +1,103 @@
+import type { Subject } from 'rxjs';
+import { SerialError } from '../../errors/serial-error';
+import { SerialErrorCode } from '../../errors/serial-error-code';
+import { resolveErrorSeverity } from './error-severity';
+import {
+  normalizeSerialError,
+  type NormalizeSerialErrorOptions,
+} from '../normalize-serial-error';
+import type { ReadPump } from '../read-pump';
+import type { SendQueue } from '../send-queue';
+import {
+  createErrorRuntime,
+  getRuntimePort,
+  getRuntimePump,
+  type SessionRuntimeController,
+} from '../session-runtime';
+
+/**
+ * Dependencies for {@link createSessionErrorReporter}.
+ *
+ * @internal
+ */
+export interface SessionErrorReporterDeps {
+  controller: SessionRuntimeController;
+  errorsSubject: Subject<SerialError>;
+  sendQueue: SendQueue;
+  isDisposed: () => boolean;
+  updatePortInfo: (port: SerialPort | null) => void;
+  teardownPump: (pump: ReadPump | null) => Promise<void>;
+  closePortSafely: (port: SerialPort | null) => Promise<void>;
+}
+
+/**
+ * Centralised error reporting for {@link createSerialSession}.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/204 | Issue #204}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/401 | Issue #401}
+ */
+export function createSessionErrorReporter(deps: SessionErrorReporterDeps): {
+  reportError: (
+    error: unknown,
+    options: NormalizeSerialErrorOptions,
+  ) => SerialError;
+  createDisposedError: () => SerialError;
+} {
+  const {
+    controller,
+    errorsSubject,
+    sendQueue,
+    isDisposed,
+    updatePortInfo,
+    teardownPump,
+    closePortSafely,
+  } = deps;
+
+  const createDisposedError = (): SerialError =>
+    new SerialError(
+      SerialErrorCode.SESSION_DISPOSED,
+      'SerialSession has been disposed',
+    );
+
+  /**
+   * Single entry point for every error that should reach `errors$`.
+   *
+   * Responsibilities:
+   *
+   * 1. Normalise the input through {@link normalizeSerialError} so every
+   *    emission is a well-formed {@link SerialError}.
+   * 2. Multiplex the normalised error on `errors$`.
+   * 3. Resolve severity from the normalised {@link SerialError.code} via
+   *    {@link resolveErrorSeverity} (see `ERROR_SEVERITY` in
+   *    `error-severity.ts`).
+   * 4. For fatal severities, drive `state$` to `'error'`, clear the send
+   *    queue so pending writes fail fast, and tear down the live pump +
+   *    port off the hot path.
+   *
+   * Returning the normalised error keeps call sites terse: they can hand
+   * the result straight to `subscriber.error(...)` without re-normalising.
+   */
+  const reportError = (
+    error: unknown,
+    options: NormalizeSerialErrorOptions,
+  ): SerialError => {
+    const serialError = normalizeSerialError(error, options);
+    if (isDisposed()) {
+      return serialError;
+    }
+    errorsSubject.next(serialError);
+    if (resolveErrorSeverity(serialError.code) === 'fatal') {
+      const runtime = controller.runtime;
+      const portToClose = getRuntimePort(runtime);
+      const pump = getRuntimePump(runtime);
+      controller.transition(createErrorRuntime());
+      sendQueue.clear();
+      updatePortInfo(null);
+      void teardownPump(pump).then(() => closePortSafely(portToClose));
+    }
+    return serialError;
+  };
+
+  return { reportError, createDisposedError };
+}

--- a/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
@@ -1,0 +1,404 @@
+import { type BehaviorSubject, Observable, type Subject } from 'rxjs';
+import { SerialError } from '../../errors/serial-error';
+import { SerialErrorCode } from '../../errors/serial-error-code';
+import { buildRequestOptions } from './build-request-options';
+import { hasWebSerialSupport } from './has-web-serial-support';
+import type { ReceivePipeline } from './receive-pipeline';
+import {
+  normalizeSerialError,
+  type NormalizeSerialErrorOptions,
+} from '../normalize-serial-error';
+import { createReadPump, type ReadPump } from '../read-pump';
+import type { SendQueue } from '../send-queue';
+import type { ResolvedSerialSessionOptions } from '../serial-session-options';
+import { SerialSessionState } from '../serial-session-state';
+import {
+  createConnectedRuntime,
+  createConnectingRuntime,
+  createDisconnectingRuntime,
+  createDisposedRuntime,
+  createIdleRuntime,
+  getRuntimePort,
+  getRuntimePump,
+  type SessionRuntime,
+  type SessionRuntimeController,
+} from '../session-runtime';
+
+/**
+ * Dependencies for {@link createSessionLifecycle}.
+ *
+ * @internal
+ */
+export interface SessionLifecycleDeps {
+  controller: SessionRuntimeController;
+  resolvedOptions: ResolvedSerialSessionOptions;
+  sendQueue: SendQueue;
+  receivePipeline: ReceivePipeline;
+  portInfoSubject: BehaviorSubject<SerialPortInfo | null>;
+  errorsSubject: Subject<SerialError>;
+  isDisposed: () => boolean;
+  reportError: (
+    error: unknown,
+    options: NormalizeSerialErrorOptions,
+  ) => SerialError;
+  createDisposedError: () => SerialError;
+}
+
+/**
+ * Port and pump lifecycle operations for {@link createSerialSession}.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/401 | Issue #401}
+ */
+export interface SessionLifecycle {
+  connect$: () => Observable<void>;
+  disconnect$: () => Observable<void>;
+  dispose$: () => Observable<void>;
+  writeToPort: (payload: Uint8Array) => Promise<void>;
+  teardownPump: (pump: ReadPump | null) => Promise<void>;
+  closePortSafely: (port: SerialPort | null) => Promise<void>;
+  updatePortInfo: (port: SerialPort | null) => void;
+}
+
+/**
+ * @internal
+ */
+export function createSessionLifecycle(
+  deps: SessionLifecycleDeps,
+): SessionLifecycle {
+  const {
+    controller,
+    resolvedOptions,
+    sendQueue,
+    receivePipeline,
+    portInfoSubject,
+    errorsSubject,
+    isDisposed,
+    reportError,
+    createDisposedError,
+  } = deps;
+
+  const updatePortInfo = (port: SerialPort | null): void => {
+    portInfoSubject.next(port ? port.getInfo() : null);
+  };
+
+  const teardownPump = async (pump: ReadPump | null): Promise<void> => {
+    receivePipeline.clearReplay();
+    receivePipeline.clearLineBuffer();
+    if (pump) {
+      await pump.stop();
+    }
+  };
+
+  const closePortSafely = async (port: SerialPort | null): Promise<void> => {
+    if (!port) {
+      return;
+    }
+    try {
+      await port.close();
+    } catch {
+      // The read pump may already have errored the stream, which makes
+      // close() reject. We ignore it here because disconnect$ has a
+      // dedicated error path for close failures initiated by the user.
+    }
+  };
+
+  const teardownFromSnapshot = async (
+    snapshot: SessionRuntime,
+  ): Promise<void> => {
+    if (snapshot.status === SerialSessionState.Connecting) {
+      snapshot.cancel();
+    }
+
+    sendQueue.clear();
+
+    if (
+      snapshot.status === SerialSessionState.Connected ||
+      snapshot.status === SerialSessionState.Disconnecting ||
+      snapshot.status === SerialSessionState.Error
+    ) {
+      const portToClose = getRuntimePort(snapshot);
+      const pump = getRuntimePump(snapshot);
+      await teardownPump(pump);
+      await closePortSafely(portToClose);
+      updatePortInfo(null);
+    }
+
+    receivePipeline.clearLineBuffer();
+  };
+
+  const completeSubjects = (): void => {
+    controller.complete();
+    errorsSubject.complete();
+    receivePipeline.complete();
+    portInfoSubject.complete();
+  };
+
+  const dispose$ = (): Observable<void> =>
+    new Observable<void>((subscriber) => {
+      if (isDisposed()) {
+        subscriber.next();
+        subscriber.complete();
+        return;
+      }
+
+      const snapshot = controller.runtime;
+      controller.transition(createDisposedRuntime());
+
+      const run = async (): Promise<void> => {
+        try {
+          await teardownFromSnapshot(snapshot);
+          completeSubjects();
+          subscriber.next();
+          subscriber.complete();
+        } catch (error) {
+          const serialError = normalizeSerialError(error, {
+            fallbackCode: SerialErrorCode.UNKNOWN,
+            messagePrefix: 'Unexpected dispose failure',
+          });
+          subscriber.error(serialError);
+        }
+      };
+
+      void run();
+    });
+
+  const writeToPort = async (payload: Uint8Array): Promise<void> => {
+    const runtime = controller.runtime;
+    if (
+      runtime.status !== SerialSessionState.Connected ||
+      !runtime.port.writable
+    ) {
+      throw new SerialError(
+        SerialErrorCode.PORT_NOT_OPEN,
+        'Cannot send data while session is not connected',
+      );
+    }
+    const writer = runtime.port.writable.getWriter();
+    try {
+      await writer.write(payload);
+    } finally {
+      try {
+        writer.releaseLock();
+      } catch {
+        // releaseLock throws when the stream is already errored; the real
+        // failure is surfaced through the write() rejection above so we
+        // intentionally swallow this secondary error.
+      }
+    }
+  };
+
+  const connect$ = (): Observable<void> =>
+    new Observable<void>((subscriber) => {
+      if (isDisposed()) {
+        subscriber.error(createDisposedError());
+        return;
+      }
+
+      if (!hasWebSerialSupport()) {
+        const error = reportError(
+          new SerialError(
+            SerialErrorCode.BROWSER_NOT_SUPPORTED,
+            'Web Serial API is not supported in this environment',
+          ),
+          { fallbackCode: SerialErrorCode.BROWSER_NOT_SUPPORTED },
+        );
+        subscriber.error(error);
+        return;
+      }
+
+      const current = controller.status;
+      if (
+        current !== SerialSessionState.Idle &&
+        current !== SerialSessionState.Error
+      ) {
+        const error = reportError(
+          new SerialError(
+            SerialErrorCode.PORT_ALREADY_OPEN,
+            `Cannot connect while session state is '${current}'`,
+          ),
+          { fallbackCode: SerialErrorCode.PORT_ALREADY_OPEN },
+        );
+        subscriber.error(error);
+        return;
+      }
+
+      let cancelled = false;
+      const cancelInFlightConnect = (): void => {
+        cancelled = true;
+        if (controller.status === SerialSessionState.Connecting) {
+          controller.transition(createIdleRuntime());
+        }
+      };
+      controller.transition(createConnectingRuntime(cancelInFlightConnect));
+
+      const run = async (): Promise<void> => {
+        let selectedPort: SerialPort | null = null;
+        try {
+          selectedPort = await navigator.serial.requestPort(
+            buildRequestOptions(resolvedOptions),
+          );
+          await selectedPort.open({
+            baudRate: resolvedOptions.baudRate,
+            dataBits: resolvedOptions.dataBits,
+            stopBits: resolvedOptions.stopBits,
+            parity: resolvedOptions.parity,
+            bufferSize: resolvedOptions.bufferSize,
+            flowControl: resolvedOptions.flowControl,
+          });
+        } catch (error) {
+          if (selectedPort) {
+            await closePortSafely(selectedPort);
+          }
+          const serialError = reportError(error, {
+            fallbackCode: SerialErrorCode.PORT_OPEN_FAILED,
+            messagePrefix: 'Failed to open port',
+          });
+          if (!cancelled) {
+            subscriber.error(serialError);
+          }
+          return;
+        }
+
+        if (cancelled || isDisposed()) {
+          await closePortSafely(selectedPort);
+          return;
+        }
+
+        receivePipeline.clearLineBuffer();
+        if (resolvedOptions.receiveReplay.enabled) {
+          receivePipeline.startLiveReceiveReplay();
+        }
+        const pump = createReadPump(selectedPort, {
+          onChunk: receivePipeline.handleChunk,
+          onError: (pumpError) =>
+            reportError(pumpError, {
+              fallbackCode: SerialErrorCode.READ_FAILED,
+              messagePrefix: 'Read pump failed',
+            }),
+          onDone: () => {
+            if (controller.status !== SerialSessionState.Connected) {
+              return;
+            }
+            reportError(
+              new SerialError(
+                SerialErrorCode.CONNECTION_LOST,
+                'Read pump ended unexpectedly: stream closed while connected',
+              ),
+              {
+                fallbackCode: SerialErrorCode.CONNECTION_LOST,
+              },
+            );
+          },
+        });
+        pump.start();
+        sendQueue.clear();
+        if (isDisposed()) {
+          await teardownPump(pump);
+          await closePortSafely(selectedPort);
+          return;
+        }
+        controller.transition(createConnectedRuntime(selectedPort, pump));
+        updatePortInfo(selectedPort);
+        subscriber.next();
+        subscriber.complete();
+      };
+
+      void run();
+
+      return () => {
+        cancelInFlightConnect();
+      };
+    });
+
+  const disconnect$ = (): Observable<void> =>
+    new Observable<void>((subscriber) => {
+      if (isDisposed()) {
+        subscriber.next();
+        subscriber.complete();
+        return;
+      }
+
+      const runtime = controller.runtime;
+
+      if (
+        runtime.status === SerialSessionState.Idle ||
+        runtime.status === SerialSessionState.Unsupported ||
+        runtime.status === SerialSessionState.Disconnecting
+      ) {
+        subscriber.next();
+        subscriber.complete();
+        return;
+      }
+
+      if (runtime.status === SerialSessionState.Connecting) {
+        runtime.cancel();
+        subscriber.next();
+        subscriber.complete();
+        return;
+      }
+
+      if (
+        runtime.status !== SerialSessionState.Connected &&
+        runtime.status !== SerialSessionState.Error
+      ) {
+        const error = reportError(
+          new SerialError(
+            SerialErrorCode.PORT_NOT_OPEN,
+            `Cannot disconnect while session state is '${runtime.status}'`,
+          ),
+          { fallbackCode: SerialErrorCode.PORT_NOT_OPEN },
+        );
+        subscriber.error(error);
+        return;
+      }
+
+      const portToClose = getRuntimePort(runtime);
+      controller.transition(createDisconnectingRuntime(portToClose));
+      sendQueue.clear();
+
+      const run = async (): Promise<void> => {
+        try {
+          const pump = getRuntimePump(controller.runtime);
+          await teardownPump(pump);
+          if (portToClose) {
+            try {
+              await portToClose.close();
+            } catch (error) {
+              updatePortInfo(null);
+              const serialError = reportError(error, {
+                fallbackCode: SerialErrorCode.CONNECTION_LOST,
+                messagePrefix: 'Failed to close port',
+              });
+              subscriber.error(serialError);
+              return;
+            }
+          }
+          updatePortInfo(null);
+          if (!isDisposed()) {
+            controller.transition(createIdleRuntime());
+          }
+          subscriber.next();
+          subscriber.complete();
+        } catch (error) {
+          const serialError = reportError(error, {
+            fallbackCode: SerialErrorCode.UNKNOWN,
+            messagePrefix: 'Unexpected disconnect failure',
+          });
+          subscriber.error(serialError);
+        }
+      };
+
+      void run();
+    });
+
+  return {
+    connect$,
+    disconnect$,
+    dispose$,
+    writeToPort,
+    teardownPump,
+    closePortSafely,
+    updatePortInfo,
+  };
+}


### PR DESCRIPTION
## Summary
`createSerialSession` の 597 行 closure を `session-error-reporter` / `receive-pipeline` / `session-lifecycle` の 3 内部モジュールへ段階的に分割し、公開 API を維持したまま保守性を向上させた。`create-serial-session.ts` は 189 行の薄い composer に縮小した。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #401
- Refs #391

## What changed?
- `session/internal/session-error-reporter.ts` を新設し `reportError` / `createDisposedError` を抽出
- `session/internal/receive-pipeline.ts` を新設し receive / lines / receiveReplay 配線と `handleChunk` を抽出
- `session/internal/session-lifecycle.ts` を新設し connect / disconnect / dispose / teardown を抽出
- `create-serial-session.ts` を薄い composer に縮小（597 行 → 189 行）

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build`
3. `pnpm --filter @gurezo/web-serial-rxjs run verify:dist`

## Environment (if relevant)
- Browser: N/A（ユニットテストのみ）
- OS: macOS
- web-serial-rxjs version (for verification): 作業ブランチ
- RxJS version: workspace 既定

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)