### PR TITLE
refactor(web-serial-rxjs): derive SerialSessionOptions from SerialOptions

### DIFF
--- a/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
@@ -245,7 +245,7 @@ export function createSessionLifecycle(
             parity: resolvedOptions.parity,
             bufferSize: resolvedOptions.bufferSize,
             flowControl: resolvedOptions.flowControl,
-          });
+          } satisfies SerialOptions);
         } catch (error) {
           if (selectedPort) {
             await closePortSafely(selectedPort);

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -8,11 +8,24 @@ import {
 } from './internal/line-buffer';
 
 /**
+ * W3C connection fields shared with {@link SerialOptions}.
+ *
+ * @internal
+ */
+type SerialSessionConnectionFields = Pick<
+  SerialOptions,
+  'baudRate' | 'dataBits' | 'stopBits' | 'parity' | 'bufferSize' | 'flowControl'
+>;
+
+/**
  * Options for creating a {@link SerialSession} via {@link createSerialSession}.
  *
- * These options configure the serial port connection parameters used when
- * calling `port.open` and `navigator.serial.requestPort`. All properties
- * are optional; omitted fields fall back to {@link DEFAULT_SERIAL_SESSION_OPTIONS}.
+ * Connection parameters (`baudRate`, `dataBits`, `stopBits`, `parity`,
+ * `bufferSize`, `flowControl`) are derived from the W3C {@link SerialOptions}
+ * type and passed to `port.open`. All connection fields are optional here;
+ * omitted values fall back to {@link DEFAULT_SERIAL_SESSION_OPTIONS}
+ * (`baudRate` 9600, `dataBits` 8, `stopBits` 1, `parity` `'none'`,
+ * `bufferSize` 255, `flowControl` `'none'`).
  *
  * @example
  * ```typescript
@@ -26,55 +39,13 @@ import {
  * });
  * ```
  *
+ * @see {@link SerialOptions}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/402 | Issue #402}
  */
-export interface SerialSessionOptions {
-  /**
-   * Baud rate for the serial port connection (bits per second).
-   *
-   * Common values include 9600, 19200, 38400, 57600, 115200, etc.
-   * Must match the baud rate configured on the connected device.
-   *
-   * @default 9600
-   */
-  baudRate?: number;
-
-  /**
-   * Number of data bits per character (7 or 8).
-   *
-   * @default 8
-   */
-  dataBits?: 7 | 8;
-
-  /**
-   * Number of stop bits (1 or 2).
-   *
-   * @default 1
-   */
-  stopBits?: 1 | 2;
-
-  /**
-   * Parity checking mode.
-   *
-   * @default 'none'
-   */
-  parity?: 'none' | 'even' | 'odd';
-
-  /**
-   * Buffer size for the underlying read stream, in bytes.
-   *
-   * @default 255
-   */
-  bufferSize?: number;
-
-  /**
-   * Flow control mode.
-   *
-   * @default 'none'
-   */
-  flowControl?: 'none' | 'hardware';
-
+export interface SerialSessionOptions
+  extends Partial<SerialSessionConnectionFields> {
   /**
    * Filters for port selection when requesting a port.
    *

--- a/packages/web-serial-rxjs/src/types.ts
+++ b/packages/web-serial-rxjs/src/types.ts
@@ -1,5 +1,3 @@
-import type { SerialSessionOptions } from './session/serial-session-options';
-
 /**
  * Payload accepted by {@link SerialSession.send$}.
  *
@@ -11,10 +9,13 @@ export type SerialPayload = string | Uint8Array;
 /**
  * Connection parameters passed to `port.open` when opening a serial port.
  *
- * Excludes {@link SerialSessionOptions.filters}, which apply only to
+ * Derived from the W3C {@link SerialOptions} type. Excludes
+ * {@link SerialSessionOptions.filters}, which apply only to
  * `navigator.serial.requestPort`.
+ *
+ * @see {@link SerialOptions}
  */
 export type SerialConnectionOptions = Pick<
-  SerialSessionOptions,
+  SerialOptions,
   'baudRate' | 'dataBits' | 'stopBits' | 'parity' | 'bufferSize' | 'flowControl'
 >;

--- a/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
+++ b/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   DEFAULT_SERIAL_SESSION_OPTIONS,
   resolveSerialSessionOptions,
+  type SerialSessionOptions,
 } from '../../src/session/serial-session-options';
 import { DEFAULT_TERMINAL_BUFFER_OPTIONS } from '../../src/terminal/create-terminal-buffer';
 
@@ -99,5 +100,42 @@ describe('resolveSerialSessionOptions', () => {
         SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS,
       );
     }
+  });
+
+  it('accepts representative SerialSessionOptions shapes', () => {
+    const emptyOptions: SerialSessionOptions = {};
+    const partialConnectionOptions: SerialSessionOptions = { baudRate: 115200 };
+    const mixedOptions: SerialSessionOptions = {
+      baudRate: 9600,
+      receiveReplay: { enabled: true },
+      terminalBuffer: { maxLines: 50 },
+      lineBuffer: { maxChars: 1024 },
+      filters: [{ usbVendorId: 0x1234 }],
+    };
+
+    expect(resolveSerialSessionOptions(emptyOptions)).toEqual(
+      DEFAULT_SERIAL_SESSION_OPTIONS,
+    );
+    expect(resolveSerialSessionOptions(partialConnectionOptions)).toEqual({
+      ...DEFAULT_SERIAL_SESSION_OPTIONS,
+      baudRate: 115200,
+    });
+    expect(resolveSerialSessionOptions(mixedOptions)).toEqual({
+      ...DEFAULT_SERIAL_SESSION_OPTIONS,
+      baudRate: 9600,
+      receiveReplay: {
+        ...DEFAULT_SERIAL_SESSION_OPTIONS.receiveReplay,
+        enabled: true,
+      },
+      terminalBuffer: {
+        ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
+        maxLines: 50,
+      },
+      lineBuffer: {
+        ...DEFAULT_LINE_BUFFER_OPTIONS,
+        maxChars: 1024,
+      },
+      filters: [{ usbVendorId: 0x1234 }],
+    });
   });
 });


### PR DESCRIPTION
## Summary
W3C `SerialOptions` から `SerialSessionOptions` の接続パラメータを派生させ、手書き型定義との二重管理を解消しました。Web Serial 仕様との drift を compile-time で検知できるようにし、既存の options assignability は維持します。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #402
- Parent: #391

## What changed?
- `SerialSessionOptions` を `Partial<Pick<SerialOptions, ...>>` から派生
- `SerialConnectionOptions` を `SerialOptions` から直接 `Pick`
- `port.open` 引数に `satisfies SerialOptions` を追加
- JSDoc に `SerialOptions` 参照を追加
- 代表的な options 形状の assignability テストを追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build`
3. `pnpm exec nx run web-serial-rxjs:verify:dist`
4. examples 各プロジェクトの build が型エラーなしで通ることを確認

## Environment (if relevant)
- N/A（型定義リファクタリングのみ）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)