### PR TITLE
feat(web-serial-rxjs): add typed error context map to SerialError

### DIFF
--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -195,7 +195,14 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 
 ## SerialError / SerialErrorCode
 
-`SerialError` は `Error` を継承し、`code: SerialErrorCode` と任意の `originalError: Error` を持ちます。`is(code): boolean` で簡潔にコード判定できます。
+`SerialError` は `Error` を継承し、`code: SerialErrorCode`、任意の `originalError: Error`、および code 別の構造化メタデータ `context` を持ちます。`is(code)` は `code` と `context` を literal 型に narrow します。`originalError` は後方互換のため残されていますが、cause 系コードでは `context.cause` を優先してください。
+
+| Code                     | `context` の形 | emit されるタイミング                                              |
+| ------------------------ | -------------- | ------------------------------------------------------------------ |
+| `LINE_BUFFER_OVERFLOW`   | `{ maxChars: number }` | `lines$` の未完成 tail が `lineBuffer.maxChars` を超過。先頭データを破棄（non-fatal） |
+| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `{ maxChars: number; bufferSize: number }` | `receiveReplay$` バッファが `receiveReplay` の上限を超過。古いチャンクを破棄（non-fatal） |
+| `PORT_OPEN_FAILED` など cause 系 | `{ cause: unknown }` | 下表の各タイミング。`originalError` も同期して保持 |
+| その他                   | `undefined`    | 下表の各タイミング                                                 |
 
 | Code                     | emit されるタイミング                                              |
 | ------------------------ | ------------------------------------------------------------------ |
@@ -206,8 +213,6 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 | `PORT_NOT_OPEN`          | 許可されない状態で `send$` / `disconnect$` を呼んだ                |
 | `READ_FAILED`            | 内部 read pump でエラーが発生                                      |
 | `WRITE_FAILED`           | `port.writable.getWriter().write()` が reject                      |
-| `LINE_BUFFER_OVERFLOW`   | `lines$` の未完成 tail が `lineBuffer.maxChars` を超過。先頭データを破棄（non-fatal） |
-| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` バッファが `receiveReplay` の上限を超過。古いチャンクを破棄（non-fatal） |
 | `CONNECTION_LOST`        | `port.close()` 失敗または接続中に切断                              |
 | `INVALID_FILTER_OPTIONS` | `filters` に不正な値が含まれる（セッション生成時）                 |
 | `INVALID_RECEIVE_REPLAY_OPTIONS` | `receiveReplay.bufferSize` または `receiveReplay.maxChars` が範囲外（セッション生成時） |

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -195,7 +195,14 @@ Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a
 
 ## SerialError / SerialErrorCode
 
-`SerialError` extends `Error` with a `code: SerialErrorCode` and an optional `originalError: Error`. It exposes `is(code): boolean` for ergonomic comparison.
+`SerialError` extends `Error` with a `code: SerialErrorCode`, an optional `originalError: Error`, and structured per-code metadata on `context`. `is(code)` narrows both `code` and `context` to the literal types for that code. `originalError` is retained for backward compatibility; prefer `context.cause` for cause-bearing codes.
+
+| Code                     | `context` shape | When it is emitted                                                  |
+| ------------------------ | --------------- | ------------------------------------------------------------------- |
+| `LINE_BUFFER_OVERFLOW`   | `{ maxChars: number }` | `lines$` incomplete tail exceeded `lineBuffer.maxChars`; leading data discarded (non-fatal). |
+| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `{ maxChars: number; bufferSize: number }` | `receiveReplay$` buffer exceeded `receiveReplay` limits; oldest chunks discarded (non-fatal). |
+| Cause-bearing codes (e.g. `PORT_OPEN_FAILED`) | `{ cause: unknown }` | See table below. `originalError` is kept in sync. |
+| Other codes              | `undefined`     | See table below.                                                    |
 
 | Code                     | When it is emitted                                                  |
 | ------------------------ | ------------------------------------------------------------------- |
@@ -206,8 +213,6 @@ Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a
 | `PORT_NOT_OPEN`          | `send$` called while not `'connected'`.                             |
 | `READ_FAILED`            | Internal read pump errored.                                         |
 | `WRITE_FAILED`           | `port.writable.getWriter().write()` rejected.                       |
-| `LINE_BUFFER_OVERFLOW`   | `lines$` incomplete tail exceeded `lineBuffer.maxChars`; leading data discarded (non-fatal). |
-| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` buffer exceeded `receiveReplay` limits; oldest chunks discarded (non-fatal). |
 | `CONNECTION_LOST`        | `port.close()` failed or the port dropped mid-session.              |
 | `INVALID_FILTER_OPTIONS` | `filters` contained an invalid entry (at session creation).         |
 | `INVALID_RECEIVE_REPLAY_OPTIONS` | `receiveReplay.bufferSize` or `receiveReplay.maxChars` was out of range at session creation. |

