### PR TITLE
feat(web-serial-rxjs): validate all session options at factory time

### DIFF
--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -44,6 +44,16 @@ function createSerialSession(options?: SerialSessionOptions): SerialSession;
 | `terminalBuffer` | `TerminalBufferOptions` | `{ maxLines: 10000, maxChars: 1048576 }` | `terminalText$` のメモリ上限。`createTerminalBuffer` を参照。 |
 | `lineBuffer` | `LineBufferOptions` | `{ maxChars: 1048576 }` | `lines$` の未完成行 tail のメモリ上限。下記を参照。 |
 
+`createSerialSession` 呼び出し時（factory 時）に `resolveSerialSessionOptions` が以下を検証します。不正値は `SerialError` として throw されます。
+
+| 対象 | 検証内容 | エラーコード |
+| --- | --- | --- |
+| `baudRate` | safe integer かつ `> 0` | `INVALID_CONNECTION_OPTIONS` |
+| `filters` | USB vendor/product ID の範囲 | `INVALID_FILTER_OPTIONS` |
+| `receiveReplay` | `bufferSize` / `maxChars` の範囲 | `INVALID_RECEIVE_REPLAY_OPTIONS` |
+| `terminalBuffer` | `maxLines` / `maxChars` が safe integer かつ `>= 0` | `INVALID_TERMINAL_BUFFER_OPTIONS` |
+| `lineBuffer` | `maxChars` が safe integer かつ `>= 0` | `INVALID_LINE_BUFFER_OPTIONS` |
+
 ### `SerialSessionReceiveReplayOptions`
 
 | フィールド   | 型        | 既定値   | 説明 |
@@ -63,6 +73,8 @@ function createSerialSession(options?: SerialSessionOptions): SerialSession;
 | `maxLines`   | `number`  | `10000`    | 累積表示テキストに保持する完了行数の上限。 |
 | `maxChars`   | `number`  | `1048576`  | 表示テキスト全体（完了部分 + 編集中行）の文字数上限。 |
 
+無効な `maxLines` / `maxChars` は `createSerialSession` 時に `INVALID_TERMINAL_BUFFER_OPTIONS` で throw します。
+
 ### `LineBufferOptions`
 
 `SerialSessionOptions.lineBuffer` で `lines$` の**未完成行 tail**（改行未到達の保持データ）の上限を指定します。`maxChars` を超えたときは tail の**先頭**文字から破棄し、non-fatal の `SerialErrorCode.LINE_BUFFER_OVERFLOW` を `errors$` に emit します（セッションは切断されません）。完了した行は trim 前にそのまま emit されます。`0` で制限を無効化します。
@@ -70,6 +82,8 @@ function createSerialSession(options?: SerialSessionOptions): SerialSession;
 | フィールド   | 型        | 既定値     | 説明 |
 | ------------ | --------- | ---------- | ---- |
 | `maxChars`   | `number`  | `1048576`  | 未完成行 tail に保持する最大文字数。 |
+
+無効な `maxChars` は `createSerialSession` 時に `INVALID_LINE_BUFFER_OPTIONS` で throw します。
 
 ## createTerminalBuffer(receive$, options?)
 
@@ -195,8 +209,11 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 | `LINE_BUFFER_OVERFLOW`   | `lines$` の未完成 tail が `lineBuffer.maxChars` を超過。先頭データを破棄（non-fatal） |
 | `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` バッファが `receiveReplay` の上限を超過。古いチャンクを破棄（non-fatal） |
 | `CONNECTION_LOST`        | `port.close()` 失敗または接続中に切断                              |
-| `INVALID_FILTER_OPTIONS` | `filters` に不正な値が含まれる                                     |
+| `INVALID_FILTER_OPTIONS` | `filters` に不正な値が含まれる（セッション生成時）                 |
 | `INVALID_RECEIVE_REPLAY_OPTIONS` | `receiveReplay.bufferSize` または `receiveReplay.maxChars` が範囲外（セッション生成時） |
