### PR TITLE
refactor(web-serial-rxjs): migrate SerialErrorCode to const object pattern

### DIFF
--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -197,6 +197,8 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 
 `SerialError` は `Error` を継承し、`code: SerialErrorCode`、任意の `originalError: Error`、および code 別の構造化メタデータ `context` を持ちます。`is(code)` は `code` と `context` を literal 型に narrow します。`originalError` は後方互換のため残されていますが、cause 系コードでは `context.cause` を優先してください。
 
+上記と同じ文字列のユニオン型に加え、**定数オブジェクト** `SerialErrorCode`（例: `SerialErrorCode.READ_FAILED` は `'READ_FAILED'`）が export され、補完やタイポ防止に使えます。従来どおり文字列リテラルで型注釈・比較しても問題ありません。enum から const object への宣言変更は [v3 移行ガイド](./MIGRATION_V3.ja.md) を参照してください。
+
 | Code                     | `context` の形 | emit されるタイミング                                              |
 | ------------------------ | -------------- | ------------------------------------------------------------------ |
 | `LINE_BUFFER_OVERFLOW`   | `{ maxChars: number }` | `lines$` の未完成 tail が `lineBuffer.maxChars` を超過。先頭データを破棄（non-fatal） |

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -197,6 +197,8 @@ Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a
 
 `SerialError` extends `Error` with a `code: SerialErrorCode`, an optional `originalError: Error`, and structured per-code metadata on `context`. `is(code)` narrows both `code` and `context` to the literal types for that code. `originalError` is retained for backward compatibility; prefer `context.cause` for cause-bearing codes.
 
+The same union is available as a **const object** `SerialErrorCode` (e.g. `SerialErrorCode.READ_FAILED` is `'READ_FAILED'`) for IDE completion and to avoid string typos. String literals stay valid for types and runtime comparisons. See [Migrating to v3](./MIGRATION_V3.md) for the enum-to-const declaration change.
+
 | Code                     | `context` shape | When it is emitted                                                  |
 | ------------------------ | --------------- | ------------------------------------------------------------------- |
 | `LINE_BUFFER_OVERFLOW`   | `{ maxChars: number }` | `lines$` incomplete tail exceeded `lineBuffer.maxChars`; leading data discarded (non-fatal). |

--- a/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V2.ja.md
@@ -45,7 +45,7 @@ session.send$('hi').subscribe();
 | `readableToObservable`            | 不要。`receive$` がストリームを提供します                        |
 | `buildRequestOptions`             | `createSerialSession` に `filters` を渡すだけで OK               |
 
-`SerialError` と `SerialErrorCode` は v1 と同一です。
+`SerialError` と `SerialErrorCode` は v2 では v1 と同一です。v3 では `SerialErrorCode` が const object + 型エイリアスへ変わります（[v3 移行ガイド](./MIGRATION_V3.ja.md) を参照）。ランタイムのメンバー名と値は不変です。
 
 ## メソッド／フィールド対応表
 

--- a/packages/web-serial-rxjs/docs/MIGRATION_V2.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V2.md
@@ -45,7 +45,7 @@ The following v1 exports are **deleted** and no compatibility shim is provided.
 | `readableToObservable`            | Not needed; `receive$` is the stream                             |
 | `buildRequestOptions`             | Pass `filters` to `createSerialSession` directly                 |
 