--- a/packages/web-serial-rxjs/src/errors/serial-error-context.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error-context.ts
@@ -1,0 +1,65 @@
+import { SerialErrorCode } from './serial-error-code';
+
+/**
+ * Context payload for errors that wrap an underlying failure.
+ */
+export type SerialErrorCauseContext = {
+  readonly cause: unknown;
+};
+
+/**
+ * Maps each {@link SerialErrorCode} to its structured context shape.
+ *
+ * Codes mapped to `undefined` have no machine-readable metadata beyond
+ * {@link SerialError.message}. Overflow codes expose configured limits so
+ * callers do not need to parse error messages.
+ */
+export interface SerialErrorContextMap {
+  [SerialErrorCode.BROWSER_NOT_SUPPORTED]: undefined;
+  [SerialErrorCode.PORT_NOT_AVAILABLE]: SerialErrorCauseContext;
+  [SerialErrorCode.PORT_OPEN_FAILED]: SerialErrorCauseContext;
+  [SerialErrorCode.PORT_ALREADY_OPEN]: undefined;
+  [SerialErrorCode.PORT_NOT_OPEN]: undefined;
+  [SerialErrorCode.READ_FAILED]: SerialErrorCauseContext;
+  [SerialErrorCode.WRITE_FAILED]: SerialErrorCauseContext;
+  [SerialErrorCode.CONNECTION_LOST]: SerialErrorCauseContext;
+  [SerialErrorCode.INVALID_FILTER_OPTIONS]: undefined;
+  [SerialErrorCode.OPERATION_CANCELLED]: SerialErrorCauseContext;
+  [SerialErrorCode.OPERATION_TIMEOUT]: undefined;
+  [SerialErrorCode.LINE_BUFFER_OVERFLOW]: {
+    readonly maxChars: number;
+  };
+  [SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS]: undefined;
+  [SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS]: undefined;
+  [SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS]: undefined;
+  [SerialErrorCode.INVALID_CONNECTION_OPTIONS]: undefined;
+  [SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW]: {
+    readonly maxChars: number;
+    readonly bufferSize: number;
+  };
+  [SerialErrorCode.SESSION_DISPOSED]: undefined;
+  [SerialErrorCode.UNKNOWN]: SerialErrorCauseContext;
+}
+
+const CAUSE_CONTEXT_CODES = new Set<SerialErrorCode>([
+  SerialErrorCode.PORT_NOT_AVAILABLE,
+  SerialErrorCode.PORT_OPEN_FAILED,
+  SerialErrorCode.READ_FAILED,
+  SerialErrorCode.WRITE_FAILED,
+  SerialErrorCode.CONNECTION_LOST,
+  SerialErrorCode.OPERATION_CANCELLED,
+  SerialErrorCode.UNKNOWN,
+]);
+
+/**
+ * @internal
+ */
+export function isCauseContextCode(
+  code: SerialErrorCode,
+): code is keyof {
+  [K in keyof SerialErrorContextMap as SerialErrorContextMap[K] extends SerialErrorCauseContext
+    ? K
+    : never]: SerialErrorContextMap[K];
+} {
+  return CAUSE_CONTEXT_CODES.has(code);
+}