+| `INVALID_TERMINAL_BUFFER_OPTIONS` | `terminalBuffer.maxLines` または `terminalBuffer.maxChars` が範囲外（セッション生成時） |
+| `INVALID_LINE_BUFFER_OPTIONS` | `lineBuffer.maxChars` が範囲外（セッション生成時） |
+| `INVALID_CONNECTION_OPTIONS` | `baudRate` が範囲外（セッション生成時） |
 | `OPERATION_CANCELLED`    | ユーザーがポート選択ダイアログをキャンセル                         |
 | `OPERATION_TIMEOUT`      | 内部操作がタイムアウト                                             |
 | `SESSION_DISPOSED`       | `dispose$` / `destroy$` 後に `connect$` または `send$` を呼んだ    |

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -44,6 +44,16 @@ function createSerialSession(options?: SerialSessionOptions): SerialSession;
 | `terminalBuffer` | `TerminalBufferOptions` | `{ maxLines: 10000, maxChars: 1048576 }` | Memory limits for `terminalText$`; see `createTerminalBuffer`. |
 | `lineBuffer` | `LineBufferOptions` | `{ maxChars: 1048576 }` | Memory limit for the incomplete line tail used by `lines$`; see below. |
 
+At `createSerialSession` time (factory), `resolveSerialSessionOptions` validates the following. Invalid values throw `SerialError`:
+
+| Target | Validation | Error code |
+| --- | --- | --- |
+| `baudRate` | safe integer and `> 0` | `INVALID_CONNECTION_OPTIONS` |
+| `filters` | USB vendor/product ID ranges | `INVALID_FILTER_OPTIONS` |
+| `receiveReplay` | `bufferSize` / `maxChars` ranges | `INVALID_RECEIVE_REPLAY_OPTIONS` |
+| `terminalBuffer` | `maxLines` / `maxChars` are safe integers and `>= 0` | `INVALID_TERMINAL_BUFFER_OPTIONS` |
+| `lineBuffer` | `maxChars` is a safe integer and `>= 0` | `INVALID_LINE_BUFFER_OPTIONS` |
+
 ### `SerialSessionReceiveReplayOptions`
 
 | Field         | Type      | Default | Description |
@@ -63,6 +73,8 @@ Used by `createTerminalBuffer` and `SerialSessionOptions.terminalBuffer`. When a
 | `maxLines` | `number` | `10000`    | Max number of completed lines retained in the cumulative display text. |
 | `maxChars` | `number` | `1048576`  | Max total characters in the display text (`completed` + current line). |
 
+Invalid `maxLines` or `maxChars` values cause `createSerialSession` to throw `SerialError` with `INVALID_TERMINAL_BUFFER_OPTIONS`.
+
 ### `LineBufferOptions`
 
 Used by `SerialSessionOptions.lineBuffer` for the **incomplete line tail** held while framing `lines$`. When `maxChars` is exceeded, **leading** characters of the tail are discarded and a non-fatal `SerialError` with `SerialErrorCode.LINE_BUFFER_OVERFLOW` is emitted on `errors$`. Completed lines are emitted in full before the tail is trimmed. Pass `0` to disable the limit.
@@ -70,6 +82,8 @@ Used by `SerialSessionOptions.lineBuffer` for the **incomplete line tail** held 
 | Field      | Type     | Default    | Description |
 | ---------- | -------- | ---------- | ----------- |
 | `maxChars` | `number` | `1048576`  | Max characters retained in the incomplete line tail (no line terminator yet). |
+
+Invalid `maxChars` values cause `createSerialSession` to throw `SerialError` with `INVALID_LINE_BUFFER_OPTIONS`.
 
 ## createTerminalBuffer(receive$, options?)
 
@@ -195,8 +209,11 @@ Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a
 | `LINE_BUFFER_OVERFLOW`   | `lines$` incomplete tail exceeded `lineBuffer.maxChars`; leading data discarded (non-fatal). |
 | `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` buffer exceeded `receiveReplay` limits; oldest chunks discarded (non-fatal). |
 | `CONNECTION_LOST`        | `port.close()` failed or the port dropped mid-session.              |
-| `INVALID_FILTER_OPTIONS` | `filters` contained an invalid entry.                               |
+| `INVALID_FILTER_OPTIONS` | `filters` contained an invalid entry (at session creation).         |
 | `INVALID_RECEIVE_REPLAY_OPTIONS` | `receiveReplay.bufferSize` or `receiveReplay.maxChars` was out of range at session creation. |