-`SerialError` and `SerialErrorCode` are unchanged.
+`SerialError` and `SerialErrorCode` are unchanged in v2. In v3, `SerialErrorCode` becomes a const object + type alias (see [Migrating to v3](./MIGRATION_V3.md)); runtime member names and values stay the same.
 
 ## Method / field mapping
 

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
@@ -1,0 +1,94 @@
+# v3 への移行（`SerialErrorCode` const object）
+
+v3 では `SerialErrorCode` の TypeScript 上の宣言方法が変わります。**ランタイムの値とメンバー名は不変**です — `SerialErrorCode.READ_FAILED` は引き続き文字列 `'READ_FAILED'` です。
+
+本ガイドでは変更点と、必要に応じて更新すべき箇所を説明します。
+
+## TL;DR
+
+```typescript
+// v2 も v3 も — 典型的な使い方は変更不要
+import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
+
+session.errors$.subscribe((error) => {
+  if (error.is(SerialErrorCode.READ_FAILED)) {
+    console.error(error.context.cause);
+  }
+});
+```
+
+## 変更内容
+
+| v2 | v3 |
+| --- | --- |
+| `export enum SerialErrorCode { ... }` | `export const SerialErrorCode = { ... } as const` + `export type SerialErrorCode` |
+| TypeDoc: `enums/SerialErrorCode.html` | TypeDoc: `variables/SerialErrorCode.html` |
+
+`SerialError`、`SerialErrorContextMap`、`SerialSessionState` は本変更の対象外です。
+
+## 移行不要（典型的なパターン）
+
+以下は v2 と v3 で同じように動作します:
+
+- `SerialErrorCode.BROWSER_NOT_SUPPORTED`（他のメンバーも同様）
+- `error.code === SerialErrorCode.WRITE_FAILED`
+- `error.is(SerialErrorCode.LINE_BUFFER_OVERFLOW)` による `context` の narrowing
+- `switch (error.code) { case SerialErrorCode.READ_FAILED: ... }`
+- `Object.values(SerialErrorCode)`（文字列値のみを返す）
+
+## 更新が必要な場合
+
+### 型のみの import
+
+型だけ import する場合は従来どおり:
+
+```typescript
+import type { SerialErrorCode } from '@gurezo/web-serial-rxjs';
+```
+
+型は enum 型から string literal union へ変わりますが、多くのアプリではそのまま置き換え可能です。
+
+### enum 固有の挙動に依存していたコード
+
+以下に依存している場合は見直しが必要です:
+
+- **enum の reverse mapping** — string enum には reverse mapping はなく、const object も同様です。
+- **任意の文字列の代入** — `const code: SerialErrorCode = someString` は引き続き既知のコード文字列である必要があります。
+- **TypeDoc の深いリンク** — ブックマークを `enums/SerialErrorCode.html` から `variables/SerialErrorCode.html` へ更新してください。
+
+### `.d.ts` の宣言形
+
+公開型は `enum SerialErrorCode` から次の形へ変わります:
+
+```typescript
+export declare const SerialErrorCode: {
+  readonly BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED';
+  // ...
+};
+export type SerialErrorCode =
+  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+```
+
+`.d.ts` を解析して `enum` 宣言を期待するツールは調整が必要な場合があります。ランタイムのバンドルは同等です。
+
+## `SerialSessionState` との統一
+
+v3 では、すでに `SerialSessionState` で採用しているパターンを `SerialErrorCode` にも適用します:
+
+```typescript
+export const SerialErrorCode = {
+  BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED',
+  READ_FAILED: 'READ_FAILED',
+  // ...
+} as const;
+
+export type SerialErrorCode =
+  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+```
+
+メンバー名は `SCREAMING_SNAKE_CASE` のままです（`SerialSessionState` の PascalCase キーとは意図的に異なります）。既存の `SerialErrorCode.X` 参照を壊しません。
+
+## 関連ドキュメント
+
+- [v1 から v2 への移行](./MIGRATION_V2.ja.md)
+- [API リファレンス – SerialError / SerialErrorCode](./API_REFERENCE.ja.md#serialerror--serialerrorcode)

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.md
@@ -1,0 +1,94 @@
+# Migrating to v3 (`SerialErrorCode` const object)
+
+v3 changes how `SerialErrorCode` is declared in TypeScript. **Runtime values and member names are unchanged** — `SerialErrorCode.READ_FAILED` is still the string `'READ_FAILED'`.
+
+This guide covers what changed and what (if anything) you need to update.
+
+## TL;DR
+
+```typescript
+// v2 and v3 — no change required for typical usage
+import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
+
+session.errors$.subscribe((error) => {
+  if (error.is(SerialErrorCode.READ_FAILED)) {
+    console.error(error.context.cause);
+  }
+});
+```
+
+## What changed
+
+| v2 | v3 |
+| --- | --- |
+| `export enum SerialErrorCode { ... }` | `export const SerialErrorCode = { ... } as const` + `export type SerialErrorCode` |
+| TypeDoc: `enums/SerialErrorCode.html` | TypeDoc: `variables/SerialErrorCode.html` |
+
+`SerialError`, `SerialErrorContextMap`, and `SerialSessionState` are not affected by this change.
+
+## No migration needed (typical patterns)
+
+These patterns work the same in v2 and v3:
+
+- `SerialErrorCode.BROWSER_NOT_SUPPORTED` (and any other member)
+- `error.code === SerialErrorCode.WRITE_FAILED`
+- `error.is(SerialErrorCode.LINE_BUFFER_OVERFLOW)` with narrowed `context`
+- `switch (error.code) { case SerialErrorCode.READ_FAILED: ... }`
+- `Object.values(SerialErrorCode)` (returns string values only)
+
+## When you may need to update
+
+### Type-only imports
+
+If you import `SerialErrorCode` as a type only, continue using:
+
+```typescript
+import type { SerialErrorCode } from '@gurezo/web-serial-rxjs';
+```
+
+The type is now a string literal union instead of an enum type. For most apps this is a drop-in replacement.
+
+### Code that depended on enum-specific behaviour
+
+Update if you relied on:
+
+- **Enum reverse mapping** — string enums never had reverse mapping; const object behaves the same.
+- **Assigning arbitrary strings** — `const code: SerialErrorCode = someString` still requires the string to match a known code.
+- **TypeDoc deep links** — update bookmarks from `enums/SerialErrorCode.html` to `variables/SerialErrorCode.html`.
+
+### Declaration shape in `.d.ts`
+
+Published types change from `enum SerialErrorCode` to:
+
+```typescript
+export declare const SerialErrorCode: {
+  readonly BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED';
+  // ...
+};
+export type SerialErrorCode =
+  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+```
+
+Tools that parse `.d.ts` and expect an `enum` declaration may need adjustment. Runtime bundles are equivalent.
+
+## Alignment with `SerialSessionState`
+
+v3 applies the same pattern already used by `SerialSessionState`:
+
+```typescript
+export const SerialErrorCode = {
+  BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED',
+  READ_FAILED: 'READ_FAILED',
+  // ...
+} as const;
+
+export type SerialErrorCode =
+  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+```
+
+Member names stay `SCREAMING_SNAKE_CASE` (unlike `SerialSessionState`'s PascalCase keys) so existing `SerialErrorCode.X` references remain valid.
+
+## See also
+
+- [Migrating from v1 to v2](./MIGRATION_V2.md)
+- [API Reference – SerialError / SerialErrorCode](./API_REFERENCE.md#serialerror--serialerrorcode)

--- a/packages/web-serial-rxjs/src/errors/serial-error-code.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error-code.ts
@@ -24,7 +24,7 @@
  * }
  * ```
  */
-export enum SerialErrorCode {
+export const SerialErrorCode = {
   /**
    * Browser does not support the Web Serial API.
    *
@@ -34,7 +34,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Inform the user to use a supported browser.
    */
-  BROWSER_NOT_SUPPORTED = 'BROWSER_NOT_SUPPORTED',
+  BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED',
 
   /**
    * Serial port is not available.
@@ -45,7 +45,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Check if the port is available or being used by another application.
    */
-  PORT_NOT_AVAILABLE = 'PORT_NOT_AVAILABLE',
+  PORT_NOT_AVAILABLE: 'PORT_NOT_AVAILABLE',
 
   /**
    * Failed to open the serial port.
@@ -55,7 +55,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Verify connection parameters and check hardware connections.
    */
-  PORT_OPEN_FAILED = 'PORT_OPEN_FAILED',
+  PORT_OPEN_FAILED: 'PORT_OPEN_FAILED',
 
   /**
    * Serial port is already open.
@@ -65,7 +65,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Disconnect the current port before connecting a new one.
    */
-  PORT_ALREADY_OPEN = 'PORT_ALREADY_OPEN',
+  PORT_ALREADY_OPEN: 'PORT_ALREADY_OPEN',
 
   /**
    * Serial port is not open.
@@ -75,7 +75,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Call {@link SerialClient.connect} before reading or writing.
    */
-  PORT_NOT_OPEN = 'PORT_NOT_OPEN',
+  PORT_NOT_OPEN: 'PORT_NOT_OPEN',
 
   /**
    * Failed to read from the serial port.
@@ -85,7 +85,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Check the connection and hardware, then retry the read operation.
    */
-  READ_FAILED = 'READ_FAILED',
+  READ_FAILED: 'READ_FAILED',
 
   /**
    * Failed to write to the serial port.
@@ -95,7 +95,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Check the connection and hardware, then retry the write operation.
    */
-  WRITE_FAILED = 'WRITE_FAILED',
+  WRITE_FAILED: 'WRITE_FAILED',
 
   /**
    * Serial port connection was lost.
@@ -106,7 +106,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Check the physical connection and reconnect if needed.
    */
-  CONNECTION_LOST = 'CONNECTION_LOST',
+  CONNECTION_LOST: 'CONNECTION_LOST',
 
   /**
    * Invalid filter options provided.
@@ -116,7 +116,7 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Verify filter options match the expected format and value ranges.
    */
-  INVALID_FILTER_OPTIONS = 'INVALID_FILTER_OPTIONS',
+  INVALID_FILTER_OPTIONS: 'INVALID_FILTER_OPTIONS',
 
   /**
    * Operation was cancelled by the user.
@@ -127,7 +127,7 @@ export enum SerialErrorCode {
    * **Suggested action**: This is a normal condition - no action required, but you may want
    * to inform the user that the operation was cancelled.
    */
-  OPERATION_CANCELLED = 'OPERATION_CANCELLED',
+  OPERATION_CANCELLED: 'OPERATION_CANCELLED',
 
   /**
    * Operation timed out before completion.
@@ -135,7 +135,7 @@ export enum SerialErrorCode {
    * This error occurs when an operation waits for a condition (for example, prompt
    * detection) and the timeout period elapses first.
    */
-  OPERATION_TIMEOUT = 'OPERATION_TIMEOUT',
+  OPERATION_TIMEOUT: 'OPERATION_TIMEOUT',
 
   /**
    * Internal line buffer exceeded its configured size limit.
@@ -147,7 +147,7 @@ export enum SerialErrorCode {
    * **Suggested action**: Increase `lineBuffer.maxChars`, handle framing on `receive$`,
    * or ensure the device sends line terminators.
    */
-  LINE_BUFFER_OVERFLOW = 'LINE_BUFFER_OVERFLOW',
+  LINE_BUFFER_OVERFLOW: 'LINE_BUFFER_OVERFLOW',
 
   /**
    * Invalid receive replay options provided.
@@ -158,7 +158,7 @@ export enum SerialErrorCode {
    * **Suggested action**: Verify `receiveReplay` options match the documented
    * ranges and value types.
    */
-  INVALID_RECEIVE_REPLAY_OPTIONS = 'INVALID_RECEIVE_REPLAY_OPTIONS',
+  INVALID_RECEIVE_REPLAY_OPTIONS: 'INVALID_RECEIVE_REPLAY_OPTIONS',
 
   /**
    * Invalid terminal buffer options provided.
@@ -169,7 +169,7 @@ export enum SerialErrorCode {
    * **Suggested action**: Verify `terminalBuffer` options match the documented
    * ranges and value types.
    */
-  INVALID_TERMINAL_BUFFER_OPTIONS = 'INVALID_TERMINAL_BUFFER_OPTIONS',
+  INVALID_TERMINAL_BUFFER_OPTIONS: 'INVALID_TERMINAL_BUFFER_OPTIONS',
 
   /**
    * Invalid line buffer options provided.
@@ -180,7 +180,7 @@ export enum SerialErrorCode {
    * **Suggested action**: Verify `lineBuffer` options match the documented
    * ranges and value types.
    */
-  INVALID_LINE_BUFFER_OPTIONS = 'INVALID_LINE_BUFFER_OPTIONS',
+  INVALID_LINE_BUFFER_OPTIONS: 'INVALID_LINE_BUFFER_OPTIONS',
 
   /**
    * Invalid connection options provided.
@@ -191,7 +191,7 @@ export enum SerialErrorCode {
    * **Suggested action**: Verify connection options match the documented
    * ranges and value types.
    */
-  INVALID_CONNECTION_OPTIONS = 'INVALID_CONNECTION_OPTIONS',
+  INVALID_CONNECTION_OPTIONS: 'INVALID_CONNECTION_OPTIONS',
 
   /**
    * Receive replay buffer exceeded its configured character limit.
@@ -203,7 +203,7 @@ export enum SerialErrorCode {
    * **Suggested action**: Increase `receiveReplay.maxChars`, reduce chunk size at
    * the source, or subscribe earlier to avoid relying on a large replay buffer.
    */
-  RECEIVE_REPLAY_BUFFER_OVERFLOW = 'RECEIVE_REPLAY_BUFFER_OVERFLOW',
+  RECEIVE_REPLAY_BUFFER_OVERFLOW: 'RECEIVE_REPLAY_BUFFER_OVERFLOW',
 
   /**
    * Session has been disposed and can no longer be used.
@@ -215,7 +215,7 @@ export enum SerialErrorCode {
    * **Suggested action**: Call {@link SerialSession.dispose$} only when
    * permanently tearing down a session, then create a new one if needed.
    */
-  SESSION_DISPOSED = 'SESSION_DISPOSED',
+  SESSION_DISPOSED: 'SESSION_DISPOSED',
 
   /**
    * Unknown error occurred.
@@ -225,5 +225,12 @@ export enum SerialErrorCode {
    *
    * **Suggested action**: Check the error message and originalError for more details.
    */
-  UNKNOWN = 'UNKNOWN',
-}
+  UNKNOWN: 'UNKNOWN',
+} as const;
+
+/**
+ * String union of allowed {@link SerialErrorCode} runtime values
+ * (same set as the values on the {@link SerialErrorCode} object).
+ */
+export type SerialErrorCode =
+  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];

--- a/packages/web-serial-rxjs/tests/errors/serial-error-code.test.ts
+++ b/packages/web-serial-rxjs/tests/errors/serial-error-code.test.ts
@@ -32,12 +32,13 @@ describe('SerialErrorCode', () => {
     expect(SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW).toBe(
       'RECEIVE_REPLAY_BUFFER_OVERFLOW',
     );
+    expect(SerialErrorCode.SESSION_DISPOSED).toBe('SESSION_DISPOSED');
     expect(SerialErrorCode.UNKNOWN).toBe('UNKNOWN');
   });
 
-  it('should be an enum with string values', () => {
+  it('should be a const object with string values', () => {
     const codes = Object.values(SerialErrorCode);
-    expect(codes.length).toBeGreaterThan(0);
+    expect(codes.length).toBe(19);
     codes.forEach((code) => {
       expect(typeof code).toBe('string');
       expect(code.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
`SerialErrorCode` を `SerialSessionState` と同じ const object + union type パターンへ移行し、enum と const の混在を解消しました。ランタイムの `SerialErrorCode.X` 参照形式は維持しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [x] Breaking change

## Related issues
- Parent: #391
- Fixes #405

## What changed?
- `SerialErrorCode` を `export enum` から `as const` オブジェクト + 型エイリアスへ移行
- const object 向けに `SerialErrorCode` テストを更新（`SESSION_DISPOSED` カバレッジ追加）
- v3 向け migration guide（`MIGRATION_V3.md` / `.ja.md`）を追加
- API リファレンスの `SerialErrorCode` 説明を更新

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `.d.ts` 上の `SerialErrorCode` 宣言が enum から const + type へ変化。ランタイムのメンバー名・文字列値は不変。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: `packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md` を参照。典型的な `SerialErrorCode.X` 比較は変更不要。

BREAKING CHANGE: SerialErrorCode の公開型定義が enum から const object + string literal union へ変更されました。TypeDoc の URL も enums から variables へ変わります。

## How to test
1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build && pnpm exec nx run web-serial-rxjs:verify-dist`
3. `pnpm exec nx run-many -t typecheck --projects=example-angular,example-react,example-vue,example-svelte,example-vanilla-js,example-vanilla-ts`
4. `SerialErrorCode.READ_FAILED` 等の比較・`SerialError.is()` の narrowing が従来どおり動作することを確認

## Environment (if relevant)
- 該当なし（型定義・ドキュメント中心の変更）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)