### PR TITLE
feat(web-serial-rxjs): expose discriminated union session state

### DIFF
--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -3,7 +3,10 @@ import { Component, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import {
+  SerialSessionStatus,
+  type SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
 import { SerialClientService } from './services/serial-client.service';
 
 type StatusType = 'info' | 'success' | 'error';
@@ -22,7 +25,9 @@ export class App {
   private readonly destroyRef = inject(DestroyRef);
 
   readonly browserSupported = this.serialService.isBrowserSupported();
-  readonly state = signal<SerialSessionState>(SerialSessionState.Idle);
+  readonly state = signal<SerialSessionState>({
+    status: SerialSessionStatus.Idle,
+  });
   readonly isConnected = signal(false);
   readonly receivedData = signal('');
   readonly errorMessage = signal<string | null>(null);
@@ -32,7 +37,10 @@ export class App {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((state) => {
         this.state.set(state);
-        if (state === SerialSessionState.Connected || state === SerialSessionState.Idle) {
+        if (
+          state.status === SerialSessionStatus.Connected ||
+          state.status === SerialSessionStatus.Idle
+        ) {
           this.errorMessage.set(null);
         }
       });
@@ -53,11 +61,11 @@ export class App {
   }
 
   get connecting(): boolean {
-    return this.state() === SerialSessionState.Connecting;
+    return this.state().status === SerialSessionStatus.Connecting;
   }
 
   get disconnecting(): boolean {
-    return this.state() === SerialSessionState.Disconnecting;
+    return this.state().status === SerialSessionStatus.Disconnecting;
   }
 
   get hasReceivedData(): boolean {
@@ -69,20 +77,20 @@ export class App {
     if (error) {
       return { type: 'error', message: `エラー: ${error}` };
     }
-    switch (this.state()) {
-      case SerialSessionState.Connecting:
+    switch (this.state().status) {
+      case SerialSessionStatus.Connecting:
         return { type: 'info', message: '接続中...' };
-      case SerialSessionState.Disconnecting:
+      case SerialSessionStatus.Disconnecting:
         return { type: 'info', message: '切断中...' };
-      case SerialSessionState.Connected:
+      case SerialSessionStatus.Connected:
         return { type: 'success', message: 'シリアルポートに接続しました。' };
-      case SerialSessionState.Unsupported:
+      case SerialSessionStatus.Unsupported:
         return {
           type: 'error',
           message:
             'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
         };
-      case SerialSessionState.Error:
+      case SerialSessionStatus.Error:
         return { type: 'error', message: 'エラーが発生しました。' };
       default:
         return { type: 'info', message: 'シリアルポートに接続していません。' };

--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -10,7 +10,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialClientService } from './serial-client.service';
 
-const SS = webSerialRxjs.SerialSessionState;
+const SS = webSerialRxjs.SerialSessionStatus;
 
 interface MockCore {
   session: webSerialRxjs.SerialSession;
@@ -26,9 +26,9 @@ interface MockCore {
 }
 
 const createMockCore = (): MockCore => {
-  const stateSubject = new BehaviorSubject<webSerialRxjs.SerialSessionState>(
-    SS.Idle,
-  );
+  const stateSubject = new BehaviorSubject<webSerialRxjs.SerialSessionState>({
+    status: SS.Idle,
+  });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<webSerialRxjs.SerialError>();
   const isConnectedSubject = new BehaviorSubject(false);
@@ -117,16 +117,16 @@ describe('SerialClientService', () => {
 
   it('should emit the initial idle state on state$', async () => {
     const state = await firstValueFrom(service.state$);
-    expect(state).toBe(SS.Idle);
+    expect(state).toEqual({ status: SS.Idle });
   });
 
   it('should forward session state transitions', async () => {
     const mock = latestMock();
-    mock.stateSubject.next(SS.Connecting);
-    mock.stateSubject.next(SS.Connected);
+    mock.stateSubject.next({ status: SS.Connecting });
+    mock.stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
 
     const state = await firstValueFrom(service.state$);
-    expect(state).toBe(SS.Connected);
+    expect(state).toEqual({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
   });
 
   it('should connect through the session', async () => {

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -10,7 +10,7 @@ import { BehaviorSubject, distinctUntilChanged, map, of, Subject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App';
 
-const SS = webSerialRxjs.SerialSessionState;
+const SS = webSerialRxjs.SerialSessionStatus;
 
 interface MockSession {
   session: SerialSession;
@@ -26,12 +26,12 @@ interface MockSession {
 }
 
 const createMockSession = (): MockSession => {
-  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnected$ = stateSubject.pipe(
-    map((s) => s === SS.Connected),
+    map((s) => s.status === SS.Connected),
     distinctUntilChanged(),
   );
   const connect$ = vi.fn(() => of(undefined));
@@ -144,12 +144,12 @@ describe('App', () => {
     expect(baudRateSelect).toHaveValue('115200');
   });
 
-  it('state$ が SerialSessionState.Connected なら成功ステータスを表示する', async () => {
+  it('state$ が SerialSessionStatus.Connected なら成功ステータスを表示する', async () => {
     const user = userEvent.setup();
     render(<App />);
 
     await user.click(screen.getByText('接続'));
-    act(() => latestMock().stateSubject.next(SS.Connected));
+    act(() => latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } }));
 
     await waitFor(() => {
       expect(
@@ -164,7 +164,7 @@ describe('App', () => {
     render(<App />);
 
     await user.click(screen.getByText('接続'));
-    act(() => latestMock().stateSubject.next(SS.Connected));
+    act(() => latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } }));
     await waitFor(() => {
       expect(
         screen.getByText('シリアルポートに接続しました。'),
@@ -172,7 +172,7 @@ describe('App', () => {
     });
 
     await user.click(screen.getByText('切断'));
-    act(() => latestMock().stateSubject.next(SS.Idle));
+    act(() => latestMock().stateSubject.next({ status: SS.Idle }));
 
     await waitFor(() => {
       expect(
@@ -187,7 +187,7 @@ describe('App', () => {
     render(<App />);
 
     await user.click(screen.getByText('接続'));
-    act(() => latestMock().stateSubject.next(SS.Connected));
+    act(() => latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } }));
     await waitFor(() => {
       expect(
         screen.getByText('シリアルポートに接続しました。'),

--- a/apps/example-react/src/App.tsx
+++ b/apps/example-react/src/App.tsx
@@ -1,4 +1,4 @@
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { useState } from 'react';
 import { useSerialSession } from './hooks/useSerialSession';
 
@@ -19,8 +19,8 @@ export function App() {
     clearReceivedData,
   } = useSerialSession(baudRate);
 
-  const connecting = state === SerialSessionState.Connecting;
-  const disconnecting = state === SerialSessionState.Disconnecting;
+  const connecting = state.status === SerialSessionStatus.Connecting;
+  const disconnecting = state.status === SerialSessionStatus.Disconnecting;
 
   const status: { type: StatusType; message: string } = errorMessage
     ? { type: 'error', message: `エラー: ${errorMessage}` }

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -15,7 +15,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSerialSession } from './useSerialSession';
 
-const SS = webSerialRxjs.SerialSessionState;
+const SS = webSerialRxjs.SerialSessionStatus;
 
 interface MockCore {
   session: SerialSession;
@@ -31,7 +31,7 @@ interface MockCore {
 }
 
 const createMockCore = (supported = true): MockCore => {
-  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnectedSubject = new BehaviorSubject(false);
@@ -104,7 +104,7 @@ describe('useSerialSession', () => {
 
   it('初期状態は idle、receivedData は空、errorMessage は null', () => {
     const { result } = renderHook(() => useSerialSession());
-    expect(result.current.state).toBe(SS.Idle);
+    expect(result.current.state).toEqual({ status: SS.Idle });
     expect(result.current.isConnected).toBe(false);
     expect(result.current.receivedData).toBe('');
     expect(result.current.errorMessage).toBeNull();
@@ -126,10 +126,10 @@ describe('useSerialSession', () => {
 
   it('state$ の変化が state に反映される', () => {
     const { result } = renderHook(() => useSerialSession());
-    act(() => latestMock().stateSubject.next(SS.Connecting));
-    expect(result.current.state).toBe(SS.Connecting);
-    act(() => latestMock().stateSubject.next(SS.Connected));
-    expect(result.current.state).toBe(SS.Connected);
+    act(() => latestMock().stateSubject.next({ status: SS.Connecting }));
+    expect(result.current.state).toEqual({ status: SS.Connecting });
+    act(() => latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } }));
+    expect(result.current.state).toEqual({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
   });
 
   it('terminalText$ の更新が receivedData に反映される', () => {
@@ -155,7 +155,7 @@ describe('useSerialSession', () => {
       latestMock().errorsSubject.next({ message: 'boom' } as SerialError),
     );
     expect(result.current.errorMessage).toBe('boom');
-    act(() => latestMock().stateSubject.next(SS.Connected));
+    act(() => latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } }));
     expect(result.current.errorMessage).toBeNull();
   });
 
@@ -201,8 +201,8 @@ describe('useSerialSession', () => {
       vi.mocked(webSerialRxjs.createSerialSession),
     ).toHaveBeenLastCalledWith({ baudRate: 115200 });
 
-    act(() => latestMock().stateSubject.next(SS.Connecting));
-    expect(result.current.state).toBe(SS.Connecting);
+    act(() => latestMock().stateSubject.next({ status: SS.Connecting }));
+    expect(result.current.state).toEqual({ status: SS.Connecting });
   });
 
   it('connect$ 実行時に terminalText の表示状態をリセットする', () => {
@@ -246,7 +246,7 @@ describe('useSerialSession', () => {
 
     // StrictMode の再 setup で active な subscription は最後の mock セッション側に
     // 切り替わるため、その state$ を更新したらフックの state に反映される。
-    act(() => latestMock().stateSubject.next(SS.Connecting));
-    expect(result.current.state).toBe(SS.Connecting);
+    act(() => latestMock().stateSubject.next({ status: SS.Connecting }));
+    expect(result.current.state).toEqual({ status: SS.Connecting });
   });
 });

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,6 +1,7 @@
 import {
-  SerialSessionState,
+  SerialSessionStatus,
   type SerialError,
+  type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
 import {
   createSerialSessionController,
@@ -42,7 +43,9 @@ export function useSerialSession(
   const [browserSupported] = useState(() =>
     (controllerRef.current as SerialSessionController).isBrowserSupported(),
   );
-  const [state, setState] = useState<SerialSessionState>(SerialSessionState.Idle);
+  const [state, setState] = useState<SerialSessionState>({
+    status: SerialSessionStatus.Idle,
+  });
   const [isConnected, setIsConnected] = useState(false);
   const [receivedData, setReceivedData] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -55,8 +58,8 @@ export function useSerialSession(
       controller.state$.subscribe((next) => {
         setState(next);
         if (
-          next === SerialSessionState.Connected ||
-          next === SerialSessionState.Idle
+          next.status === SerialSessionStatus.Connected ||
+          next.status === SerialSessionStatus.Idle
         )
           setErrorMessage(null);
       }),

--- a/apps/example-svelte/src/App.svelte
+++ b/apps/example-svelte/src/App.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
-  import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+  import {
+    SerialSessionStatus,
+    type SerialSessionState,
+  } from '@gurezo/web-serial-rxjs';
   import { useSerialSession } from './stores/useSerialSession';
 
   let baudRate = 9600;
@@ -26,20 +29,20 @@
     if (error) {
       return { type: 'error', message: `エラー: ${error}` };
     }
-    switch (current) {
-      case SerialSessionState.Connecting:
+    switch (current.status) {
+      case SerialSessionStatus.Connecting:
         return { type: 'info', message: '接続中...' };
-      case SerialSessionState.Disconnecting:
+      case SerialSessionStatus.Disconnecting:
         return { type: 'info', message: '切断中...' };
-      case SerialSessionState.Connected:
+      case SerialSessionStatus.Connected:
         return { type: 'success', message: 'シリアルポートに接続しました。' };
-      case SerialSessionState.Unsupported:
+      case SerialSessionStatus.Unsupported:
         return {
           type: 'error',
           message:
             'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
         };
-      case SerialSessionState.Error:
+      case SerialSessionStatus.Error:
         return { type: 'error', message: 'エラーが発生しました。' };
       default:
         return { type: 'info', message: 'シリアルポートに接続していません。' };
@@ -47,8 +50,8 @@
   };
 
   $: status = statusFor($state, $errorMessage);
-  $: connecting = $state === SerialSessionState.Connecting;
-  $: disconnecting = $state === SerialSessionState.Disconnecting;
+  $: connecting = $state.status === SerialSessionStatus.Connecting;
+  $: disconnecting = $state.status === SerialSessionStatus.Disconnecting;
 
   const handleConnect = () => {
     clearReceivedData();

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -14,7 +14,7 @@ import { get } from 'svelte/store';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSerialSession } from './useSerialSession';
 
-const SS = webSerialRxjs.SerialSessionState;
+const SS = webSerialRxjs.SerialSessionStatus;
 
 interface MockCore {
   session: SerialSession;
@@ -30,7 +30,7 @@ interface MockCore {
 }
 
 const createMockCore = (supported = true): MockCore => {
-  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnectedSubject = new BehaviorSubject(false);
@@ -122,7 +122,7 @@ describe('useSerialSession', () => {
 
   it('初期状態は idle、receivedData は空、errorMessage は null、browserSupported は true', () => {
     const s = useSerialSession();
-    expect(get(s.state)).toBe(SS.Idle);
+    expect(get(s.state)).toEqual({ status: SS.Idle });
     expect(get(s.isConnected)).toBe(false);
     expect(get(s.receivedData)).toBe('');
     expect(get(s.errorMessage)).toBeNull();
@@ -145,10 +145,10 @@ describe('useSerialSession', () => {
   it('state$ の変化が state に反映される', () => {
     const s = useSerialSession();
     const unsub = s.state.subscribe(() => void 0);
-    latestMock().stateSubject.next(SS.Connecting);
-    expect(get(s.state)).toBe(SS.Connecting);
-    latestMock().stateSubject.next(SS.Connected);
-    expect(get(s.state)).toBe(SS.Connected);
+    latestMock().stateSubject.next({ status: SS.Connecting });
+    expect(get(s.state)).toEqual({ status: SS.Connecting });
+    latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
+    expect(get(s.state)).toEqual({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
     unsub();
   });
 
@@ -174,7 +174,7 @@ describe('useSerialSession', () => {
     const unsub = s.errorMessage.subscribe(() => void 0);
     latestMock().errorsSubject.next({ message: 'boom' } as SerialError);
     expect(get(s.errorMessage)).toBe('boom');
-    latestMock().stateSubject.next(SS.Connected);
+    latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
     expect(get(s.errorMessage)).toBeNull();
     unsub();
   });
@@ -216,8 +216,8 @@ describe('useSerialSession', () => {
       vi.mocked(webSerialRxjs.createSerialSession),
     ).toHaveBeenLastCalledWith({ baudRate: 115200 });
 
-    latestMock().stateSubject.next(SS.Connecting);
-    expect(get(s.state)).toBe(SS.Connecting);
+    latestMock().stateSubject.next({ status: SS.Connecting });
+    expect(get(s.state)).toEqual({ status: SS.Connecting });
     unsub();
   });
 

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,6 +1,7 @@
 import {
-  SerialSessionState,
+  SerialSessionStatus,
   type SerialError,
+  type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
 import { createSerialSessionController } from '@gurezo/examples-shared';
 import { type Observable, Subscription } from 'rxjs';
@@ -29,10 +30,13 @@ export function useSerialSession(
 
   const browserSupported = readable(controller.isBrowserSupported());
 
-  const state = readable<SerialSessionState>(SerialSessionState.Idle, (set) => {
-    const sub = controller.state$.subscribe((next) => set(next));
-    return () => sub.unsubscribe();
-  });
+  const state = readable<SerialSessionState>(
+    { status: SerialSessionStatus.Idle },
+    (set) => {
+      const sub = controller.state$.subscribe((next) => set(next));
+      return () => sub.unsubscribe();
+    },
+  );
 
   const isConnected = readable<boolean>(false, (set) => {
     const sub = controller.isConnected$.subscribe((next) => set(next));
@@ -52,8 +56,8 @@ export function useSerialSession(
     subs.add(
       controller.state$.subscribe((next) => {
         if (
-          next === SerialSessionState.Connected ||
-          next === SerialSessionState.Idle
+          next.status === SerialSessionStatus.Connected ||
+          next.status === SerialSessionStatus.Idle
         )
           set(null);
       }),

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,4 +1,4 @@
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { createSerialSessionController } from '@gurezo/examples-shared';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -12,6 +12,7 @@ const STATUS = {
   disconnecting: ['info', '切断中です...'],
   unsupported: ['error', UNSUPPORTED_MSG],
   error: ['error', 'エラーが発生しました。errors$ を確認してください。'],
+  disposed: ['info', 'セッションは破棄されました。'],
 };
 
 const $ = (id) => {
@@ -43,13 +44,13 @@ export class App {
     );
 
     this.controller.state$.subscribe((state) => {
-      const connected = state === SerialSessionState.Connected;
+      const connected = state.status === SerialSessionStatus.Connected;
       const busy =
-        state === SerialSessionState.Connecting ||
-        state === SerialSessionState.Disconnecting;
+        state.status === SerialSessionStatus.Connecting ||
+        state.status === SerialSessionStatus.Disconnecting;
       connectBtn.disabled = !supported || connected || busy;
       baudRateSelect.disabled = connected || busy;
-      setStatus(status, ...STATUS[state]);
+      setStatus(status, ...STATUS[state.status]);
     });
 
     this.controller.isConnected$.subscribe((isConnected) => {

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -4,11 +4,11 @@ import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { App } from './app.js';
 
 const createMockSession = () => {
-  const state$ = new BehaviorSubject('idle');
+  const state$ = new BehaviorSubject({ status: 'idle' });
   const receive$ = new Subject();
   const errors$ = new Subject();
   const isConnected$ = state$.pipe(
-    map((s) => s === 'connected'),
+    map((s) => s.status === 'connected'),
     distinctUntilChanged(),
   );
   return {

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -9,7 +9,7 @@ interface MockSession {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  state$: BehaviorSubject<string>;
+  state$: BehaviorSubject<{ status: string }>;
   receive$: Subject<string>;
   terminalText$: Subject<string>;
   errors$: Subject<{ message: string }>;
@@ -17,11 +17,11 @@ interface MockSession {
 }
 
 const createMockSession = (): MockSession => {
-  const state$ = new BehaviorSubject<string>('idle');
+  const state$ = new BehaviorSubject<{ status: string }>({ status: 'idle' });
   const receive$ = new Subject<string>();
   const errors$ = new Subject<{ message: string }>();
   const isConnected$ = state$.pipe(
-    map((s) => s === 'connected'),
+    map((s) => s.status === 'connected'),
     distinctUntilChanged(),
   );
   return {

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,4 +1,7 @@
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import {
+  SerialSessionStatus,
+  type SerialSessionStatus as SerialSessionStatusType,
+} from '@gurezo/web-serial-rxjs';
 import { createSerialSessionController } from '@gurezo/examples-shared';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -7,15 +10,16 @@ type StatusType = 'info' | 'success' | 'error';
 
 const UNSUPPORTED_MSG =
   'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。';
-const S = SerialSessionState;
+const S = SerialSessionStatus;
 
-const STATUS: Record<SerialSessionState, [StatusType, string]> = {
+const STATUS: Record<SerialSessionStatusType, [StatusType, string]> = {
   [S.Idle]: ['info', 'シリアルポートから切断しました。'],
   [S.Connecting]: ['info', '接続中です...'],
   [S.Connected]: ['success', 'シリアルポートに接続しました。'],
   [S.Disconnecting]: ['info', '切断中です...'],
   [S.Unsupported]: ['error', UNSUPPORTED_MSG],
   [S.Error]: ['error', 'エラーが発生しました。errors$ を確認してください。'],
+  [S.Disposed]: ['info', 'セッションは破棄されました。'],
 };
 
 const $ = <T extends HTMLElement>(id: string): T => {
@@ -50,11 +54,11 @@ export class App {
     );
 
     this.controller.state$.subscribe((state) => {
-      const connected = state === S.Connected;
-      const busy = state === S.Connecting || state === S.Disconnecting;
+      const connected = state.status === S.Connected;
+      const busy = state.status === S.Connecting || state.status === S.Disconnecting;
       connectBtn.disabled = !supported || connected || busy;
       baudRateSelect.disabled = connected || busy;
-      setStatus(status, ...STATUS[state]);
+      setStatus(status, ...STATUS[state.status]);
     });
 
     this.controller.isConnected$.subscribe((isConnected) => {

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // @ts-expect-error - Vue SFC file, types are defined in vue-shims.d.ts
 import App from './App.vue';
 
-const SS = webSerialRxjs.SerialSessionState;
+const SS = webSerialRxjs.SerialSessionStatus;
 
 interface MockSession {
   session: SerialSession;
@@ -26,22 +26,22 @@ interface MockSession {
 }
 
 const createMockSession = (): MockSession => {
-  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnected$ = stateSubject.pipe(
-    map((s) => s === SS.Connected),
+    map((s) => s.status === SS.Connected),
     distinctUntilChanged(),
   );
   const connect$ = vi.fn(() => {
-    stateSubject.next(SS.Connecting);
-    stateSubject.next(SS.Connected);
+    stateSubject.next({ status: SS.Connecting });
+    stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
     return of(undefined);
   });
   const disconnect$ = vi.fn(() => {
-    stateSubject.next(SS.Disconnecting);
-    stateSubject.next(SS.Idle);
+    stateSubject.next({ status: SS.Disconnecting });
+    stateSubject.next({ status: SS.Idle });
     return of(undefined);
   });
   const dispose$ = vi.fn(() => of(undefined));

--- a/apps/example-vue/src/app/App.vue
+++ b/apps/example-vue/src/app/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { computed, ref } from 'vue';
 import { useSerialClient } from '../composables/useSerialClient';
 
@@ -21,30 +21,30 @@ const {
 } = useSerialClient(baudRate.value);
 
 const connecting = computed(
-  () => state.value === SerialSessionState.Connecting,
+  () => state.value.status === SerialSessionStatus.Connecting,
 );
 const disconnecting = computed(
-  () => state.value === SerialSessionState.Disconnecting,
+  () => state.value.status === SerialSessionStatus.Disconnecting,
 );
 
 const status = computed<{ type: StatusType; message: string }>(() => {
   if (errorMessage.value) {
     return { type: 'error', message: `エラー: ${errorMessage.value}` };
   }
-  switch (state.value) {
-    case SerialSessionState.Connecting:
+  switch (state.value.status) {
+    case SerialSessionStatus.Connecting:
       return { type: 'info', message: '接続中...' };
-    case SerialSessionState.Disconnecting:
+    case SerialSessionStatus.Disconnecting:
       return { type: 'info', message: '切断中...' };
-    case SerialSessionState.Connected:
+    case SerialSessionStatus.Connected:
       return { type: 'success', message: 'シリアルポートに接続しました。' };
-    case SerialSessionState.Unsupported:
+    case SerialSessionStatus.Unsupported:
       return {
         type: 'error',
         message:
           'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
       };
-    case SerialSessionState.Error:
+    case SerialSessionStatus.Error:
       return { type: 'error', message: 'エラーが発生しました。' };
     default:
       return { type: 'info', message: 'シリアルポートに接続していません。' };

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -14,7 +14,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSerialClient } from './useSerialClient';
 
-const SS = webSerialRxjs.SerialSessionState;
+const SS = webSerialRxjs.SerialSessionStatus;
 
 interface MockCore {
   session: SerialSession;
@@ -30,7 +30,7 @@ interface MockCore {
 }
 
 const createMockCore = (supported = true): MockCore => {
-  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnectedSubject = new BehaviorSubject(false);
@@ -134,7 +134,7 @@ describe('useSerialClient', () => {
   it('should initialize with default refs', () => {
     const { api } = mountHarness();
     expect(api.browserSupported.value).toBe(true);
-    expect(api.state.value).toBe(SS.Idle);
+    expect(api.state.value).toEqual({ status: SS.Idle });
     expect(api.isConnected.value).toBe(false);
     expect(api.receivedData.value).toBe('');
     expect(api.errorMessage.value).toBe(null);
@@ -150,11 +150,11 @@ describe('useSerialClient', () => {
     const { api } = mountHarness();
     const mock = latestMock();
 
-    mock.stateSubject.next(SS.Connecting);
-    expect(api.state.value).toBe(SS.Connecting);
+    mock.stateSubject.next({ status: SS.Connecting });
+    expect(api.state.value).toEqual({ status: SS.Connecting });
 
-    mock.stateSubject.next(SS.Connected);
-    expect(api.state.value).toBe(SS.Connected);
+    mock.stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
+    expect(api.state.value).toEqual({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
   });
 
   it('should clear errorMessage when returning to idle or connected', () => {
@@ -164,7 +164,7 @@ describe('useSerialClient', () => {
     mock.errorsSubject.next({ message: 'boom' } as SerialError);
     expect(api.errorMessage.value).toBe('boom');
 
-    mock.stateSubject.next(SS.Connected);
+    mock.stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
     expect(api.errorMessage.value).toBe(null);
   });
 

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,6 +1,7 @@
 import {
-  SerialSessionState,
+  SerialSessionStatus,
   type SerialError,
+  type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
 import { createSerialSessionController } from '@gurezo/examples-shared';
 import { type Observable } from 'rxjs';
@@ -25,14 +26,17 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
   });
 
   const browserSupported = ref(controller.isBrowserSupported());
-  const state = ref<SerialSessionState>(SerialSessionState.Idle);
+  const state = ref<SerialSessionState>({ status: SerialSessionStatus.Idle });
   const isConnected = ref(false);
   const receivedData = ref('');
   const errorMessage = ref<string | null>(null);
 
   const stateSub = controller.state$.subscribe((next) => {
     state.value = next;
-    if (next === SerialSessionState.Connected || next === SerialSessionState.Idle) {
+    if (
+      next.status === SerialSessionStatus.Connected ||
+      next.status === SerialSessionStatus.Idle
+    ) {
       errorMessage.value = null;
     }
   });

--- a/libs/examples-shared/src/create-serial-session-controller.spec.ts
+++ b/libs/examples-shared/src/create-serial-session-controller.spec.ts
@@ -13,7 +13,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createSerialSessionController } from './create-serial-session-controller';
 
-const SS = webSerialRxjs.SerialSessionState;
+const SS = webSerialRxjs.SerialSessionStatus;
 
 interface MockCore {
   session: SerialSession;
@@ -29,7 +29,7 @@ interface MockCore {
 }
 
 const createMockCore = (supported = true): MockCore => {
-  const stateSubject = new BehaviorSubject<SerialSessionState>(SS.Idle);
+  const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
   const isConnectedSubject = new BehaviorSubject(false);
@@ -125,11 +125,11 @@ describe('createSerialSessionController', () => {
     const textSub = controller.terminalText$.subscribe((v) => texts.push(v));
     const errorSub = controller.errors$.subscribe((v) => errors.push(v));
 
-    mock.stateSubject.next(SS.Connecting);
+    mock.stateSubject.next({ status: SS.Connecting });
     mock.receiveSubject.next('hello');
     mock.errorsSubject.next({ message: 'boom' } as SerialError);
 
-    expect(states.at(-1)).toBe(SS.Connecting);
+    expect(states.at(-1)).toEqual({ status: SS.Connecting });
     expect(texts.at(-1)).toBe('hello');
     expect(errors.at(-1)?.message).toBe('boom');
 

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -96,29 +96,33 @@ function createTerminalBuffer(
 ): TerminalBuffer;
 ```
 
-## SerialSessionState
+## SerialSessionState / SerialSessionStatus
 
-上記と同じ文字列のユニオン型に加え、**定数オブジェクト** `SerialSessionState`（例: `SerialSessionState.Connected` は `'connected'`）が export され、補完やタイポ防止に使えます。従来どおり文字列リテラルで型注釈・比較しても問題ありません。
+v3 では **`SerialSessionStatus`** が lifecycle 文字列定数（例: `SerialSessionStatus.Connected` は `'connected'`）を提供し、**`SerialSessionState`** は `state$` が emit する discriminated union 型です。
 
-`state$` は以下のいずれかを emit します。
+`state$` は次のいずれかのオブジェクトを emit します。
 
-- `'idle'` — ポート未接続。Web Serial 対応環境での初期値。
-- `'connecting'` — `connect$` 実行中。
-- `'connected'` — ポートが開いており read pump が動作中。
-- `'disconnecting'` — `disconnect$` 実行中。
-- `'unsupported'` — `navigator.serial` が存在しない環境でセッションを生成した場合。
-- `'error'` — 致命的な失敗が発生した。`disconnect$` で復帰するか、新しいセッションを作成する。
-- `'disposed'` — `dispose$` / `destroy$` によりセッションが永久破棄された。すべての Observable が complete する。継続するには新しいセッションを作成する。
+- `{ status: 'idle' }` — ポート未接続。Web Serial 対応環境での初期値。
+- `{ status: 'connecting' }` — `connect$` 実行中。
+- `{ status: 'connected', portInfo }` — ポートが開いており read pump が動作中。`portInfo` は `SerialPort.getInfo()` と同じ形。
+- `{ status: 'disconnecting' }` — `disconnect$` 実行中。
+- `{ status: 'unsupported' }` — `navigator.serial` が存在しない環境でセッションを生成した場合。
+- `{ status: 'error', error }` — 致命的な失敗。`error` は `errors$` に流れた `SerialError` と同一インスタンス。
+- `{ status: 'disposed' }` — `dispose$` / `destroy$` によりセッションが永久破棄された。
 
-遷移:
+比較例:
 
+```typescript
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Connected) {
+    console.log(state.portInfo);
+  }
+});
 ```
-idle -> connecting -> connected -> disconnecting -> idle
-                              \-> error
-idle / connected / connecting / disconnecting / error -> error（致命的失敗）
-any -> unsupported（生成時に navigator.serial が存在しない場合）
-（任意のアクティブ状態） -> disposed（dispose$ による永久 teardown）
-```
+
+v2 からの移行は [v3 移行ガイド](./MIGRATION_V3.ja.md) を参照してください。
 
 ## SerialSession
 
@@ -167,11 +171,11 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 
 ### `isConnected$: Observable<boolean>`
 
-`SerialSessionState` が `'connected'` のとき `true`、それ以外のとき `false` です。`state$` から `distinctUntilChanged` 付きで派生しており、接続有無の UI 分岐にそのまま使えます。必要に応じて従来どおり `state$` から自前の `map` でも構いません。
+`state$.status` が `SerialSessionStatus.Connected` のとき `true`、それ以外のとき `false` です。`state$` から `distinctUntilChanged` 付きで派生しており、接続有無の UI 分岐にそのまま使えます。必要に応じて従来どおり `state$` から自前の `map` でも構いません。
 
 ### `errors$: Observable<SerialError>`
 
-主エラーチャネル。接続・読み取り・書き込み・クローズで発生したすべての失敗が `SerialError` に正規化されて流れます。致命的な失敗は `state$` を `'error'` に遷移させ、read pump とポートをテアダウンします。
+主エラーチャネル。接続・読み取り・書き込み・クローズで発生したすべての失敗が `SerialError` に正規化されて流れます。致命的な失敗は `state$` を `{ status: 'error', error }` に遷移させ、read pump とポートをテアダウンします。
 
 ### `receive$: Observable<string>`
 

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -96,29 +96,33 @@ function createTerminalBuffer(
 ): TerminalBuffer;
 ```
 
-## SerialSessionState
+## SerialSessionState / SerialSessionStatus
 
-The same union is available as a **const object** `SerialSessionState` (e.g. `SerialSessionState.Connected` is `'connected'`) for IDE completion and to avoid string typos. String literals stay valid for types and runtime comparisons.
+v3 exposes **`SerialSessionStatus`** as lifecycle string constants (e.g. `SerialSessionStatus.Connected` is `'connected'`) and **`SerialSessionState`** as the discriminated union type emitted by `state$`.
 
-`state$` emits one of:
+`state$` emits objects such as:
 
-- `'idle'` — no active port; initial state when Web Serial is supported.
-- `'connecting'` — `connect$` is in flight.
-- `'connected'` — port is open and the read pump is running.
-- `'disconnecting'` — `disconnect$` is in flight.
-- `'unsupported'` — `navigator.serial` was not available at session creation time.
-- `'error'` — a fatal failure occurred. Call `disconnect$` to recover, or create a new session.
-- `'disposed'` — the session was permanently torn down via `dispose$` / `destroy$`. All observables complete; create a new session to continue.
+- `{ status: 'idle' }` — no active port; initial state when Web Serial is supported.
+- `{ status: 'connecting' }` — `connect$` is in flight.
+- `{ status: 'connected', portInfo }` — port is open and the read pump is running.
+- `{ status: 'disconnecting' }` — `disconnect$` is in flight.
+- `{ status: 'unsupported' }` — `navigator.serial` was not available at session creation time.
+- `{ status: 'error', error }` — fatal failure; `error` is the same `SerialError` instance on `errors$`.
+- `{ status: 'disposed' }` — session permanently torn down via `dispose$`.
 
-Valid transitions:
+Example:
 
+```typescript
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Connected) {
+    console.log(state.portInfo);
+  }
+});
 ```
-idle -> connecting -> connected -> disconnecting -> idle
-                              \-> error
-idle / connected / connecting / disconnecting / error -> error (fatal failure)
-any -> unsupported (when navigator.serial is missing at construction)
-(any active state) -> disposed (permanent teardown via dispose$)
-```
+
+See [Migrating to v3](./MIGRATION_V3.md) for the v2 string migration.
 
 ## SerialSession
 
@@ -167,11 +171,11 @@ Replays the current state on subscribe. Prefer driving your UI from this stream 
 
 ### `isConnected$: Observable<boolean>`
 
-`true` when the session is in `'connected'`; `false` for every other `SerialSessionState` value. Derived from `state$` with `distinctUntilChanged` so simple UIs can bind without repeating string comparisons (you can still `map` `state$` yourself if you prefer).
+`true` when `state$.status` is `SerialSessionStatus.Connected`; `false` otherwise.
 
 ### `errors$: Observable<SerialError>`
 
-Primary error channel. Every connect / read / write / close failure is normalised to `SerialError` and pushed here. Fatal failures additionally drive `state$` to `'error'` and tear down the live pump and port.
+Primary error channel. Every connect / read / write / close failure is normalised to `SerialError` and pushed here. Fatal failures additionally drive `state$` to `{ status: 'error', error }` and tear down the live pump and port.
 
 ### `receive$: Observable<string>`
 

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
@@ -1,14 +1,32 @@
-# v3 への移行（`SerialErrorCode` const object）
+# v3 への移行
 
-v3 では `SerialErrorCode` の TypeScript 上の宣言方法が変わります。**ランタイムの値とメンバー名は不変**です — `SerialErrorCode.READ_FAILED` は引き続き文字列 `'READ_FAILED'` です。
+v3 では TypeScript 向けに次の 2 つの破壊的変更があります。
 
-本ガイドでは変更点と、必要に応じて更新すべき箇所を説明します。
+1. **`SerialErrorCode`** — `enum` から const object + union type へ（ランタイム値は不変）。
+2. **`state$` の payload** — フラットな文字列から、状態ごとの詳細を持つ discriminated union へ。
+
+本ガイドでは両方を説明します。エラーコードのランタイム文字列は変わりません（`SerialErrorCode.READ_FAILED` は引き続き `'READ_FAILED'` です）。
 
 ## TL;DR
 
 ```typescript
-// v2 も v3 も — 典型的な使い方は変更不要
-import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
+import {
+  SerialError,
+  SerialErrorCode,
+  SerialSessionStatus,
+  type SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state: SerialSessionState) => {
+  switch (state.status) {
+    case SerialSessionStatus.Connected:
+      console.log(state.portInfo);
+      break;
+    case SerialSessionStatus.Error:
+      console.error(state.error);
+      break;
+  }
+});
 
 session.errors$.subscribe((error) => {
   if (error.is(SerialErrorCode.READ_FAILED)) {
@@ -17,78 +35,112 @@ session.errors$.subscribe((error) => {
 });
 ```
 
-## 変更内容
+---
+
+## 1. `SerialErrorCode` const object
+
+### 変更内容
 
 | v2 | v3 |
 | --- | --- |
 | `export enum SerialErrorCode { ... }` | `export const SerialErrorCode = { ... } as const` + `export type SerialErrorCode` |
 | TypeDoc: `enums/SerialErrorCode.html` | TypeDoc: `variables/SerialErrorCode.html` |
 
-`SerialError`、`SerialErrorContextMap`、`SerialSessionState` は本変更の対象外です。
-
-## 移行不要（典型的なパターン）
-
-以下は v2 と v3 で同じように動作します:
+### 移行不要（典型的なパターン）
 
 - `SerialErrorCode.BROWSER_NOT_SUPPORTED`（他のメンバーも同様）
 - `error.code === SerialErrorCode.WRITE_FAILED`
 - `error.is(SerialErrorCode.LINE_BUFFER_OVERFLOW)` による `context` の narrowing
 - `switch (error.code) { case SerialErrorCode.READ_FAILED: ... }`
-- `Object.values(SerialErrorCode)`（文字列値のみを返す）
 
-## 更新が必要な場合
+### 更新が必要な場合
 
-### 型のみの import
+- **型のみの import** — `import type { SerialErrorCode } from '@gurezo/web-serial-rxjs'` のまま利用可能。
+- **TypeDoc の深いリンク** — `enums/SerialErrorCode.html` から `variables/SerialErrorCode.html` へ更新。
+- **`.d.ts` を解析するツール** — 宣言形が `enum` から `const` + type alias に変わります。
 
-型だけ import する場合は従来どおり:
+---
+
+## 2. discriminated union `state$`
+
+### 変更内容
+
+| v2 | v3 |
+| --- | --- |
+| `state$: Observable<'idle' \| 'connected' \| ...>` | `state$: Observable<SerialSessionState>`（discriminated union） |
+| `SerialSessionState` const（文字列リテラル） | **`SerialSessionStatus`** const（文字列リテラル） |
+| `state === SerialSessionState.Connected` | `state.status === SerialSessionStatus.Connected` |
+| `state$` と `portInfo$` / `errors$` を手動で相関 | `connected` に `portInfo`、`error` に `SerialError` を同梱 |
+
+### v2（変更前）
 
 ```typescript
-import type { SerialErrorCode } from '@gurezo/web-serial-rxjs';
+import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  if (state === SerialSessionState.Connected) {
+    session.getPortInfo(); // 別途取得
+  }
+});
 ```
 
-型は enum 型から string literal union へ変わりますが、多くのアプリではそのまま置き換え可能です。
-
-### enum 固有の挙動に依存していたコード
-
-以下に依存している場合は見直しが必要です:
-
-- **enum の reverse mapping** — string enum には reverse mapping はなく、const object も同様です。
-- **任意の文字列の代入** — `const code: SerialErrorCode = someString` は引き続き既知のコード文字列である必要があります。
-- **TypeDoc の深いリンク** — ブックマークを `enums/SerialErrorCode.html` から `variables/SerialErrorCode.html` へ更新してください。
-
-### `.d.ts` の宣言形
-
-公開型は `enum SerialErrorCode` から次の形へ変わります:
+### v3（変更後）
 
 ```typescript
-export declare const SerialErrorCode: {
-  readonly BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED';
-  // ...
-};
-export type SerialErrorCode =
-  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  switch (state.status) {
+    case SerialSessionStatus.Connected:
+      console.log(state.portInfo);
+      break;
+    case SerialSessionStatus.Error:
+      console.error(state.error);
+      break;
+  }
+});
 ```
 
-`.d.ts` を解析して `enum` 宣言を期待するツールは調整が必要な場合があります。ランタイムのバンドルは同等です。
-
-## `SerialSessionState` との統一
-
-v3 では、すでに `SerialSessionState` で採用しているパターンを `SerialErrorCode` にも適用します:
+### 型の形
 
 ```typescript
-export const SerialErrorCode = {
-  BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED',
-  READ_FAILED: 'READ_FAILED',
-  // ...
+export const SerialSessionStatus = {
+  Idle: 'idle',
+  Connecting: 'connecting',
+  Connected: 'connected',
+  Disconnecting: 'disconnecting',
+  Unsupported: 'unsupported',
+  Error: 'error',
+  Disposed: 'disposed',
 } as const;
 
-export type SerialErrorCode =
-  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+export type SerialSessionState =
+  | { readonly status: typeof SerialSessionStatus.Idle }
+  | { readonly status: typeof SerialSessionStatus.Connecting }
+  | { readonly status: typeof SerialSessionStatus.Connected; readonly portInfo: SerialPortInfo }
+  | { readonly status: typeof SerialSessionStatus.Disconnecting }
+  | { readonly status: typeof SerialSessionStatus.Unsupported }
+  | { readonly status: typeof SerialSessionStatus.Error; readonly error: SerialError }
+  | { readonly status: typeof SerialSessionStatus.Disposed };
 ```
 
-メンバー名は `SCREAMING_SNAKE_CASE` のままです（`SerialSessionState` の PascalCase キーとは意図的に異なります）。既存の `SerialErrorCode.X` 参照を壊しません。
+### 移行チェックリスト
+
+- [ ] **定数**として使っていた `SerialSessionState` を `SerialSessionStatus` に置き換える。
+- [ ] `state === SerialSessionState.X` を `state.status === SerialSessionStatus.X` に置き換える。
+- [ ] `switch (state)` を `switch (state.status)` に置き換える（または `if` で `state.status` を比較）。
+- [ ] `connected` 時は `state.portInfo` を利用（任意 — `portInfo$` も引き続き利用可能）。
+- [ ] `error` 時は `state.error` を利用（fatal error は `errors$` と同一インスタンス）。
+
+### 変更なし
+
+- `portInfo$`、`getPortInfo()`、`errors$`、`isConnected$` は引き続き利用可能。
+- `isConnected$` は内部で connected 状態から派生します。
+
+---
 
 ## 関連ドキュメント
 
 - [v1 から v2 への移行](./MIGRATION_V2.ja.md)
+- [API リファレンス – SerialSessionState / SerialSessionStatus](./API_REFERENCE.ja.md#serialsessionstate--serialsessionstatus)
 - [API リファレンス – SerialError / SerialErrorCode](./API_REFERENCE.ja.md#serialerror--serialerrorcode)

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.md
@@ -1,14 +1,32 @@
-# Migrating to v3 (`SerialErrorCode` const object)
+# Migrating to v3
 
-v3 changes how `SerialErrorCode` is declared in TypeScript. **Runtime values and member names are unchanged** — `SerialErrorCode.READ_FAILED` is still the string `'READ_FAILED'`.
+v3 introduces two TypeScript-facing breaking changes:
 
-This guide covers what changed and what (if anything) you need to update.
+1. **`SerialErrorCode`** — `enum` → const object + union type (runtime values unchanged).
+2. **`state$` payload** — flat string → discriminated union with per-status detail.
+
+This guide covers both. Runtime string values for error codes are unchanged (`SerialErrorCode.READ_FAILED` is still `'READ_FAILED'`).
 
 ## TL;DR
 
 ```typescript
-// v2 and v3 — no change required for typical usage
-import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
+import {
+  SerialError,
+  SerialErrorCode,
+  SerialSessionStatus,
+  type SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state: SerialSessionState) => {
+  switch (state.status) {
+    case SerialSessionStatus.Connected:
+      console.log(state.portInfo);
+      break;
+    case SerialSessionStatus.Error:
+      console.error(state.error);
+      break;
+  }
+});
 
 session.errors$.subscribe((error) => {
   if (error.is(SerialErrorCode.READ_FAILED)) {
@@ -17,78 +35,112 @@ session.errors$.subscribe((error) => {
 });
 ```
 
-## What changed
+---
+
+## 1. `SerialErrorCode` const object
+
+### What changed
 
 | v2 | v3 |
 | --- | --- |
 | `export enum SerialErrorCode { ... }` | `export const SerialErrorCode = { ... } as const` + `export type SerialErrorCode` |
 | TypeDoc: `enums/SerialErrorCode.html` | TypeDoc: `variables/SerialErrorCode.html` |
 
-`SerialError`, `SerialErrorContextMap`, and `SerialSessionState` are not affected by this change.
-
-## No migration needed (typical patterns)
-
-These patterns work the same in v2 and v3:
+### No migration needed (typical patterns)
 
 - `SerialErrorCode.BROWSER_NOT_SUPPORTED` (and any other member)
 - `error.code === SerialErrorCode.WRITE_FAILED`
 - `error.is(SerialErrorCode.LINE_BUFFER_OVERFLOW)` with narrowed `context`
 - `switch (error.code) { case SerialErrorCode.READ_FAILED: ... }`
-- `Object.values(SerialErrorCode)` (returns string values only)
 
-## When you may need to update
+### When you may need to update
 
-### Type-only imports
-
-If you import `SerialErrorCode` as a type only, continue using:
-
-```typescript
-import type { SerialErrorCode } from '@gurezo/web-serial-rxjs';
-```
-
-The type is now a string literal union instead of an enum type. For most apps this is a drop-in replacement.
-
-### Code that depended on enum-specific behaviour
-
-Update if you relied on:
-
-- **Enum reverse mapping** — string enums never had reverse mapping; const object behaves the same.
-- **Assigning arbitrary strings** — `const code: SerialErrorCode = someString` still requires the string to match a known code.
+- **Type-only imports** — continue using `import type { SerialErrorCode } from '@gurezo/web-serial-rxjs'`.
 - **TypeDoc deep links** — update bookmarks from `enums/SerialErrorCode.html` to `variables/SerialErrorCode.html`.
+- **Tools parsing `.d.ts`** — declaration shape changes from `enum` to `const` + type alias.
 
-### Declaration shape in `.d.ts`
+---
 
-Published types change from `enum SerialErrorCode` to:
+## 2. Discriminated union `state$`
+
+### What changed
+
+| v2 | v3 |
+| --- | --- |
+| `state$: Observable<'idle' \| 'connected' \| ...>` | `state$: Observable<SerialSessionState>` (discriminated union) |
+| `SerialSessionState` const (string literals) | **`SerialSessionStatus`** const (string literals) |
+| Compare `state === SerialSessionState.Connected` | Compare `state.status === SerialSessionStatus.Connected` |
+| Correlate `state$` + `portInfo$` / `errors$` manually | `connected` carries `portInfo`; `error` carries `SerialError` |
+
+### v2 (before)
 
 ```typescript
-export declare const SerialErrorCode: {
-  readonly BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED';
-  // ...
-};
-export type SerialErrorCode =
-  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  if (state === SerialSessionState.Connected) {
+    session.getPortInfo(); // separate call
+  }
+});
 ```
 
-Tools that parse `.d.ts` and expect an `enum` declaration may need adjustment. Runtime bundles are equivalent.
-
-## Alignment with `SerialSessionState`
-
-v3 applies the same pattern already used by `SerialSessionState`:
+### v3 (after)
 
 ```typescript
-export const SerialErrorCode = {
-  BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED',
-  READ_FAILED: 'READ_FAILED',
-  // ...
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  switch (state.status) {
+    case SerialSessionStatus.Connected:
+      console.log(state.portInfo);
+      break;
+    case SerialSessionStatus.Error:
+      console.error(state.error);
+      break;
+  }
+});
+```
+
+### Type shape
+
+```typescript
+export const SerialSessionStatus = {
+  Idle: 'idle',
+  Connecting: 'connecting',
+  Connected: 'connected',
+  Disconnecting: 'disconnecting',
+  Unsupported: 'unsupported',
+  Error: 'error',
+  Disposed: 'disposed',
 } as const;
 
-export type SerialErrorCode =
-  (typeof SerialErrorCode)[keyof typeof SerialErrorCode];
+export type SerialSessionState =
+  | { readonly status: typeof SerialSessionStatus.Idle }
+  | { readonly status: typeof SerialSessionStatus.Connecting }
+  | { readonly status: typeof SerialSessionStatus.Connected; readonly portInfo: SerialPortInfo }
+  | { readonly status: typeof SerialSessionStatus.Disconnecting }
+  | { readonly status: typeof SerialSessionStatus.Unsupported }
+  | { readonly status: typeof SerialSessionStatus.Error; readonly error: SerialError }
+  | { readonly status: typeof SerialSessionStatus.Disposed };
 ```
 
-Member names stay `SCREAMING_SNAKE_CASE` (unlike `SerialSessionState`'s PascalCase keys) so existing `SerialErrorCode.X` references remain valid.
+### Migration checklist
+
+- [ ] Replace `import { SerialSessionState }` used as **constants** with `SerialSessionStatus`.
+- [ ] Replace `state === SerialSessionState.X` with `state.status === SerialSessionStatus.X`.
+- [ ] Replace `switch (state)` with `switch (state.status)` (or compare `state.status` in `if`).
+- [ ] Use `state.portInfo` when `state.status === 'connected'` instead of correlating `portInfo$` (optional — `portInfo$` still works).
+- [ ] Use `state.error` when `state.status === 'error'` (same instance as `errors$` for fatal errors).
+
+### Unchanged
+
+- `portInfo$`, `getPortInfo()`, `errors$`, and `isConnected$` remain available.
+- `isConnected$` still derives from connected status internally.
+
+---
 
 ## See also
 
 - [Migrating from v1 to v2](./MIGRATION_V2.md)
+- [API Reference – SerialSessionState / SerialSessionStatus](./API_REFERENCE.md#serialsessionstate--serialsessionstatus)
 - [API Reference – SerialError / SerialErrorCode](./API_REFERENCE.md#serialerror--serialerrorcode)

--- a/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
@@ -48,9 +48,10 @@ TypeDoc のトップページから、まず以下を参照してください。
 
 | 公開面 | 役割 |
 | --- | --- |
-| `state$` | **接続ライフサイクル** — `idle` / `connecting` / `connected` / `disconnecting` / `error` / `unsupported` / `disposed`。購読時に現在値をリプレイ。分岐は文字列直書きではなく **`SerialSessionState`** との比較を推奨。 |
-| `SerialSessionState` | **状態定数** — エクスポートされる const object（例: `SerialSessionState.Connected`, `SerialSessionState.Idle`）。`state$` が emit する値と同じ。 |
-| `isConnected$` | **接続中かどうか** — `state$` が `SerialSessionState.Connected` のときだけ `true`、それ以外は `false`（`state$` から `distinctUntilChanged` 付きで派生）。 |
+| `state$` | **接続ライフサイクル** — discriminated union（`status` + 必要に応じ `portInfo` / `error`）。購読時に現在値をリプレイ。分岐は **`SerialSessionStatus`** との比較を推奨。 |
+| `SerialSessionStatus` | **状態定数** — エクスポートされる const object（例: `SerialSessionStatus.Connected` → `'connected'`）。`state$.status` と比較する。 |
+| `SerialSessionState` | **`state$` の payload 型** — discriminated union。 |
+| `isConnected$` | **接続中かどうか** — `state$.status` が `SerialSessionStatus.Connected` のときだけ `true`（`state$` から `distinctUntilChanged` 付きで派生）。 |
 | `receive$` | **生のデコードチャンク** — UTF-8 テキストを read pump が返すとおりに受け取る（行揃えではない。マルチバイト安全）。`\r` 等も保持。**ターミナル風の表示**や `\r` による上書き表示向け。 |
 | `terminalText$` | **ターミナル表示向けの累積テキスト** — `receive$` 由来の表示用テキスト。`\r` による上書きを折りたたみつつ通常の改行挙動は維持するため、ターミナル風ビューへ 1 つの文字列をそのままバインドしたい場合に使います。既定では完了行 10,000 行・文字数 1,048,576 文字まで保持します（`SerialSessionOptions.terminalBuffer` で変更可能）。 |
 | `lines$` | **行単位の受信** — `\n` / `\r\n` / 内部の `\r` など実装に従い 1 行ずつ emit。**ログ・1 行ごとの解析**向け。`\r` をそのまま残す必要がある raw ターミナル表示には向かない。 |
@@ -61,30 +62,30 @@ TypeDoc のトップページから、まず以下を参照してください。
 | `send$(string \| Uint8Array)` | 送信を **FIFO** で直列化（並行 `send$` も呼び出し順）。 |
 | `isBrowserSupported()` | `connect$` の前に使う、Web Serial 利用可否の同期的な `boolean`。 |
 
-### SerialSessionState（早見表）
+### SerialSessionStatus（早見表）
 
-`state$` が emit する文字列のユニオンです。コードでは **const オブジェクト**（例: `SerialSessionState.Connected` → `'connected'`）での比較を推奨します。有効な遷移・例外系の扱いの詳細は [API リファレンスの SerialSessionState](https://gurezo.github.io/web-serial-rxjs/variables/SerialSessionState.html) および [GitHub 上の表・図](./API_REFERENCE.ja.md#serialsessionstate) を参照してください。
+`state$` の各 variant は `status` フィールドを持ちます。コードでは **const オブジェクト**（例: `SerialSessionStatus.Connected` → `'connected'`）での比較を推奨します。
 
 | 定数 | 値 | 意味 |
 | --- | --- | --- |
-| `SerialSessionState.Idle` | `'idle'` | ポート未接続。Web Serial 利用可能な場合の初期値。 |
-| `SerialSessionState.Connecting` | `'connecting'` | `connect$` 実行中。 |
-| `SerialSessionState.Connected` | `'connected'` | ポートが開き、内部 read pump が動作中。 |
-| `SerialSessionState.Disconnecting` | `'disconnecting'` | `disconnect$` 実行中。 |
-| `SerialSessionState.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
-| `SerialSessionState.Error` | `'error'` | 接続まわりの致命エラー。`disconnect$` か新しいセッションで復帰。 |
-| `SerialSessionState.Disposed` | `'disposed'` | `dispose$` により永久破棄。すべての Observable が complete。継続には新しいセッションを作成。 |
+| `SerialSessionStatus.Idle` | `'idle'` | ポート未接続。Web Serial 利用可能な場合の初期値。 |
+| `SerialSessionStatus.Connecting` | `'connecting'` | `connect$` 実行中。 |
+| `SerialSessionStatus.Connected` | `'connected'` | ポートが開き、内部 read pump が動作中。`portInfo` 付き。 |
+| `SerialSessionStatus.Disconnecting` | `'disconnecting'` | `disconnect$` 実行中。 |
+| `SerialSessionStatus.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
+| `SerialSessionStatus.Error` | `'error'` | 接続まわりの致命エラー。`error` 付き。 |
+| `SerialSessionStatus.Disposed` | `'disposed'` | `dispose$` により永久破棄。すべての Observable が complete。 |
 
 **`receive$` と `lines$`:** 機器から来たバイト列を**そのまま**画面に反映する（シェル、`ls` のプログレス、`\r` で行を描き直す出力など）ときは **`receive$`** を使います。**改行区切りのログ**や**1 行ずつ処理するプロトコル**では **`lines$`** が適しています。ターミナル表示に **`lines$`** を繋ぐと、内部で `\r` を行境界として扱うため **上書き表示が壊れる**ことがあります。独自区切りは **`receive$` 上で RxJS を合成**します（[高度な使用方法 — 行単位のフレーミング](./ADVANCED_USAGE.ja.md)）。
 
-**`isConnected$`（UI 用）** — 読み取り専用の `Observable<boolean>` です。`state$` を `SerialSessionState.Connected` と毎回比較しなくても接続有無の UI 分岐に使えます。独自ルールが必要な場合は、従来どおり `state$` から `map` で派生しても構いません。
+**`isConnected$`（UI 用）** — 読み取り専用の `Observable<boolean>` です。`state$.status` を `SerialSessionStatus.Connected` と毎回比較しなくても接続有無の UI 分岐に使えます。
 
 **`lines$`（行区切り）** — 組み込みの行分割。ターミナルのミラーや `\r` を保持したいときは **`receive$`** を購読します（[高度な使用方法 — 行単位のフレーミング](./ADVANCED_USAGE.ja.md)）。
 
 ### 最小サンプル
 
 ```typescript
-import { createSerialSession, SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { createSerialSession, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { filter } from 'rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
@@ -96,9 +97,9 @@ if (!session.isBrowserSupported()) {
 session.lines$.subscribe(console.log);
 session.errors$.subscribe(console.error);
 session.state$
-  .pipe(filter((s) => s === SerialSessionState.Connected))
-  .subscribe(() => {
-    /* 例: ポートが開いてから有効化する UI */
+  .pipe(filter((s) => s.status === SerialSessionStatus.Connected))
+  .subscribe((state) => {
+    console.log(state.portInfo);
   });
 session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();

--- a/packages/web-serial-rxjs/docs/OVERVIEW.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.md
@@ -48,9 +48,10 @@ This library is framework-agnostic and can be used with:
 
 | Surface | Role |
 | --- | --- |
-| `state$` | **Connection lifecycle** — `idle` / `connecting` / `connected` / `disconnecting` / `error` / `unsupported` / `disposed`. Replays the current state on subscribe. Compare with **`SerialSessionState`** instead of string literals. |
-| `SerialSessionState` | **State constants** — exported const object (e.g. `SerialSessionState.Connected`, `SerialSessionState.Idle`) with the same values `state$` emits. |
-| `isConnected$` | **Connected flag** — `true` only when `state$` is `SerialSessionState.Connected`; `false` in every other state (derived from `state$` with `distinctUntilChanged`). |
+| `state$` | **Connection lifecycle** — discriminated union (`status` plus optional `portInfo` / `error`). Replays on subscribe. Compare **`state.status`** with **`SerialSessionStatus`**. |
+| `SerialSessionStatus` | **Status constants** — const object (e.g. `SerialSessionStatus.Connected` → `'connected'`). Compare with `state$.status`. |
+| `SerialSessionState` | **Payload type** for `state$` (discriminated union). |
+| `isConnected$` | **Connected flag** — `true` only when `state$.status` is `SerialSessionStatus.Connected`. |
 | `receive$` | **Raw decoder chunks** — UTF-8 text as emitted by the pump (not line-aligned; multi-byte safe). Preserves `\r` and other control characters. Use for **terminal-like mirrors** and progress output that relies on carriage-return redraws. |
 | `terminalText$` | **Terminal-ready cumulative text** — display-oriented text derived from `receive$` that folds carriage-return redraws while keeping normal newline behavior. Use when you want to bind one string directly to a terminal-like viewport. By default retains at most 10,000 lines and 1,048,576 characters (configure via `SerialSessionOptions.terminalBuffer`). |
 | `lines$` | **Line-delimited UTF-8 text** — one string per complete line via the built-in buffer (`\n`, `\r\n`, interior `\r`). Use for **logs** and **line-by-line parsing**, not for mirroring raw terminal streams where `\r` must stay intact. |
@@ -61,30 +62,30 @@ This library is framework-agnostic and can be used with:
 | `send$(string \| Uint8Array)` | **Enqueue** outgoing data; writes are **FIFO-ordered** when multiple `send$` run concurrently. |
 | `isBrowserSupported()` | Synchronous `boolean` for Web Serial availability before `connect$`. |
 
-### SerialSessionState (quick reference)
+### SerialSessionStatus (quick reference)
 
-`state$` uses the string union below. Prefer the **const object** (e.g. `SerialSessionState.Connected` → `'connected'`) in code. Full lifecycle diagram, transitions, and edge cases: [API Reference – SerialSessionState](variables/SerialSessionState.html).
+Each `state$` emission has a `status` field. Prefer the **const object** (e.g. `SerialSessionStatus.Connected` → `'connected'`).
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
-| `SerialSessionState.Idle` | `'idle'` | No open port; initial state when the browser supports Web Serial. |
-| `SerialSessionState.Connecting` | `'connecting'` | `connect$` in progress. |
-| `SerialSessionState.Connected` | `'connected'` | Port is open; internal read pump is running. |
-| `SerialSessionState.Disconnecting` | `'disconnecting'` | `disconnect$` in progress. |
-| `SerialSessionState.Unsupported` | `'unsupported'` | Web Serial was not available when the session was created. |
-| `SerialSessionState.Error` | `'error'` | Fatal I/O or lifecycle failure; call `disconnect$` or build a new session. |
-| `SerialSessionState.Disposed` | `'disposed'` | Session permanently torn down via `dispose$`; all observables complete. Create a new session to continue. |
+| `SerialSessionStatus.Idle` | `'idle'` | No open port; initial when Web Serial is supported. |
+| `SerialSessionStatus.Connecting` | `'connecting'` | `connect$` in progress. |
+| `SerialSessionStatus.Connected` | `'connected'` | Port open; read pump running (`portInfo` included). |
+| `SerialSessionStatus.Disconnecting` | `'disconnecting'` | `disconnect$` in progress. |
+| `SerialSessionStatus.Unsupported` | `'unsupported'` | Web Serial unavailable at session creation. |
+| `SerialSessionStatus.Error` | `'error'` | Fatal failure (`error` included). |
+| `SerialSessionStatus.Disposed` | `'disposed'` | Session permanently torn down via `dispose$`. |
 
 **`receive$` vs `lines$`:** use **`receive$`** when the UI must show **exactly** what the device sent (e.g. interactive shells, `ls` progress, any stream using `\r` to redraw a line). Use **`lines$`** for **newline-oriented** consumers—logs, one-line replies, parsers. Feeding **`lines$`** into a terminal widget can drop or split on `\r` and break redraw semantics. For custom delimiters beyond the built-in line buffer, compose on **`receive$`** ([Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
 
-**`isConnected$` (for simple UIs)** — a read-only `Observable<boolean>`. Use it for “port open?” toggles without comparing `state$` to `SerialSessionState.Connected` yourself. You can still derive your own boolean from `state$` with `map` if you need different rules.
+**`isConnected$` (for simple UIs)** — a read-only `Observable<boolean>`. Use it for “port open?” toggles without comparing `state$.status` to `SerialSessionStatus.Connected` yourself.
 
 **`lines$` (newline framing)** — built-in line splitting; for non-line protocols or terminal mirrors, subscribe to **`receive$`** instead (recipes in [Advanced Usage](./ADVANCED_USAGE.md#line-framing)).
 
 ### Minimal example
 
 ```typescript
-import { createSerialSession, SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { createSerialSession, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { filter } from 'rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
@@ -96,9 +97,9 @@ if (!session.isBrowserSupported()) {
 session.lines$.subscribe(console.log);
 session.errors$.subscribe(console.error);
 session.state$
-  .pipe(filter((s) => s === SerialSessionState.Connected))
-  .subscribe(() => {
-    /* e.g. enable UI that must wait until the port is open */
+  .pipe(filter((s) => s.status === SerialSessionStatus.Connected))
+  .subscribe((state) => {
+    console.log(state.portInfo);
   });
 session.connect$().subscribe();
 session.send$('hello\r\n').subscribe();

--- a/packages/web-serial-rxjs/docs/QUICK_START.ja.md
+++ b/packages/web-serial-rxjs/docs/QUICK_START.ja.md
@@ -4,19 +4,19 @@
 
 標準的な改行区切り（`\n` / `\r\n`）には **`lines$`** を使います。**`receive$`** はデコーダが返す生のチャンク列のままです。独自区切りや別の分割ルールが必要なときは `receive$` 上に `scan` などで組み立てます（[高度な使用方法](./ADVANCED_USAGE.ja.md#行単位のフレーミング)）。接続の真偽は **`isConnected$`** を使うか、従来どおり `state$` から `map` しても構いません。
 
-### SerialSessionState（早見表）
+### SerialSessionStatus（早見表）
 
 | 定数 | 値 | 意味 |
 | --- | --- | --- |
-| `SerialSessionState.Idle` | `'idle'` | ポート未接続。Web Serial 利用可能な場合の初期値。 |
-| `SerialSessionState.Connecting` | `'connecting'` | `connect$` 実行中。 |
-| `SerialSessionState.Connected` | `'connected'` | ポートが開き、read pump が動作中。 |
-| `SerialSessionState.Disconnecting` | `'disconnecting'` | `disconnect$` 実行中。 |
-| `SerialSessionState.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
-| `SerialSessionState.Error` | `'error'` | 致命的な失敗。`disconnect$` または新しいセッションで復帰。 |
-| `SerialSessionState.Disposed` | `'disposed'` | `dispose$` により永久破棄。すべての Observable が complete。 |
+| `SerialSessionStatus.Idle` | `'idle'` | ポート未接続。Web Serial 利用可能な場合の初期値。 |
+| `SerialSessionStatus.Connecting` | `'connecting'` | `connect$` 実行中。 |
+| `SerialSessionStatus.Connected` | `'connected'` | ポートが開き、read pump が動作中（`portInfo` 付き）。 |
+| `SerialSessionStatus.Disconnecting` | `'disconnecting'` | `disconnect$` 実行中。 |
+| `SerialSessionStatus.Unsupported` | `'unsupported'` | セッション生成時点で Web Serial が利用できない。 |
+| `SerialSessionStatus.Error` | `'error'` | 致命的な失敗（`error` 付き）。 |
+| `SerialSessionStatus.Disposed` | `'disposed'` | `dispose$` により永久破棄。すべての Observable が complete。 |
 
-遷移・詳細は [API リファレンスの SerialSessionState](./API_REFERENCE.ja.md#serialsessionstate) を参照してください。
+詳細は [API リファレンス](./API_REFERENCE.ja.md#serialsessionstate--serialsessionstatus) と [v3 移行ガイド](./MIGRATION_V3.ja.md) を参照してください。
 
 ```typescript
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
@@ -43,14 +43,17 @@ session.connect$().subscribe({
 });
 ```
 
-`state$` の分岐は **`SerialSessionState`** の定数で比較します（`'connected'` などの文字列直書きは避けてください）:
+`state$` の分岐は **`state.status`** を **`SerialSessionStatus`** の定数と比較します:
 
 ```typescript
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 
-session.state$.subscribe((s) => {
-  if (s === SerialSessionState.Unsupported) {
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Unsupported) {
     console.warn('このブラウザでは Web Serial を利用できません');
+  }
+  if (state.status === SerialSessionStatus.Connected) {
+    console.log(state.portInfo);
   }
 });
 ```

--- a/packages/web-serial-rxjs/docs/QUICK_START.md
+++ b/packages/web-serial-rxjs/docs/QUICK_START.md
@@ -4,19 +4,19 @@ This is the **shortest path** to opening a serial port, receiving **newline-deli
 
 Use **`lines$`** for standard newline-framed text (`\n`, `\r\n`). **`receive$`** is still the raw UTF-8 decoder chunk stream when you need custom framing (see [Advanced Usage](./ADVANCED_USAGE.md#line-framing)). For a simple "are we connected?" boolean, use **`isConnected$`** (or still derive from `state$` with `map` if you prefer).
 
-### SerialSessionState (quick reference)
+### SerialSessionStatus (quick reference)
 
 | Constant | Value | Meaning |
 | --- | --- | --- |
-| `SerialSessionState.Idle` | `'idle'` | No open port; initial when Web Serial is supported. |
-| `SerialSessionState.Connecting` | `'connecting'` | `connect$` in progress. |
-| `SerialSessionState.Connected` | `'connected'` | Port open; read pump running. |
-| `SerialSessionState.Disconnecting` | `'disconnecting'` | `disconnect$` in progress. |
-| `SerialSessionState.Unsupported` | `'unsupported'` | Web Serial unavailable at session creation. |
-| `SerialSessionState.Error` | `'error'` | Fatal failure; `disconnect$` or a new session. |
-| `SerialSessionState.Disposed` | `'disposed'` | Session permanently torn down via `dispose$`; all observables complete. |
+| `SerialSessionStatus.Idle` | `'idle'` | No open port; initial when Web Serial is supported. |
+| `SerialSessionStatus.Connecting` | `'connecting'` | `connect$` in progress. |
+| `SerialSessionStatus.Connected` | `'connected'` | Port open; read pump running (`portInfo` included). |
+| `SerialSessionStatus.Disconnecting` | `'disconnecting'` | `disconnect$` in progress. |
+| `SerialSessionStatus.Unsupported` | `'unsupported'` | Web Serial unavailable at session creation. |
+| `SerialSessionStatus.Error` | `'error'` | Fatal failure (`error` included). |
+| `SerialSessionStatus.Disposed` | `'disposed'` | Session permanently torn down via `dispose$`. |
 
-Details and lifecycle: [API Reference – SerialSessionState](./API_REFERENCE.md#serialsessionstate).
+Details: [API Reference](./API_REFERENCE.md#serialsessionstate--serialsessionstatus) and [Migrating to v3](./MIGRATION_V3.md).
 
 ```typescript
 import { createSerialSession } from '@gurezo/web-serial-rxjs';
@@ -45,14 +45,17 @@ session.connect$().subscribe({
 });
 ```
 
-Prefer **`SerialSessionState`** for comparisons (not raw strings such as `'connected'`):
+Compare **`state.status`** with **`SerialSessionStatus`**:
 
 ```typescript
-import { SerialSessionState } from '@gurezo/web-serial-rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 
-session.state$.subscribe((s) => {
-  if (s === SerialSessionState.Unsupported) {
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Unsupported) {
     console.warn('Web Serial is not available');
+  }
+  if (state.status === SerialSessionStatus.Connected) {
+    console.log(state.portInfo);
   }
 });
 ```

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -21,7 +21,8 @@
  * - {@link SerialSessionOptions} - connection options
  * - {@link SerialPayload} - payload accepted by {@link SerialSession.send$}
  * - {@link SerialConnectionOptions} - `port.open` connection parameters (excluding filters)
- * - {@link SerialSessionState} - `state$` payload values (const + type)
+ * - {@link SerialSessionStatus} - lifecycle status literals for `state$.status`
+ * - {@link SerialSessionState} - discriminated union emitted by `state$`
  * - {@link SerialError} / {@link SerialErrorCode} - unified error surface
  * - {@link SerialErrorContextMap} - structured metadata per error code
  *
@@ -63,9 +64,18 @@
 
 export { assertNever } from './internal/assert-never';
 
-export { createSerialSession, SerialSessionState, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions, MAX_RECEIVE_REPLAY_BUFFER_SIZE, MAX_RECEIVE_REPLAY_MAX_CHARS } from './session';
+export { createSerialSession, SerialSessionStatus, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions, MAX_RECEIVE_REPLAY_BUFFER_SIZE, MAX_RECEIVE_REPLAY_MAX_CHARS } from './session';
 export type {
   SerialSession,
+  SerialSessionState,
+  SerialSessionStatus,
+  IdleSessionState,
+  ConnectingSessionState,
+  ConnectedSessionState,
+  DisconnectingSessionState,
+  UnsupportedSessionState,
+  ErrorSessionState,
+  DisposedSessionState,
   SerialSessionOptions,
   SerialSessionReceiveReplayOptions,
   ResolvedSerialSessionOptions,

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -68,7 +68,6 @@ export { createSerialSession, SerialSessionStatus, DEFAULT_LINE_BUFFER_OPTIONS, 
 export type {
   SerialSession,
   SerialSessionState,
-  SerialSessionStatus,
   IdleSessionState,
   ConnectingSessionState,
   ConnectedSessionState,

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -20,7 +20,7 @@ import {
   resolveSerialSessionOptions,
   type SerialSessionOptions,
 } from './serial-session-options';
-import { SerialSessionState } from './serial-session-state';
+import { SerialSessionStatus } from './serial-session-state';
 import {
   createInitialRuntime,
   createSessionRuntimeController,
@@ -90,7 +90,7 @@ export function createSerialSession(
   const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const isDisposed = (): boolean =>
-    controller.status === SerialSessionState.Disposed;
+    controller.status === SerialSessionStatus.Disposed;
 
   const errorReporterRef: {
     reportError?: (
@@ -138,7 +138,7 @@ export function createSerialSession(
     resolvedOptions.terminalBuffer,
   ).text$;
   const isConnected$ = controller.state$.pipe(
-    map((state) => state === SerialSessionState.Connected),
+    map((state) => state.status === SerialSessionStatus.Connected),
     distinctUntilChanged(),
   );
   const portInfo$ = portInfoSubject.asObservable();

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -11,7 +11,18 @@ export {
   MAX_RECEIVE_REPLAY_MAX_CHARS,
 } from './serial-session-options';
 export type { SerialPayload, SerialConnectionOptions } from '../types';
-export { SerialSessionState } from './serial-session-state';
+export { SerialSessionStatus } from './serial-session-state';
+export type {
+  SerialSessionState,
+  SerialSessionStatus,
+  IdleSessionState,
+  ConnectingSessionState,
+  ConnectedSessionState,
+  DisconnectingSessionState,
+  UnsupportedSessionState,
+  ErrorSessionState,
+  DisposedSessionState,
+} from './serial-session-state';
 export {
   DEFAULT_LINE_BUFFER_OPTIONS,
   type LineBufferOptions,

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -14,7 +14,6 @@ export type { SerialPayload, SerialConnectionOptions } from '../types';
 export { SerialSessionStatus } from './serial-session-state';
 export type {
   SerialSessionState,
-  SerialSessionStatus,
   IdleSessionState,
   ConnectingSessionState,
   ConnectedSessionState,

--- a/packages/web-serial-rxjs/src/session/internal/session-error-reporter.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-error-reporter.ts
@@ -91,7 +91,7 @@ export function createSessionErrorReporter(deps: SessionErrorReporterDeps): {
       const runtime = controller.runtime;
       const portToClose = getRuntimePort(runtime);
       const pump = getRuntimePump(runtime);
-      controller.transition(createErrorRuntime());
+      controller.transition(createErrorRuntime(serialError));
       sendQueue.clear();
       updatePortInfo(null);
       void teardownPump(pump).then(() => closePortSafely(portToClose));

--- a/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
@@ -11,7 +11,7 @@ import {
 import { createReadPump, type ReadPump } from '../read-pump';
 import type { SendQueue } from '../send-queue';
 import type { ResolvedSerialSessionOptions } from '../serial-session-options';
-import { SerialSessionState } from '../serial-session-state';
+import { SerialSessionStatus } from '../serial-session-state';
 import {
   createConnectedRuntime,
   createConnectingRuntime,
@@ -106,16 +106,16 @@ export function createSessionLifecycle(
   const teardownFromSnapshot = async (
     snapshot: SessionRuntime,
   ): Promise<void> => {
-    if (snapshot.status === SerialSessionState.Connecting) {
+    if (snapshot.status === SerialSessionStatus.Connecting) {
       snapshot.cancel();
     }
 
     sendQueue.clear();
 
     if (
-      snapshot.status === SerialSessionState.Connected ||
-      snapshot.status === SerialSessionState.Disconnecting ||
-      snapshot.status === SerialSessionState.Error
+      snapshot.status === SerialSessionStatus.Connected ||
+      snapshot.status === SerialSessionStatus.Disconnecting ||
+      snapshot.status === SerialSessionStatus.Error
     ) {
       const portToClose = getRuntimePort(snapshot);
       const pump = getRuntimePump(snapshot);
@@ -166,7 +166,7 @@ export function createSessionLifecycle(
   const writeToPort = async (payload: Uint8Array): Promise<void> => {
     const runtime = controller.runtime;
     if (
-      runtime.status !== SerialSessionState.Connected ||
+      runtime.status !== SerialSessionStatus.Connected ||
       !runtime.port.writable
     ) {
       throw new SerialError(
@@ -209,8 +209,8 @@ export function createSessionLifecycle(
 
       const current = controller.status;
       if (
-        current !== SerialSessionState.Idle &&
-        current !== SerialSessionState.Error
+        current !== SerialSessionStatus.Idle &&
+        current !== SerialSessionStatus.Error
       ) {
         const error = reportError(
           new SerialError(
@@ -226,7 +226,7 @@ export function createSessionLifecycle(
       let cancelled = false;
       const cancelInFlightConnect = (): void => {
         cancelled = true;
-        if (controller.status === SerialSessionState.Connecting) {
+        if (controller.status === SerialSessionStatus.Connecting) {
           controller.transition(createIdleRuntime());
         }
       };
@@ -277,7 +277,7 @@ export function createSessionLifecycle(
               messagePrefix: 'Read pump failed',
             }),
           onDone: () => {
-            if (controller.status !== SerialSessionState.Connected) {
+            if (controller.status !== SerialSessionStatus.Connected) {
               return;
             }
             reportError(
@@ -322,16 +322,16 @@ export function createSessionLifecycle(
       const runtime = controller.runtime;
 
       if (
-        runtime.status === SerialSessionState.Idle ||
-        runtime.status === SerialSessionState.Unsupported ||
-        runtime.status === SerialSessionState.Disconnecting
+        runtime.status === SerialSessionStatus.Idle ||
+        runtime.status === SerialSessionStatus.Unsupported ||
+        runtime.status === SerialSessionStatus.Disconnecting
       ) {
         subscriber.next();
         subscriber.complete();
         return;
       }
 
-      if (runtime.status === SerialSessionState.Connecting) {
+      if (runtime.status === SerialSessionStatus.Connecting) {
         runtime.cancel();
         subscriber.next();
         subscriber.complete();
@@ -339,8 +339,8 @@ export function createSessionLifecycle(
       }
 
       if (
-        runtime.status !== SerialSessionState.Connected &&
-        runtime.status !== SerialSessionState.Error
+        runtime.status !== SerialSessionStatus.Connected &&
+        runtime.status !== SerialSessionStatus.Error
       ) {
         const error = reportError(
           new SerialError(

--- a/packages/web-serial-rxjs/src/session/serial-session-state.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-state.ts
@@ -1,11 +1,10 @@
+import type { SerialError } from '../errors/serial-error';
+
 /**
- * Reactive lifecycle state for a {@link SerialSession}.
+ * Canonical status literals for a {@link SerialSession} lifecycle.
  *
- * This is the v2 API counterpart of the legacy `SerialState` used by
- * `SerialClient`. The runtime values are the same flat strings v1
- * consumers used for UI switches; the {@link SerialSessionState} const
- * object is the canonical source of those literals so call sites can
- * avoid string typos and get IDE completion.
+ * Use these constants when comparing {@link SerialSessionState.status}
+ * so call sites avoid string typos and get IDE completion.
  *
  * Lifecycle transitions:
  *
@@ -14,12 +13,12 @@
  *                                \-> error
  * (any)  -> unsupported   (when Web Serial API is unavailable)
  * (any)  -> error         (when an unrecoverable failure occurs)
+ * (any)  -> disposed      (when dispose$ completes)
  * ```
  *
- * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}
- * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/406 | Issue #406}
  */
-export const SerialSessionState = {
+export const SerialSessionStatus = {
   Idle: 'idle',
   Connecting: 'connecting',
   Connected: 'connected',
@@ -30,8 +29,62 @@ export const SerialSessionState = {
 } as const;
 
 /**
- * String union of allowed {@link SerialSessionState} runtime values
- * (same set as the values on the {@link SerialSessionState} object).
+ * String union of allowed {@link SerialSessionStatus} runtime values
+ * (same set as the values on the {@link SerialSessionStatus} object).
+ */
+export type SerialSessionStatus =
+  (typeof SerialSessionStatus)[keyof typeof SerialSessionStatus];
+
+/** @see {@link SerialSessionState} */
+export interface IdleSessionState {
+  readonly status: typeof SerialSessionStatus.Idle;
+}
+
+/** @see {@link SerialSessionState} */
+export interface ConnectingSessionState {
+  readonly status: typeof SerialSessionStatus.Connecting;
+}
+
+/** @see {@link SerialSessionState} */
+export interface ConnectedSessionState {
+  readonly status: typeof SerialSessionStatus.Connected;
+  readonly portInfo: SerialPortInfo;
+}
+
+/** @see {@link SerialSessionState} */
+export interface DisconnectingSessionState {
+  readonly status: typeof SerialSessionStatus.Disconnecting;
+}
+
+/** @see {@link SerialSessionState} */
+export interface UnsupportedSessionState {
+  readonly status: typeof SerialSessionStatus.Unsupported;
+}
+
+/** @see {@link SerialSessionState} */
+export interface ErrorSessionState {
+  readonly status: typeof SerialSessionStatus.Error;
+  readonly error: SerialError;
+}
+
+/** @see {@link SerialSessionState} */
+export interface DisposedSessionState {
+  readonly status: typeof SerialSessionStatus.Disposed;
+}
+
+/**
+ * Discriminated union emitted by {@link SerialSession.state$}.
+ *
+ * Each variant carries the lifecycle `status` plus optional detail fields
+ * (`portInfo` when connected, `error` when in a fatal error state).
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/406 | Issue #406}
  */
 export type SerialSessionState =
-  (typeof SerialSessionState)[keyof typeof SerialSessionState];
+  | IdleSessionState
+  | ConnectingSessionState
+  | ConnectedSessionState
+  | DisconnectingSessionState
+  | UnsupportedSessionState
+  | ErrorSessionState
+  | DisposedSessionState;

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -90,15 +90,16 @@ export interface SerialSession {
   destroy$(): Observable<void>;
 
   /**
-   * Reactive session lifecycle state.
+   * Reactive session lifecycle state as a discriminated union.
    *
-   * Replays the current state on subscribe. UIs should drive entirely from
-   * this stream instead of reconstructing their own BehaviorSubject.
+   * Replays the current state on subscribe. Switch on `state.status` and
+   * use the per-variant fields (`portInfo`, `error`) instead of correlating
+   * separate streams.
    */
   readonly state$: Observable<SerialSessionState>;
 
   /**
-   * `true` when {@link state$} is `'connected'`, `false` for all other states.
+   * `true` when {@link state$} has `status: 'connected'`, `false` otherwise.
    *
    * Derived from `state$` with `distinctUntilChanged` so UIs can bind
    * connect/disabled flags without reimplementing the comparison.
@@ -107,8 +108,8 @@ export interface SerialSession {
 
   /**
    * The active port’s {@link SerialPort.getInfo} snapshot, or `null` when no
-   * port is open (including {@link SerialSessionState.Idle},
-   * {@link SerialSessionState.Error}, and {@link SerialSessionState.Unsupported}).
+   * port is open (including {@link SerialSessionStatus.Idle},
+   * {@link SerialSessionStatus.Error}, and {@link SerialSessionStatus.Unsupported}).
    *
    * Emits the current value on subscribe. Use with {@link state$} to know when
    * the value is valid for your UI.

--- a/packages/web-serial-rxjs/src/session/session-runtime.ts
+++ b/packages/web-serial-rxjs/src/session/session-runtime.ts
@@ -1,7 +1,12 @@
 import { BehaviorSubject, Observable } from 'rxjs';
 import { assertNever } from '../internal/assert-never';
+import type { SerialError } from '../errors/serial-error';
 import type { ReadPump } from './read-pump';
-import { SerialSessionState } from './serial-session-state';
+import {
+  SerialSessionStatus,
+  type SerialSessionState,
+  type SerialSessionStatus as SerialSessionStatusType,
+} from './serial-session-state';
 
 /**
  * Discriminated union representing the full internal runtime state of a
@@ -9,8 +14,8 @@ import { SerialSessionState } from './serial-session-state';
  * are valid for that status.
  *
  * This is the single source of truth for session lifecycle + resources.
- * Public consumers still observe the flat {@link SerialSessionState} string
- * via `state$`; this union is internal only.
+ * Public consumers observe the mapped {@link SerialSessionState} via
+ * `state$`; this union is internal only.
  *
  * @internal
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/397 | Issue #397}
@@ -26,50 +31,51 @@ export type SessionRuntime =
 
 /** @internal */
 export interface IdleRuntime {
-  readonly status: typeof SerialSessionState.Idle;
+  readonly status: typeof SerialSessionStatus.Idle;
 }
 
 /** @internal */
 export interface ConnectingRuntime {
-  readonly status: typeof SerialSessionState.Connecting;
+  readonly status: typeof SerialSessionStatus.Connecting;
   readonly cancel: () => void;
 }
 
 /** @internal */
 export interface ConnectedRuntime {
-  readonly status: typeof SerialSessionState.Connected;
+  readonly status: typeof SerialSessionStatus.Connected;
   readonly port: SerialPort;
   readonly pump: ReadPump;
 }
 
 /** @internal */
 export interface DisconnectingRuntime {
-  readonly status: typeof SerialSessionState.Disconnecting;
+  readonly status: typeof SerialSessionStatus.Disconnecting;
   readonly port: SerialPort | null;
 }
 
 /** @internal */
 export interface ErrorRuntime {
-  readonly status: typeof SerialSessionState.Error;
+  readonly status: typeof SerialSessionStatus.Error;
+  readonly error: SerialError;
 }
 
 /** @internal */
 export interface UnsupportedRuntime {
-  readonly status: typeof SerialSessionState.Unsupported;
+  readonly status: typeof SerialSessionStatus.Unsupported;
 }
 
 /** @internal */
 export interface DisposedRuntime {
-  readonly status: typeof SerialSessionState.Disposed;
+  readonly status: typeof SerialSessionStatus.Disposed;
 }
 
-const S = SerialSessionState;
+const S = SerialSessionStatus;
 
 /**
  * Allowed transitions for the internal SerialSession state machine.
  *
  * `as const satisfies` keeps literal transition targets while ensuring every
- * {@link SerialSessionState} key is present. Drift from the state union
+ * {@link SerialSessionStatus} key is present. Drift from the status union
  * becomes a compile error.
  *
  * @internal
@@ -84,7 +90,7 @@ export const ALLOWED_TRANSITIONS = {
   [S.Unsupported]: [S.Disposed],
   [S.Disposed]: [],
 } as const satisfies Readonly<
-  Record<SerialSessionState, readonly SerialSessionState[]>
+  Record<SerialSessionStatusType, readonly SerialSessionStatusType[]>
 >;
 
 /**
@@ -92,23 +98,52 @@ export const ALLOWED_TRANSITIONS = {
  *
  * @internal
  */
-export type AllowedTransition<T extends SerialSessionState> =
+export type AllowedTransition<T extends SerialSessionStatusType> =
   (typeof ALLOWED_TRANSITIONS)[T][number];
 
 /** @internal */
-export function runtimeToSessionState(runtime: SessionRuntime): SerialSessionState {
+export function runtimeToSessionStatus(
+  runtime: SessionRuntime,
+): SerialSessionStatusType {
   return runtime.status;
+}
+
+/**
+ * Map internal runtime to the public {@link SerialSessionState} payload.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/406 | Issue #406}
+ */
+export function runtimeToPublicState(runtime: SessionRuntime): SerialSessionState {
+  switch (runtime.status) {
+    case S.Idle:
+      return { status: S.Idle };
+    case S.Connecting:
+      return { status: S.Connecting };
+    case S.Connected:
+      return { status: S.Connected, portInfo: runtime.port.getInfo() };
+    case S.Disconnecting:
+      return { status: S.Disconnecting };
+    case S.Unsupported:
+      return { status: S.Unsupported };
+    case S.Error:
+      return { status: S.Error, error: runtime.error };
+    case S.Disposed:
+      return { status: S.Disposed };
+    default:
+      return assertNeverRuntime(runtime);
+  }
 }
 
 /** @internal */
 export function isValidTransition(
-  from: SerialSessionState,
-  to: SerialSessionState,
+  from: SerialSessionStatusType,
+  to: SerialSessionStatusType,
 ): boolean {
   if (from === to) {
     return false;
   }
-  return (ALLOWED_TRANSITIONS[from] as readonly SerialSessionState[]).includes(
+  return (ALLOWED_TRANSITIONS[from] as readonly SerialSessionStatusType[]).includes(
     to,
   );
 }
@@ -139,8 +174,8 @@ export function createDisconnectingRuntime(
 }
 
 /** @internal */
-export function createErrorRuntime(): ErrorRuntime {
-  return { status: S.Error };
+export function createErrorRuntime(error: SerialError): ErrorRuntime {
+  return { status: S.Error, error };
 }
 
 /** @internal */
@@ -188,13 +223,13 @@ export function getRuntimePump(runtime: SessionRuntime): ReadPump | null {
 
 /**
  * Controller that owns the {@link SessionRuntime} discriminated union and
- * exposes the public `state$` stream derived from `runtime.status`.
+ * exposes the public `state$` stream derived from the runtime.
  *
  * @internal
  */
 export interface SessionRuntimeController {
   get runtime(): SessionRuntime;
-  get status(): SerialSessionState;
+  get status(): SerialSessionStatusType;
   get state$(): Observable<SerialSessionState>;
   transition(next: SessionRuntime): boolean;
   complete(): void;
@@ -210,12 +245,12 @@ export function createSessionRuntimeController(
 ): SessionRuntimeController {
   let runtime = initial;
   const subject = new BehaviorSubject<SerialSessionState>(
-    runtimeToSessionState(initial),
+    runtimeToPublicState(initial),
   );
 
   const transition = (next: SessionRuntime): boolean => {
-    const from = runtimeToSessionState(runtime);
-    const to = runtimeToSessionState(next);
+    const from = runtimeToSessionStatus(runtime);
+    const to = runtimeToSessionStatus(next);
 
     if (from === to) {
       return false;
@@ -231,7 +266,7 @@ export function createSessionRuntimeController(
     }
 
     runtime = next;
-    subject.next(to);
+    subject.next(runtimeToPublicState(next));
     return true;
   };
 
@@ -240,7 +275,7 @@ export function createSessionRuntimeController(
       return runtime;
     },
     get status() {
-      return runtimeToSessionState(runtime);
+      return runtimeToSessionStatus(runtime);
     },
     get state$() {
       return subject.asObservable();

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -11,9 +11,17 @@ import { SerialError } from '../../src/errors/serial-error';
 import { SerialErrorCode } from '../../src/errors/serial-error-code';
 import { createSerialSession } from '../../src/session/create-serial-session';
 import type { SerialSession } from '../../src/session/serial-session';
-import { SerialSessionState } from '../../src/session/serial-session-state';
+import {
+  SerialSessionStatus,
+  type SerialSessionState,
+} from '../../src/session/serial-session-state';
 
-const S = SerialSessionState;
+const S = SerialSessionStatus;
+
+const connectedState = (): SerialSessionState => ({
+  status: S.Connected,
+  portInfo: stubPortInfo,
+});
 
 const stubPortInfo: SerialPortInfo = {
   usbVendorId: 0x1a86,
@@ -186,7 +194,7 @@ describe('createSerialSession', () => {
 
       const state = await firstValueFrom(session.state$);
 
-      expect(state).toBe<SerialSessionState>(S.Idle);
+      expect(state).toEqual({ status: S.Idle });
     });
 
     it('replays unsupported when navigator.serial is missing', async () => {
@@ -194,7 +202,51 @@ describe('createSerialSession', () => {
 
       const state = await firstValueFrom(session.state$);
 
-      expect(state).toBe<SerialSessionState>(S.Unsupported);
+      expect(state).toEqual({ status: S.Unsupported });
+    });
+
+    it('includes portInfo on connected state', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const state = await firstValueFrom(session.state$);
+      expect(state).toEqual(connectedState());
+      if (state.status === S.Connected) {
+        expect(state.portInfo).toEqual(stubPortInfo);
+      } else {
+        throw new Error('expected connected state');
+      }
+    });
+
+    it('includes the same SerialError instance on error state and errors$', async () => {
+      const requestPort = vi
+        .fn()
+        .mockRejectedValue(new DOMException('user cancel', 'NotFoundError'));
+      Object.defineProperty(globalThis, 'navigator', {
+        configurable: true,
+        writable: true,
+        value: { serial: { requestPort, getPorts: vi.fn() } },
+      });
+
+      const session = createSerialSession();
+      const errorsPromise = firstValueFrom(session.errors$);
+
+      await expect(firstValueFrom(session.connect$())).rejects.toBeInstanceOf(
+        SerialError,
+      );
+
+      const emitted = await errorsPromise;
+      const state = await firstValueFrom(session.state$);
+      expect(state.status).toBe(S.Error);
+      if (state.status === S.Error) {
+        expect(state.error).toBe(emitted);
+      } else {
+        throw new Error('expected error state');
+      }
     });
   });
 
@@ -264,10 +316,10 @@ describe('createSerialSession', () => {
       await firstValueFrom(session.connect$());
 
       const states = await statesPromise;
-      expect(states).toEqual<SerialSessionState[]>([
-        S.Idle,
-        S.Connecting,
-        S.Connected,
+      expect(states).toEqual([
+        { status: S.Idle },
+        { status: S.Connecting },
+        connectedState(),
       ]);
       expect(port.open).toHaveBeenCalledTimes(1);
       expect(port.open).toHaveBeenCalledWith(
@@ -295,9 +347,10 @@ describe('createSerialSession', () => {
       const emitted = await errorsPromise;
       expect(emitted).toBeInstanceOf(SerialError);
       expect(emitted.code).toBe(SerialErrorCode.OPERATION_CANCELLED);
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
-        S.Error,
-      );
+      expect(await firstValueFrom(session.state$)).toEqual({
+        status: S.Error,
+        error: emitted,
+      });
     });
 
     it('maps generic port.open failure to PORT_OPEN_FAILED', async () => {
@@ -341,13 +394,13 @@ describe('createSerialSession', () => {
       const subscription = session.connect$().subscribe({
         error: () => undefined,
       });
-      expect(await stateAfterConnecting).toBe<SerialSessionState>(S.Connecting);
+      expect(await stateAfterConnecting).toEqual({ status: S.Connecting });
 
       subscription.unsubscribe();
       resolveRequestPort(port);
       await flushMicrotasks();
 
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(await firstValueFrom(session.state$)).toEqual({ status: S.Idle });
       expect(port.close).toHaveBeenCalledTimes(1);
     });
 
@@ -372,15 +425,15 @@ describe('createSerialSession', () => {
       const stateAfterConnecting = firstValueFrom(session.state$.pipe(skip(1), take(1)));
 
       session.connect$().subscribe({ error: () => undefined });
-      expect(await stateAfterConnecting).toBe<SerialSessionState>(S.Connecting);
+      expect(await stateAfterConnecting).toEqual({ status: S.Connecting });
 
       await expect(firstValueFrom(session.disconnect$())).resolves.toBeUndefined();
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(await firstValueFrom(session.state$)).toEqual({ status: S.Idle });
 
       resolveRequestPort(port);
       await flushMicrotasks();
 
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(await firstValueFrom(session.state$)).toEqual({ status: S.Idle });
       expect(port.close).toHaveBeenCalledTimes(1);
     });
 
@@ -404,7 +457,7 @@ describe('createSerialSession', () => {
       const session = createSerialSession();
       const connectComplete = vi.fn();
       const stateAfterConnecting = firstValueFrom(
-        session.state$.pipe(filter((s) => s === S.Connecting), take(1)),
+        session.state$.pipe(filter((s) => s.status === S.Connecting), take(1)),
       );
       session.connect$().subscribe({
         next: connectComplete,
@@ -416,7 +469,7 @@ describe('createSerialSession', () => {
       resolveRequestPort(port);
       await flushMicrotasks();
 
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(await firstValueFrom(session.state$)).toEqual({ status: S.Idle });
       expect(connectComplete).not.toHaveBeenCalled();
       expect(port.close).toHaveBeenCalledTimes(1);
     });
@@ -437,7 +490,7 @@ describe('createSerialSession', () => {
       const session = createSerialSession();
       const connectComplete = vi.fn();
       const stateAfterConnecting = firstValueFrom(
-        session.state$.pipe(filter((s) => s === S.Connecting), take(1)),
+        session.state$.pipe(filter((s) => s.status === S.Connecting), take(1)),
       );
       session.connect$().subscribe({
         next: connectComplete,
@@ -449,7 +502,7 @@ describe('createSerialSession', () => {
       resolveOpen();
       await flushMicrotasks();
 
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(await firstValueFrom(session.state$)).toEqual({ status: S.Idle });
       expect(connectComplete).not.toHaveBeenCalled();
       expect(port.close).toHaveBeenCalledTimes(1);
     });
@@ -474,7 +527,7 @@ describe('createSerialSession', () => {
 
       resolveClose();
       await expect(firstDisconnect).resolves.toBeUndefined();
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(S.Idle);
+      expect(await firstValueFrom(session.state$)).toEqual({ status: S.Idle });
     });
 
     it('rejects connect$ with BROWSER_NOT_SUPPORTED when navigator.serial is missing', async () => {
@@ -513,10 +566,10 @@ describe('createSerialSession', () => {
       await firstValueFrom(session.disconnect$());
 
       const states = await statesPromise;
-      expect(states).toEqual<SerialSessionState[]>([
-        S.Connected,
-        S.Disconnecting,
-        S.Idle,
+      expect(states).toEqual([
+        connectedState(),
+        { status: S.Disconnecting },
+        { status: S.Idle },
       ]);
       expect(close).toHaveBeenCalledTimes(1);
     });
@@ -650,9 +703,10 @@ describe('createSerialSession', () => {
       expect(received.code).toBe(SerialErrorCode.READ_FAILED);
 
       await flushMicrotasks();
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
-        S.Error,
-      );
+      expect(await firstValueFrom(session.state$)).toEqual({
+        status: S.Error,
+        error: received,
+      });
     });
 
     it('treats done:true stream completion as connection lost and leaves connected', async () => {
@@ -671,9 +725,10 @@ describe('createSerialSession', () => {
       expect(received.code).toBe(SerialErrorCode.CONNECTION_LOST);
 
       await flushMicrotasks();
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
-        S.Error,
-      );
+      expect(await firstValueFrom(session.state$)).toEqual({
+        status: S.Error,
+        error: received,
+      });
     });
   });
 
@@ -862,9 +917,7 @@ describe('createSerialSession', () => {
       await flushMicrotasks();
 
       await errorPromise;
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
-        S.Connected,
-      );
+      expect(await firstValueFrom(session.state$)).toEqual(connectedState());
     });
   });
 
@@ -991,9 +1044,7 @@ describe('createSerialSession', () => {
       await flushMicrotasks();
 
       await errorPromise;
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
-        S.Connected,
-      );
+      expect(await firstValueFrom(session.state$)).toEqual(connectedState());
     });
   });
 
@@ -1305,9 +1356,7 @@ describe('createSerialSession', () => {
         code: SerialErrorCode.WRITE_FAILED,
       });
 
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
-        S.Connected,
-      );
+      expect(await firstValueFrom(session.state$)).toEqual(connectedState());
     });
 
     it('routes close failures on disconnect$ to errors$ as CONNECTION_LOST and state -> error', async () => {
@@ -1330,9 +1379,10 @@ describe('createSerialSession', () => {
 
       const emitted = await errorsPromise;
       expect(emitted.code).toBe(SerialErrorCode.CONNECTION_LOST);
-      expect(await firstValueFrom(session.state$)).toBe<SerialSessionState>(
-        S.Error,
-      );
+      expect(await firstValueFrom(session.state$)).toEqual({
+        status: S.Error,
+        error: emitted,
+      });
     });
 
     it('forwards DOMException(NotFoundError) on requestPort as a single OPERATION_CANCELLED emission', async () => {
@@ -1417,9 +1467,9 @@ describe('createSerialSession', () => {
 
       await firstValueFrom(session.dispose$());
 
-      await expect(states).resolves.toEqual<SerialSessionState[]>([
-        S.Idle,
-        S.Disposed,
+      await expect(states).resolves.toEqual([
+        { status: S.Idle },
+        { status: S.Disposed },
       ]);
     });
 
@@ -1443,9 +1493,9 @@ describe('createSerialSession', () => {
       expect(port.close).toHaveBeenCalledTimes(1);
       expect(session.getCurrentPort()).toBeNull();
       expect(session.getPortInfo()).toBeNull();
-      await expect(states).resolves.toEqual<SerialSessionState[]>([
-        S.Connected,
-        S.Disposed,
+      await expect(states).resolves.toEqual([
+        connectedState(),
+        { status: S.Disposed },
       ]);
       await expect(errors).resolves.toEqual([]);
       await expect(receive).resolves.toEqual([]);
@@ -1481,7 +1531,10 @@ describe('createSerialSession', () => {
       connectSub.unsubscribe();
 
       await expect(states).resolves.toEqual(
-        expect.arrayContaining([S.Connecting, S.Disposed]),
+        expect.arrayContaining([
+          { status: S.Connecting },
+          { status: S.Disposed },
+        ]),
       );
     });
 
@@ -1494,13 +1547,17 @@ describe('createSerialSession', () => {
       await firstValueFrom(session.connect$());
       controller.error(new Error('device unplugged'));
       await flushMicrotasks();
-      expect(await firstValueFrom(session.state$)).toBe(S.Error);
+      const errorState = await firstValueFrom(session.state$);
+      expect(errorState.status).toBe(S.Error);
 
       const states = lastValueFrom(session.state$.pipe(toArray()));
       await firstValueFrom(session.dispose$());
 
       await expect(states).resolves.toEqual(
-        expect.arrayContaining([S.Error, S.Disposed]),
+        expect.arrayContaining([
+          { status: S.Error, error: expect.any(SerialError) },
+          { status: S.Disposed },
+        ]),
       );
     });
 

--- a/packages/web-serial-rxjs/tests/session/session-runtime.test.ts
+++ b/packages/web-serial-rxjs/tests/session/session-runtime.test.ts
@@ -1,7 +1,12 @@
 import { firstValueFrom, lastValueFrom, take, toArray } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
 import type { ReadPump } from '../../src/session/read-pump';
-import { SerialSessionState } from '../../src/session/serial-session-state';
+import {
+  SerialSessionStatus,
+  type SerialSessionState,
+} from '../../src/session/serial-session-state';
 import {
   ALLOWED_TRANSITIONS,
   createConnectedRuntime,
@@ -14,14 +19,19 @@ import {
   createSessionRuntimeController,
   createUnsupportedRuntime,
   isValidTransition,
-  runtimeToSessionState,
+  runtimeToPublicState,
+  runtimeToSessionStatus,
 } from '../../src/session/session-runtime';
 
-const S = SerialSessionState;
+const S = SerialSessionStatus;
+
+const stubPortInfo: SerialPortInfo = { usbVendorId: 1, usbProductId: 2 };
+
+const stubError = new SerialError(SerialErrorCode.READ_FAILED, 'test error');
 
 function createMockPort(): SerialPort {
   return {
-    getInfo: () => ({ usbVendorId: 1, usbProductId: 2 }),
+    getInfo: () => stubPortInfo,
     open: vi.fn(),
     close: vi.fn(),
     readable: null,
@@ -43,14 +53,14 @@ describe('session-runtime', () => {
       const runtime = createInitialRuntime(true);
 
       expect(runtime).toEqual(createIdleRuntime());
-      expect(runtimeToSessionState(runtime)).toBe(S.Idle);
+      expect(runtimeToSessionStatus(runtime)).toBe(S.Idle);
     });
 
     it('createInitialRuntime returns unsupported when not supported', () => {
       const runtime = createInitialRuntime(false);
 
       expect(runtime).toEqual(createUnsupportedRuntime());
-      expect(runtimeToSessionState(runtime)).toBe(S.Unsupported);
+      expect(runtimeToSessionStatus(runtime)).toBe(S.Unsupported);
     });
 
     it('createConnectedRuntime holds port and pump', () => {
@@ -61,6 +71,34 @@ describe('session-runtime', () => {
       expect(runtime.status).toBe(S.Connected);
       expect(runtime.port).toBe(port);
       expect(runtime.pump).toBe(pump);
+    });
+  });
+
+  describe('runtimeToPublicState', () => {
+    it('maps connected runtime to portInfo payload', () => {
+      const port = createMockPort();
+      const pump = createMockPump();
+      const runtime = createConnectedRuntime(port, pump);
+
+      expect(runtimeToPublicState(runtime)).toEqual({
+        status: S.Connected,
+        portInfo: stubPortInfo,
+      });
+    });
+
+    it('maps error runtime to error payload', () => {
+      const runtime = createErrorRuntime(stubError);
+
+      expect(runtimeToPublicState(runtime)).toEqual({
+        status: S.Error,
+        error: stubError,
+      });
+    });
+
+    it('maps idle runtime to status-only payload', () => {
+      expect(runtimeToPublicState(createIdleRuntime())).toEqual({
+        status: S.Idle,
+      });
     });
   });
 
@@ -103,7 +141,7 @@ describe('session-runtime', () => {
       it('starts in idle by default', () => {
         const controller = createSessionRuntimeController(createIdleRuntime());
 
-        expect(controller.status).toBe<SerialSessionState>(S.Idle);
+        expect(controller.status).toBe(S.Idle);
       });
 
       it('honours an explicit initial unsupported runtime', () => {
@@ -111,7 +149,7 @@ describe('session-runtime', () => {
           createUnsupportedRuntime(),
         );
 
-        expect(controller.status).toBe<SerialSessionState>(S.Unsupported);
+        expect(controller.status).toBe(S.Unsupported);
       });
     });
 
@@ -121,7 +159,7 @@ describe('session-runtime', () => {
 
         const state = await firstValueFrom(controller.state$);
 
-        expect(state).toBe<SerialSessionState>(S.Idle);
+        expect(state).toEqual<SerialSessionState>({ status: S.Idle });
       });
 
       it('emits every valid transition in order', async () => {
@@ -139,11 +177,11 @@ describe('session-runtime', () => {
         controller.transition(createIdleRuntime());
 
         await expect(collected).resolves.toEqual<SerialSessionState[]>([
-          S.Idle,
-          S.Connecting,
-          S.Connected,
-          S.Disconnecting,
-          S.Idle,
+          { status: S.Idle },
+          { status: S.Connecting },
+          { status: S.Connected, portInfo: stubPortInfo },
+          { status: S.Disconnecting },
+          { status: S.Idle },
         ]);
       });
     });
@@ -157,20 +195,20 @@ describe('session-runtime', () => {
         expect(
           controller.transition(createConnectingRuntime(() => undefined)),
         ).toBe(true);
-        expect(controller.status).toBe<SerialSessionState>(S.Connecting);
+        expect(controller.status).toBe(S.Connecting);
 
         expect(
           controller.transition(createConnectedRuntime(port, pump)),
         ).toBe(true);
-        expect(controller.status).toBe<SerialSessionState>(S.Connected);
+        expect(controller.status).toBe(S.Connected);
 
         expect(
           controller.transition(createDisconnectingRuntime(port)),
         ).toBe(true);
-        expect(controller.status).toBe<SerialSessionState>(S.Disconnecting);
+        expect(controller.status).toBe(S.Disconnecting);
 
         expect(controller.transition(createIdleRuntime())).toBe(true);
-        expect(controller.status).toBe<SerialSessionState>(S.Idle);
+        expect(controller.status).toBe(S.Idle);
       });
     });
 
@@ -181,14 +219,18 @@ describe('session-runtime', () => {
 
         const fromConnecting = createSessionRuntimeController(createIdleRuntime());
         fromConnecting.transition(createConnectingRuntime(() => undefined));
-        expect(fromConnecting.transition(createErrorRuntime())).toBe(true);
-        expect(fromConnecting.status).toBe<SerialSessionState>(S.Error);
+        expect(fromConnecting.transition(createErrorRuntime(stubError))).toBe(
+          true,
+        );
+        expect(fromConnecting.status).toBe(S.Error);
 
         const fromConnected = createSessionRuntimeController(createIdleRuntime());
         fromConnected.transition(createConnectingRuntime(() => undefined));
         fromConnected.transition(createConnectedRuntime(port, pump));
-        expect(fromConnected.transition(createErrorRuntime())).toBe(true);
-        expect(fromConnected.status).toBe<SerialSessionState>(S.Error);
+        expect(fromConnected.transition(createErrorRuntime(stubError))).toBe(
+          true,
+        );
+        expect(fromConnected.status).toBe(S.Error);
 
         const fromDisconnecting = createSessionRuntimeController(
           createIdleRuntime(),
@@ -196,24 +238,26 @@ describe('session-runtime', () => {
         fromDisconnecting.transition(createConnectingRuntime(() => undefined));
         fromDisconnecting.transition(createConnectedRuntime(port, pump));
         fromDisconnecting.transition(createDisconnectingRuntime(port));
-        expect(fromDisconnecting.transition(createErrorRuntime())).toBe(true);
-        expect(fromDisconnecting.status).toBe<SerialSessionState>(S.Error);
+        expect(fromDisconnecting.transition(createErrorRuntime(stubError))).toBe(
+          true,
+        );
+        expect(fromDisconnecting.status).toBe(S.Error);
       });
 
       it('recovers from error back to idle and forward to connecting', () => {
         const controller = createSessionRuntimeController(createIdleRuntime());
         controller.transition(createConnectingRuntime(() => undefined));
-        controller.transition(createErrorRuntime());
+        controller.transition(createErrorRuntime(stubError));
 
         expect(controller.transition(createIdleRuntime())).toBe(true);
-        expect(controller.status).toBe<SerialSessionState>(S.Idle);
+        expect(controller.status).toBe(S.Idle);
 
         controller.transition(createConnectingRuntime(() => undefined));
-        controller.transition(createErrorRuntime());
+        controller.transition(createErrorRuntime(stubError));
         expect(
           controller.transition(createConnectingRuntime(() => undefined)),
         ).toBe(true);
-        expect(controller.status).toBe<SerialSessionState>(S.Connecting);
+        expect(controller.status).toBe(S.Connecting);
       });
     });
 
@@ -226,7 +270,7 @@ describe('session-runtime', () => {
         expect(
           controller.transition(createConnectedRuntime(port, pump)),
         ).toBe(false);
-        expect(controller.status).toBe<SerialSessionState>(S.Idle);
+        expect(controller.status).toBe(S.Idle);
         expect(warnSpy).toHaveBeenCalledTimes(1);
       });
 
@@ -238,7 +282,7 @@ describe('session-runtime', () => {
         controller.transition(createConnectedRuntime(port, pump));
 
         expect(controller.transition(createIdleRuntime())).toBe(false);
-        expect(controller.status).toBe<SerialSessionState>(S.Connected);
+        expect(controller.status).toBe(S.Connected);
         expect(warnSpy).toHaveBeenCalledTimes(1);
       });
 
@@ -251,7 +295,7 @@ describe('session-runtime', () => {
         const states = await lastValueFrom(
           controller.state$.pipe(take(1), toArray()),
         );
-        expect(states).toEqual<SerialSessionState[]>([S.Idle]);
+        expect(states).toEqual<SerialSessionState[]>([{ status: S.Idle }]);
       });
     });
 
@@ -273,8 +317,8 @@ describe('session-runtime', () => {
         expect(
           controller.transition(createDisconnectingRuntime(port)),
         ).toBe(false);
-        expect(controller.transition(createErrorRuntime())).toBe(false);
-        expect(controller.status).toBe<SerialSessionState>(S.Unsupported);
+        expect(controller.transition(createErrorRuntime(stubError))).toBe(false);
+        expect(controller.status).toBe(S.Unsupported);
       });
     });
 
@@ -285,18 +329,18 @@ describe('session-runtime', () => {
 
         const fromIdle = createSessionRuntimeController(createIdleRuntime());
         expect(fromIdle.transition(createDisposedRuntime())).toBe(true);
-        expect(fromIdle.status).toBe<SerialSessionState>(S.Disposed);
+        expect(fromIdle.status).toBe(S.Disposed);
 
         const fromConnecting = createSessionRuntimeController(createIdleRuntime());
         fromConnecting.transition(createConnectingRuntime(() => undefined));
         expect(fromConnecting.transition(createDisposedRuntime())).toBe(true);
-        expect(fromConnecting.status).toBe<SerialSessionState>(S.Disposed);
+        expect(fromConnecting.status).toBe(S.Disposed);
 
         const fromConnected = createSessionRuntimeController(createIdleRuntime());
         fromConnected.transition(createConnectingRuntime(() => undefined));
         fromConnected.transition(createConnectedRuntime(port, pump));
         expect(fromConnected.transition(createDisposedRuntime())).toBe(true);
-        expect(fromConnected.status).toBe<SerialSessionState>(S.Disposed);
+        expect(fromConnected.status).toBe(S.Disposed);
 
         const fromDisconnecting = createSessionRuntimeController(
           createIdleRuntime(),
@@ -305,13 +349,13 @@ describe('session-runtime', () => {
         fromDisconnecting.transition(createConnectedRuntime(port, pump));
         fromDisconnecting.transition(createDisconnectingRuntime(port));
         expect(fromDisconnecting.transition(createDisposedRuntime())).toBe(true);
-        expect(fromDisconnecting.status).toBe<SerialSessionState>(S.Disposed);
+        expect(fromDisconnecting.status).toBe(S.Disposed);
 
         const fromError = createSessionRuntimeController(createIdleRuntime());
         fromError.transition(createConnectingRuntime(() => undefined));
-        fromError.transition(createErrorRuntime());
+        fromError.transition(createErrorRuntime(stubError));
         expect(fromError.transition(createDisposedRuntime())).toBe(true);
-        expect(fromError.status).toBe<SerialSessionState>(S.Disposed);
+        expect(fromError.status).toBe(S.Disposed);
       });
 
       it('rejects every transition once entered', () => {
@@ -330,8 +374,8 @@ describe('session-runtime', () => {
         expect(
           controller.transition(createDisconnectingRuntime(port)),
         ).toBe(false);
-        expect(controller.transition(createErrorRuntime())).toBe(false);
-        expect(controller.status).toBe<SerialSessionState>(S.Disposed);
+        expect(controller.transition(createErrorRuntime(stubError))).toBe(false);
+        expect(controller.status).toBe(S.Disposed);
       });
     });
 
@@ -345,8 +389,8 @@ describe('session-runtime', () => {
         controller.complete();
 
         await expect(collected).resolves.toEqual<SerialSessionState[]>([
-          S.Idle,
-          S.Connecting,
+          { status: S.Idle },
+          { status: S.Connecting },
         ]);
       });
     });


### PR DESCRIPTION
## Summary
`state$` を discriminated union に変更し、`connected` 状態で `portInfo`、`error` 状態で `SerialError` を型安全に取得できるようにしました。lifecycle 文字列定数は `SerialSessionStatus` にリネームし、v3 移行ガイドと全 example を追随させています。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [x] Breaking change

## Related issues
- Fixes #406
- Relates to #391

## What changed?
- `SerialSessionStatus` const + `SerialSessionState` discriminated union 型を公開 API に追加
- 内部 `SessionRuntime` から `runtimeToPublicState` で `state$` payload を構築（`ErrorRuntime` に `SerialError` を保持）
- `isConnected$` と session lifecycle 内部を `state.status` ベースに更新
- ライブラリテストに `portInfo` / `error` narrowing のカバレッジを追加
- examples-shared と全 framework example を新型に追随
- `MIGRATION_V3` / API / OVERVIEW / QUICK_START ドキュメントを更新

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `state$` が文字列 union から discriminated union に変更。旧 `SerialSessionState` 定数は `SerialSessionStatus` にリネーム。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes:
    - v2: `state === SerialSessionState.Connected`
    - v3: `state.status === SerialSessionStatus.Connected`
    - v3 connected: `state.portInfo` を直接利用可能
    - v3 error: `state.error` を直接利用可能（`errors$` と同一インスタンス）
    - 詳細は `packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md`

BREAKING CHANGE: state$ emits discriminated union objects instead of flat strings; SerialSessionState constants are renamed to SerialSessionStatus

## How to test
1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build && pnpm exec nx run web-serial-rxjs:verify:dist`
3. `pnpm exec nx run-many -t test --projects=example-react,example-angular,example-vue,example-svelte,example-vanilla-js,example-vanilla-ts,examples-shared`
4. Chromium で example アプリを起動し、connect → connected で UI が更新されること、致命エラー時に error 状態になることを確認

## Environment (if relevant)
- Browser: Chrome / Edge（Web Serial API）
- OS: macOS
- web-serial-rxjs version (for verification): 本 PR ブランチ
- RxJS version: 7.x（workspace 既定）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)