+| `INVALID_TERMINAL_BUFFER_OPTIONS` | `terminalBuffer.maxLines` or `terminalBuffer.maxChars` was out of range at session creation. |
+| `INVALID_LINE_BUFFER_OPTIONS` | `lineBuffer.maxChars` was out of range at session creation. |
+| `INVALID_CONNECTION_OPTIONS` | `baudRate` was out of range at session creation. |
 | `OPERATION_CANCELLED`    | User cancelled the port picker.                                     |
 | `OPERATION_TIMEOUT`      | Internal operation timed out.                                       |
 | `SESSION_DISPOSED`       | `connect$` or `send$` called after `dispose$` / `destroy$`.         |

--- a/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md
@@ -144,7 +144,7 @@ async function query(
 
 `SerialSessionOptions` は `SerialClientOptions` と同じフィールド（`baudRate` / `dataBits` / `stopBits` / `parity` / `bufferSize` / `flowControl` / `filters`）を持ち、デフォルト値（`9600` / `8` / `1` / `'none'` / `255` / `'none'`）も同一です。
 
-以前 `buildRequestOptions` が行っていた `filters` のバリデーションは `createSerialSession` / `connect$` 内で実施されます。不正な filters は `SerialError`（`SerialErrorCode.INVALID_FILTER_OPTIONS`）として通知されます。
+`createSerialSession` factory 時に `resolveSerialSessionOptions` が `filters`・`baudRate`・`receiveReplay`・`terminalBuffer`・`lineBuffer` を検証します。不正な値は `SerialError` として throw されます（例: `SerialErrorCode.INVALID_FILTER_OPTIONS`）。
 
 ## フレームワーク別の例
 

--- a/packages/web-serial-rxjs/docs/MIGRATION_V2.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V2.md
@@ -142,7 +142,7 @@ async function query(
 
 `SerialSessionOptions` mirrors the fields of `SerialClientOptions` (`baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`, `filters`) and uses the same defaults (`9600`, `8`, `1`, `'none'`, `255`, `'none'`).
 
-`filters` validation that previously happened inside `buildRequestOptions` now happens inside `createSerialSession` / `connect$`; invalid filters surface as `SerialError` with `SerialErrorCode.INVALID_FILTER_OPTIONS`.
+At `createSerialSession` factory time, `resolveSerialSessionOptions` validates `filters`, `baudRate`, `receiveReplay`, `terminalBuffer`, and `lineBuffer`. Invalid values throw `SerialError` (for example `SerialErrorCode.INVALID_FILTER_OPTIONS`).
 
 ## Framework examples
 

--- a/packages/web-serial-rxjs/src/errors/serial-error-code.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error-code.ts
@@ -161,6 +161,39 @@ export enum SerialErrorCode {
   INVALID_RECEIVE_REPLAY_OPTIONS = 'INVALID_RECEIVE_REPLAY_OPTIONS',
 
   /**
+   * Invalid terminal buffer options provided.
+   *
+   * This error occurs when {@link SerialSessionOptions.terminalBuffer} values are
+   * out of range, such as a negative or non-integer `maxLines` or `maxChars`.
+   *
+   * **Suggested action**: Verify `terminalBuffer` options match the documented
+   * ranges and value types.
+   */
+  INVALID_TERMINAL_BUFFER_OPTIONS = 'INVALID_TERMINAL_BUFFER_OPTIONS',
+
+  /**
+   * Invalid line buffer options provided.
+   *
+   * This error occurs when {@link SerialSessionOptions.lineBuffer} values are
+   * out of range, such as a negative or non-integer `maxChars`.
+   *
+   * **Suggested action**: Verify `lineBuffer` options match the documented
+   * ranges and value types.
+   */
+  INVALID_LINE_BUFFER_OPTIONS = 'INVALID_LINE_BUFFER_OPTIONS',
+
+  /**
+   * Invalid connection options provided.
+   *
+   * This error occurs when connection fields such as `baudRate` are out of
+   * range at session creation time.
+   *
+   * **Suggested action**: Verify connection options match the documented
+   * ranges and value types.
+   */
+  INVALID_CONNECTION_OPTIONS = 'INVALID_CONNECTION_OPTIONS',
+
+  /**
    * Receive replay buffer exceeded its configured character limit.
    *
    * This error occurs when buffered chunks on {@link SerialSession.receiveReplay$}

--- a/packages/web-serial-rxjs/src/session/internal/build-request-options.ts
+++ b/packages/web-serial-rxjs/src/session/internal/build-request-options.ts
@@ -1,62 +1,25 @@
-import { SerialError } from '../../errors/serial-error';
-import { SerialErrorCode } from '../../errors/serial-error-code';
 import type { SerialSessionOptions } from '../serial-session-options';
 
 /**
- * Build {@link SerialPortRequestOptions} from {@link SerialSessionOptions}.
+ * Build {@link SerialPortRequestOptions} from resolved {@link SerialSessionOptions}.
  *
- * Converts the `filters` field of {@link SerialSessionOptions} into the
- * shape expected by `navigator.serial.requestPort` and validates USB
- * vendor / product identifiers. Returns `undefined` when no filters are
+ * Converts the `filters` field into the shape expected by
+ * `navigator.serial.requestPort`. Returns `undefined` when no filters are
  * supplied so the browser shows all available ports.
  *
- * @param options - The session options supplied by the caller.
+ * Filter validation is performed earlier by
+ * {@link resolveSerialSessionOptions} at factory time.
+ *
+ * @param options - Resolved session options (filters already validated).
  * @returns The request options, or `undefined` when no filters are set.
- * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_FILTER_OPTIONS}
- *         when a filter is empty or contains out-of-range IDs.
  *
  * @internal
  */
 export function buildRequestOptions(
   options?: SerialSessionOptions,
 ): SerialPortRequestOptions | undefined {
-  if (!options || !options.filters || options.filters.length === 0) {
+  if (!options?.filters || options.filters.length === 0) {
     return undefined;
-  }
-
-  for (const filter of options.filters) {
-    if (!filter.usbVendorId && !filter.usbProductId) {
-      throw new SerialError(
-        SerialErrorCode.INVALID_FILTER_OPTIONS,
-        'Filter must have at least usbVendorId or usbProductId',
-      );
-    }
-
-    if (filter.usbVendorId !== undefined) {
-      if (
-        !Number.isInteger(filter.usbVendorId) ||
-        filter.usbVendorId < 0 ||
-        filter.usbVendorId > 0xffff
-      ) {
-        throw new SerialError(
-          SerialErrorCode.INVALID_FILTER_OPTIONS,
-          `Invalid usbVendorId: ${filter.usbVendorId}. Must be an integer between 0 and 65535.`,
-        );
-      }
-    }
-
-    if (filter.usbProductId !== undefined) {
-      if (
-        !Number.isInteger(filter.usbProductId) ||
-        filter.usbProductId < 0 ||
-        filter.usbProductId > 0xffff
-      ) {
-        throw new SerialError(
-          SerialErrorCode.INVALID_FILTER_OPTIONS,
-          `Invalid usbProductId: ${filter.usbProductId}. Must be an integer between 0 and 65535.`,
-        );
-      }
-    }
   }
 
   return {

--- a/packages/web-serial-rxjs/src/session/internal/validate-serial-port-filters.ts
+++ b/packages/web-serial-rxjs/src/session/internal/validate-serial-port-filters.ts
@@ -1,0 +1,57 @@
+import { SerialError } from '../../errors/serial-error';
+import { SerialErrorCode } from '../../errors/serial-error-code';
+
+/**
+ * Validate {@link SerialPortFilter} entries for session creation.
+ *
+ * @param filters - Optional filters from {@link SerialSessionOptions}.
+ * @returns The same filters reference when valid, or `undefined` when omitted/empty.
+ * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_FILTER_OPTIONS}
+ *         when a filter is empty or contains out-of-range IDs.
+ *
+ * @internal
+ */
+export function validateSerialPortFilters(
+  filters?: SerialPortFilter[],
+): SerialPortFilter[] | undefined {
+  if (!filters || filters.length === 0) {
+    return filters;
+  }
+
+  for (const filter of filters) {
+    if (!filter.usbVendorId && !filter.usbProductId) {
+      throw new SerialError(
+        SerialErrorCode.INVALID_FILTER_OPTIONS,
+        'Filter must have at least usbVendorId or usbProductId',
+      );
+    }
+
+    if (filter.usbVendorId !== undefined) {
+      if (
+        !Number.isInteger(filter.usbVendorId) ||
+        filter.usbVendorId < 0 ||
+        filter.usbVendorId > 0xffff
+      ) {
+        throw new SerialError(
+          SerialErrorCode.INVALID_FILTER_OPTIONS,
+          `Invalid usbVendorId: ${filter.usbVendorId}. Must be an integer between 0 and 65535.`,
+        );
+      }
+    }
+
+    if (filter.usbProductId !== undefined) {
+      if (
+        !Number.isInteger(filter.usbProductId) ||
+        filter.usbProductId < 0 ||
+        filter.usbProductId > 0xffff
+      ) {
+        throw new SerialError(
+          SerialErrorCode.INVALID_FILTER_OPTIONS,
+          `Invalid usbProductId: ${filter.usbProductId}. Must be an integer between 0 and 65535.`,
+        );
+      }
+    }
+  }
+
+  return filters;
+}

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_LINE_BUFFER_OPTIONS,
   type LineBufferOptions,
 } from './internal/line-buffer';
+import { validateSerialPortFilters } from './internal/validate-serial-port-filters';
 
 /**
  * W3C connection fields shared with {@link SerialOptions}.
@@ -260,19 +261,64 @@ export const DEFAULT_SERIAL_SESSION_OPTIONS = {
   lineBuffer: { ...DEFAULT_LINE_BUFFER_OPTIONS },
 } satisfies ResolvedSerialSessionOptions;
 
+/** Resolved W3C connection fields for {@link ResolvedSerialSessionOptions}. */
+export type ResolvedSerialSessionConnectionOptions =
+  Required<SerialSessionConnectionFields>;
+
+/**
+ * Merge and validate W3C connection fields from {@link SerialSessionOptions}.
+ *
+ * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_CONNECTION_OPTIONS}
+ *         when `baudRate` is out of range.
+ */
+export function resolveConnectionOptions(
+  options?: Pick<
+    SerialSessionOptions,
+    'baudRate' | 'dataBits' | 'stopBits' | 'parity' | 'bufferSize' | 'flowControl'
+  >,
+): ResolvedSerialSessionConnectionOptions {
+  const merged: ResolvedSerialSessionConnectionOptions = {
+    baudRate: DEFAULT_SERIAL_SESSION_OPTIONS.baudRate,
+    dataBits: DEFAULT_SERIAL_SESSION_OPTIONS.dataBits,
+    stopBits: DEFAULT_SERIAL_SESSION_OPTIONS.stopBits,
+    parity: DEFAULT_SERIAL_SESSION_OPTIONS.parity,
+    bufferSize: DEFAULT_SERIAL_SESSION_OPTIONS.bufferSize,
+    flowControl: DEFAULT_SERIAL_SESSION_OPTIONS.flowControl,
+    ...options,
+  };
+
+  const { baudRate } = merged;
+
+  if (!Number.isSafeInteger(baudRate) || baudRate <= 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_CONNECTION_OPTIONS,
+      `Invalid baudRate: ${baudRate}. Must be a safe integer > 0.`,
+    );
+  }
+
+  return merged;
+}
+
 /**
  * Merge and validate {@link SerialSessionOptions} into a fully resolved
  * options object for internal session use.
  *
- * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS}
- *         when `receiveReplay` values are out of range.
+ * @throws {@link SerialError} when option values are out of range:
+ *         {@link SerialErrorCode.INVALID_CONNECTION_OPTIONS},
+ *         {@link SerialErrorCode.INVALID_FILTER_OPTIONS},
+ *         {@link SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS},
+ *         {@link SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS}, or
+ *         {@link SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS}.
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/403 | Issue #403}
  */
 export function resolveSerialSessionOptions(
   options?: SerialSessionOptions,
 ): ResolvedSerialSessionOptions {
+  const connection = resolveConnectionOptions(options);
+
   return {
-    ...DEFAULT_SERIAL_SESSION_OPTIONS,
-    ...options,
+    ...connection,
+    filters: validateSerialPortFilters(options?.filters),
     receiveReplay: resolveReceiveReplayOptions(options?.receiveReplay),
     terminalBuffer: resolveTerminalBufferOptions(options?.terminalBuffer),
     lineBuffer: resolveLineBufferOptions(options?.lineBuffer),

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -171,6 +171,65 @@ export function resolveReceiveReplayOptions(
 }
 
 /**
+ * Merge and validate {@link TerminalBufferOptions}.
+ *
+ * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS}
+ *         when `maxLines` or `maxChars` are out of range.
+ */
+export function resolveTerminalBufferOptions(
+  options?: TerminalBufferOptions,
+): Required<TerminalBufferOptions> {
+  const merged: Required<TerminalBufferOptions> = {
+    ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
+    ...options,
+  };
+
+  const { maxLines, maxChars } = merged;
+
+  if (!Number.isSafeInteger(maxLines) || maxLines < 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
+      `Invalid terminalBuffer.maxLines: ${maxLines}. Must be a safe integer >= 0.`,
+    );
+  }
+
+  if (!Number.isSafeInteger(maxChars) || maxChars < 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
+      `Invalid terminalBuffer.maxChars: ${maxChars}. Must be a safe integer >= 0.`,
+    );
+  }
+
+  return merged;
+}
+
+/**
+ * Merge and validate {@link LineBufferOptions}.
+ *
+ * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS}
+ *         when `maxChars` is out of range.
+ */
+export function resolveLineBufferOptions(
+  options?: LineBufferOptions,
+): Required<LineBufferOptions> {
+  const merged: Required<LineBufferOptions> = {
+    ...DEFAULT_LINE_BUFFER_OPTIONS,
+    ...options,
+  };
+
+  const { maxChars } = merged;
+
+  if (!Number.isSafeInteger(maxChars) || maxChars < 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS,
+      `Invalid lineBuffer.maxChars: ${maxChars}. Must be a safe integer >= 0.`,
+    );
+  }
+
+  return merged;
+}
+
+/**
  * Fully resolved session options after merging {@link SerialSessionOptions}
  * with {@link DEFAULT_SERIAL_SESSION_OPTIONS}. All invariant fields are
  * required; `filters` remains optional.
@@ -215,13 +274,7 @@ export function resolveSerialSessionOptions(
     ...DEFAULT_SERIAL_SESSION_OPTIONS,
     ...options,
     receiveReplay: resolveReceiveReplayOptions(options?.receiveReplay),
-    terminalBuffer: {
-      ...DEFAULT_SERIAL_SESSION_OPTIONS.terminalBuffer,
-      ...options?.terminalBuffer,
-    },
-    lineBuffer: {
-      ...DEFAULT_SERIAL_SESSION_OPTIONS.lineBuffer,
-      ...options?.lineBuffer,
-    },
+    terminalBuffer: resolveTerminalBufferOptions(options?.terminalBuffer),
+    lineBuffer: resolveLineBufferOptions(options?.lineBuffer),
   };
 }

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -315,10 +315,11 @@ export function resolveSerialSessionOptions(
   options?: SerialSessionOptions,
 ): ResolvedSerialSessionOptions {
   const connection = resolveConnectionOptions(options);
+  const filters = validateSerialPortFilters(options?.filters);
 
   return {
     ...connection,
-    filters: validateSerialPortFilters(options?.filters),
+    ...(filters !== undefined ? { filters } : {}),
     receiveReplay: resolveReceiveReplayOptions(options?.receiveReplay),
     terminalBuffer: resolveTerminalBufferOptions(options?.terminalBuffer),
     lineBuffer: resolveLineBufferOptions(options?.lineBuffer),

--- a/packages/web-serial-rxjs/tests/errors/serial-error-code.test.ts
+++ b/packages/web-serial-rxjs/tests/errors/serial-error-code.test.ts
@@ -20,6 +20,15 @@ describe('SerialErrorCode', () => {
     expect(SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS).toBe(
       'INVALID_RECEIVE_REPLAY_OPTIONS',
     );
+    expect(SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS).toBe(
+      'INVALID_TERMINAL_BUFFER_OPTIONS',
+    );
+    expect(SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS).toBe(
+      'INVALID_LINE_BUFFER_OPTIONS',
+    );
+    expect(SerialErrorCode.INVALID_CONNECTION_OPTIONS).toBe(
+      'INVALID_CONNECTION_OPTIONS',
+    );
     expect(SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW).toBe(
       'RECEIVE_REPLAY_BUFFER_OVERFLOW',
     );

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -773,6 +773,30 @@ describe('createSerialSession', () => {
       }
     });
 
+    it('throws INVALID_CONNECTION_OPTIONS for invalid baudRate at factory time', () => {
+      expect(() => createSerialSession({ baudRate: -1 })).toThrow(SerialError);
+      try {
+        createSerialSession({ baudRate: 0 });
+      } catch (error) {
+        expect(error).toBeInstanceOf(SerialError);
+        expect((error as SerialError).code).toBe(
+          SerialErrorCode.INVALID_CONNECTION_OPTIONS,
+        );
+      }
+    });
+
+    it('throws INVALID_FILTER_OPTIONS for invalid filters at factory time', () => {
+      expect(() => createSerialSession({ filters: [{}] })).toThrow(SerialError);
+      try {
+        createSerialSession({ filters: [{ usbVendorId: -1 }] });
+      } catch (error) {
+        expect(error).toBeInstanceOf(SerialError);
+        expect((error as SerialError).code).toBe(
+          SerialErrorCode.INVALID_FILTER_OPTIONS,
+        );
+      }
+    });
+
     it('applies receiveReplay.maxChars from SerialSessionOptions', async () => {
       const { stream, controller } = makeStream();
       const port = makeMockPort(stream);

--- a/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
+++ b/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
@@ -102,6 +102,96 @@ describe('resolveSerialSessionOptions', () => {
     }
   });
 
+  it.each([
+    ['terminalBuffer.maxLines', { terminalBuffer: { maxLines: -1 } }],
+    ['terminalBuffer.maxLines', { terminalBuffer: { maxLines: 1.5 } }],
+    ['terminalBuffer.maxLines', { terminalBuffer: { maxLines: NaN } }],
+    ['terminalBuffer.maxChars', { terminalBuffer: { maxChars: -1 } }],
+    ['terminalBuffer.maxChars', { terminalBuffer: { maxChars: 1.5 } }],
+    ['terminalBuffer.maxChars', { terminalBuffer: { maxChars: NaN } }],
+  ])('rejects invalid %s', (_field, options) => {
+    expect(() => resolveSerialSessionOptions(options)).toThrow(SerialError);
+    try {
+      resolveSerialSessionOptions(options);
+    } catch (error) {
+      expect(error).toBeInstanceOf(SerialError);
+      expect((error as SerialError).code).toBe(
+        SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
+      );
+    }
+  });
+
+  it('accepts terminalBuffer zero limits as unlimited', () => {
+    expect(
+      resolveSerialSessionOptions({
+        terminalBuffer: { maxLines: 0, maxChars: 0 },
+      }).terminalBuffer,
+    ).toEqual({ maxLines: 0, maxChars: 0 });
+  });
+
+  it.each([
+    ['lineBuffer.maxChars', { lineBuffer: { maxChars: -1 } }],
+    ['lineBuffer.maxChars', { lineBuffer: { maxChars: 1.5 } }],
+    ['lineBuffer.maxChars', { lineBuffer: { maxChars: NaN } }],
+  ])('rejects invalid %s', (_field, options) => {
+    expect(() => resolveSerialSessionOptions(options)).toThrow(SerialError);
+    try {
+      resolveSerialSessionOptions(options);
+    } catch (error) {
+      expect(error).toBeInstanceOf(SerialError);
+      expect((error as SerialError).code).toBe(
+        SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS,
+      );
+    }
+  });
+
+  it('accepts lineBuffer zero maxChars as unlimited', () => {
+    expect(
+      resolveSerialSessionOptions({ lineBuffer: { maxChars: 0 } }).lineBuffer,
+    ).toEqual({ maxChars: 0 });
+  });
+
+  it.each([
+    ['filters', { filters: [{}] }],
+    ['filters', { filters: [{ usbVendorId: -1 }] }],
+    ['filters', { filters: [{ usbVendorId: 0x10000 }] }],
+    ['filters', { filters: [{ usbProductId: -1 }] }],
+    ['filters', { filters: [{ usbProductId: 0x10000 }] }],
+  ])('rejects invalid %s', (_field, options) => {
+    expect(() => resolveSerialSessionOptions(options)).toThrow(SerialError);
+    try {
+      resolveSerialSessionOptions(options);
+    } catch (error) {
+      expect(error).toBeInstanceOf(SerialError);
+      expect((error as SerialError).code).toBe(
+        SerialErrorCode.INVALID_FILTER_OPTIONS,
+      );
+    }
+  });
+
+  it.each([
+    ['baudRate', { baudRate: 0 }],
+    ['baudRate', { baudRate: -1 }],
+    ['baudRate', { baudRate: 1.5 }],
+    ['baudRate', { baudRate: NaN }],
+  ])('rejects invalid %s', (_field, options) => {
+    expect(() => resolveSerialSessionOptions(options)).toThrow(SerialError);
+    try {
+      resolveSerialSessionOptions(options);
+    } catch (error) {
+      expect(error).toBeInstanceOf(SerialError);
+      expect((error as SerialError).code).toBe(
+        SerialErrorCode.INVALID_CONNECTION_OPTIONS,
+      );
+    }
+  });
+
+  it('accepts valid baudRate values', () => {
+    expect(resolveSerialSessionOptions({ baudRate: 115200 }).baudRate).toBe(
+      115200,
+    );
+  });
+
   it('accepts representative SerialSessionOptions shapes', () => {
     const emptyOptions: SerialSessionOptions = {};
     const partialConnectionOptions: SerialSessionOptions = { baudRate: 115200 };

--- a/packages/web-serial-rxjs/tests/session/validate-serial-port-filters.test.ts
+++ b/packages/web-serial-rxjs/tests/session/validate-serial-port-filters.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { validateSerialPortFilters } from '../../src/session/internal/validate-serial-port-filters';
+
+describe('validateSerialPortFilters', () => {
+  it('returns undefined when filters are omitted', () => {
+    expect(validateSerialPortFilters(undefined)).toBeUndefined();
+  });
+
+  it('returns empty array when filters are empty', () => {
+    expect(validateSerialPortFilters([])).toEqual([]);
+  });
+
+  it('returns valid filters unchanged', () => {
+    const filters = [{ usbVendorId: 0x1234, usbProductId: 0x5678 }];
+    expect(validateSerialPortFilters(filters)).toBe(filters);
+  });
+
+  it.each([
+    [{}],
+    [{ usbVendorId: -1 }],
+    [{ usbVendorId: 0x10000 }],
+    [{ usbProductId: -1 }],
+    [{ usbProductId: 0x10000 }],
+  ])('rejects invalid filter %j', (filter) => {
+    expect(() => validateSerialPortFilters([filter])).toThrow(SerialError);
+    try {
+      validateSerialPortFilters([filter]);
+    } catch (error) {
+      expect(error).toBeInstanceOf(SerialError);
+      expect((error as SerialError).code).toBe(
+        SerialErrorCode.INVALID_FILTER_OPTIONS,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
`resolveSerialSessionOptions` に options バリデーションを統一し、JS から渡された不正値を `createSerialSession` factory 時点で `SerialError` として検出できるようにした。これにより `receiveReplay` のみ factory 検証、`filters` のみ connect 検証という非対称を解消する。

## Type of change
- [x] New feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #403
- Parent: #391

## What changed?
- `INVALID_TERMINAL_BUFFER_OPTIONS` / `INVALID_LINE_BUFFER_OPTIONS` / `INVALID_CONNECTION_OPTIONS` を追加
- `resolveTerminalBufferOptions` / `resolveLineBufferOptions` / `validateSerialPortFilters` / `resolveConnectionOptions` を追加
- `resolveSerialSessionOptions` で全対象を factory 時に検証
- `buildRequestOptions` から filter 検証を除去（resolver に集約）
- 不正値テストと API ドキュメントを更新

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `createSerialSession` が factory 時に追加の `SerialErrorCode` を throw する可能性がある（non-breaking: 以前 connect 時または silent accept だった不正値を早期 fail に変更）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

## How to test
1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build`
3. `pnpm exec nx run web-serial-rxjs:verify:dist`
4. ブラウザ console で `createSerialSession({ baudRate: -1 })` が即 throw することを確認

## Environment (if relevant)
- N/A（factory 時 validation の単体・結合テストで確認）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)