--- a/packages/web-serial-rxjs/src/errors/serial-error.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error.ts
@@ -1,7 +1,13 @@
 import { SerialErrorCode } from './serial-error-code';
+import {
+  isCauseContextCode,
+  type SerialErrorCauseContext,
+  type SerialErrorContextMap,
+} from './serial-error-context';
 
 // Re-export SerialErrorCode for convenience
 export { SerialErrorCode };
+export type { SerialErrorCauseContext, SerialErrorContextMap };
 
 /**
  * Custom error class for serial port operations.
@@ -22,6 +28,10 @@ export { SerialErrorCode };
  *       console.error(`Original error:`, error.originalError);
  *     }
  *
+ *     if (error.is(SerialErrorCode.LINE_BUFFER_OVERFLOW)) {
+ *       console.error(`maxChars: ${error.context.maxChars}`);
+ *     }
+ *
  *     // Check specific error code
  *     if (error.is(SerialErrorCode.BROWSER_NOT_SUPPORTED)) {
  *       // Handle browser not supported
@@ -30,7 +40,9 @@ export { SerialErrorCode };
  * }
  * ```
  */
-export class SerialError extends Error {
+export class SerialError<
+  TCode extends SerialErrorCode = SerialErrorCode,
+> extends Error {
   /**
    * The error code identifying the type of error that occurred.
    *
@@ -38,13 +50,25 @@ export class SerialError extends Error {
    *
    * @see {@link SerialErrorCode} for all available error codes
    */
-  public readonly code: SerialErrorCode;
+  public readonly code: TCode;
+
+  /**
+   * Structured metadata associated with {@link code}.
+   *
+   * When {@link is} returns `true`, TypeScript narrows this property to the
+   * context shape defined in {@link SerialErrorContextMap} for that code.
+   */
+  public readonly context: SerialErrorContextMap[TCode];
 
   /**
    * The original error that caused this SerialError, if available.
    *
    * This property contains the underlying error (e.g., DOMException, TypeError)
    * that was wrapped in this SerialError. It may be undefined if no original error exists.
+   *
+   * @deprecated Prefer {@link context} for cause-bearing codes. This property is
+   *   retained for backward compatibility and is kept in sync when a cause is
+   *   provided.
    */
   public readonly originalError?: Error;
 
@@ -54,13 +78,31 @@ export class SerialError extends Error {
    * @param code - The error code identifying the type of error
    * @param message - A human-readable error message
    * @param originalError - The original error that caused this SerialError, if any
+   * @param context - Structured metadata for the error code. When omitted, cause-bearing
+   *   codes derive `{ cause }` from `originalError`.
    */
-  constructor(code: SerialErrorCode, message: string, originalError?: Error) {
+  constructor(
+    code: TCode,
+    message: string,
+    originalError?: Error,
+    context?: SerialErrorContextMap[TCode],
+  ) {
     super(message);
     this.name = 'SerialError';
     this.code = code;
     if (originalError !== undefined) {
       this.originalError = originalError;
+    }
+
+    if (context !== undefined) {
+      this.context = context;
+    } else if (
+      originalError !== undefined &&
+      isCauseContextCode(code)
+    ) {
+      this.context = { cause: originalError } as SerialErrorContextMap[TCode];
+    } else {
+      this.context = undefined as SerialErrorContextMap[TCode];
     }
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
@@ -76,22 +118,23 @@ export class SerialError extends Error {
    *
    * This is a convenience method for checking the error code without directly
    * comparing the code property. When this method returns `true`, TypeScript
-   * narrows `this.code` to the literal type of the provided `code` argument.
+   * narrows `this.code` and `this.context` to the shapes defined for the
+   * provided `code` argument.
    *
    * @param code - The error code to check against
    * @returns Type predicate: `true` if this error's code matches the provided
-   *   code (and `this.code` is narrowed to that literal type), `false` otherwise
+   *   code (and `this.code` / `this.context` are narrowed), `false` otherwise
    *
    * @example
    * ```typescript
-   * if (error.is(SerialErrorCode.PORT_NOT_OPEN)) {
-   *   // error.code is narrowed to SerialErrorCode.PORT_NOT_OPEN
+   * if (error.is(SerialErrorCode.LINE_BUFFER_OVERFLOW)) {
+   *   // error.code and error.context.maxChars are narrowed
    * }
    * ```
    */
   public is<C extends SerialErrorCode>(
     code: C,
-  ): this is SerialError & { readonly code: C } {
-    return this.code === code;
+  ): this is SerialError<C> {
+    return (this.code as SerialErrorCode) === code;
   }
 }

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -23,6 +23,7 @@
  * - {@link SerialConnectionOptions} - `port.open` connection parameters (excluding filters)
  * - {@link SerialSessionState} - `state$` payload values (const + type)
  * - {@link SerialError} / {@link SerialErrorCode} - unified error surface
+ * - {@link SerialErrorContextMap} - structured metadata per error code
  *
  * ## Browser Support
  *
@@ -74,6 +75,7 @@ export type {
 } from './session';
 
 export { SerialError } from './errors/serial-error';
+export type { SerialErrorCauseContext, SerialErrorContextMap } from './errors/serial-error';
 export { SerialErrorCode } from './errors/serial-error-code';
 
 export { createTerminalBuffer, DEFAULT_TERMINAL_BUFFER_OPTIONS } from './terminal/create-terminal-buffer';

--- a/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
+++ b/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
@@ -107,7 +107,12 @@ export function createReceivePipeline(
         reportError(
           new SerialError(
             SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
-            `Receive replay buffer exceeded configured limits; oldest chunks were discarded`,
+            'Receive replay buffer exceeded configured limits; oldest chunks were discarded',
+            undefined,
+            {
+              maxChars: resolvedOptions.receiveReplay.maxChars,
+              bufferSize: resolvedOptions.receiveReplay.bufferSize,
+            },
           ),
           {
             fallbackCode: SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
@@ -120,7 +125,9 @@ export function createReceivePipeline(
       reportError(
         new SerialError(
           SerialErrorCode.LINE_BUFFER_OVERFLOW,
-          `Line buffer exceeded maxChars (${resolvedOptions.lineBuffer.maxChars}); leading data was discarded`,
+          'Line buffer exceeded maxChars; leading data was discarded',
+          undefined,
+          { maxChars: resolvedOptions.lineBuffer.maxChars },
         ),
         { fallbackCode: SerialErrorCode.LINE_BUFFER_OVERFLOW },
       );

--- a/packages/web-serial-rxjs/tests/errors/serial-error.test.ts
+++ b/packages/web-serial-rxjs/tests/errors/serial-error.test.ts
@@ -15,9 +15,10 @@ describe('SerialError', () => {
       expect(error.code).toBe(SerialErrorCode.PORT_NOT_AVAILABLE);
       expect(error.message).toBe('Port is not available');
       expect(error.originalError).toBeUndefined();
+      expect(error.context).toBeUndefined();
     });
 
-    it('should create an error with original error', () => {
+    it('should derive cause context from originalError for cause-bearing codes', () => {
       const originalError = new Error('Original error');
       const error = new SerialError(
         SerialErrorCode.READ_FAILED,
@@ -28,6 +29,19 @@ describe('SerialError', () => {
       expect(error.code).toBe(SerialErrorCode.READ_FAILED);
       expect(error.message).toBe('Failed to read');
       expect(error.originalError).toBe(originalError);
+      expect(error.context).toEqual({ cause: originalError });
+    });
+
+    it('should accept explicit structured context', () => {
+      const error = new SerialError(
+        SerialErrorCode.LINE_BUFFER_OVERFLOW,
+        'Line buffer overflow',
+        undefined,
+        { maxChars: 128 },
+      );
+
+      expect(error.context).toEqual({ maxChars: 128 });
+      expect(error.originalError).toBeUndefined();
     });
 
     it('should have correct error name', () => {
@@ -64,6 +78,22 @@ describe('SerialError', () => {
       );
 
       expect(error.is(SerialErrorCode.PORT_ALREADY_OPEN)).toBe(false);
+    });
+
+    it('should narrow error.code and context when is() returns true', () => {
+      const error = new SerialError(
+        SerialErrorCode.LINE_BUFFER_OVERFLOW,
+        'Line buffer overflow',
+        undefined,
+        { maxChars: 64 },
+      );
+
+      if (error.is(SerialErrorCode.LINE_BUFFER_OVERFLOW)) {
+        expect(error.code).toBe(SerialErrorCode.LINE_BUFFER_OVERFLOW);
+        expect(error.context.maxChars).toBe(64);
+      } else {
+        expect.fail('is() should have returned true');
+      }
     });
 
     it('should narrow error.code when is() returns true', () => {
@@ -124,6 +154,7 @@ describe('SerialError', () => {
       );
 
       expect(error.originalError).toBe(originalError);
+      expect(error.context).toEqual({ cause: originalError });
       expect(error.originalError?.message).toBe('Type error');
       expect(error.originalError).toBeInstanceOf(TypeError);
     });

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -840,6 +840,7 @@ describe('createSerialSession', () => {
 
       const error = await errorPromise;
       expect(error.code).toBe(SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW);
+      expect(error.context).toEqual({ maxChars: 4, bufferSize: 10 });
     });
 
     it('does not mutate state$ when receive replay overflows (non-fatal)', async () => {
@@ -972,6 +973,7 @@ describe('createSerialSession', () => {
 
       const error = await errorPromise;
       expect(error.code).toBe(SerialErrorCode.LINE_BUFFER_OVERFLOW);
+      expect(error.context).toEqual({ maxChars: 4 });
     });
 
     it('does not mutate state$ when line buffer overflows (non-fatal)', async () => {

--- a/packages/web-serial-rxjs/tests/session/normalize-serial-error.test.ts
+++ b/packages/web-serial-rxjs/tests/session/normalize-serial-error.test.ts
@@ -27,6 +27,7 @@ describe('normalizeSerialError', () => {
     expect(normalized).toBeInstanceOf(SerialError);
     expect(normalized.code).toBe(SerialErrorCode.OPERATION_CANCELLED);
     expect(normalized.originalError).toBe(dom);
+    expect(normalized.context).toEqual({ cause: dom });
   });
 
   it('wraps arbitrary Error instances using the provided fallback code', () => {
@@ -40,6 +41,7 @@ describe('normalizeSerialError', () => {
     expect(normalized.code).toBe(SerialErrorCode.PORT_OPEN_FAILED);
     expect(normalized.message).toBe('Failed to open port: cannot open');
     expect(normalized.originalError).toBe(cause);
+    expect(normalized.context).toEqual({ cause });
   });
 
   it('wraps non-Error values into Error causes so originalError is always an Error', () => {


### PR DESCRIPTION
## Summary
`SerialError` に code 別の構造化メタデータ `context` を追加し、overflow 系エラーで `maxChars` 等を型安全に取得できるようにしました。`is()` は `code` と `context` を narrow します。`originalError` は後方互換のため維持しています。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #404
- Parent: #391

## What changed?
- `SerialErrorContextMap` 型を追加し、各 `SerialErrorCode` に対応する context 形状を定義
- `SerialError` に `context` プロパティを追加（cause 系は `originalError` から自動導出）
- `is()` の type predicate を拡張し、`context` も narrow するよう変更
- `LINE_BUFFER_OVERFLOW` / `RECEIVE_REPLAY_BUFFER_OVERFLOW` で構造化 context を emit
- テストと API リファレンス（日英）を更新

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialError.context` と `SerialErrorContextMap` を公開 export。constructor の既存 3 引数シグネチャは維持（第 4 引数で明示 context を渡せる）。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: なし（`originalError` は残存。v3 での削除は #405 以降で検討）

## How to test
1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build`
3. `pnpm --filter @gurezo/web-serial-rxjs run verify:dist`
4. overflow テストで `error.context.maxChars` / `bufferSize` が期待値と一致することを確認

## Environment (if relevant)
- 該当なし（型とエラー構造の変更のみ）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)