### PR TITLE
refactor(web-serial-rxjs): add internal branded number types and remove explicit any

### DIFF
--- a/packages/web-serial-rxjs/src/errors/serial-error.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error.ts
@@ -9,15 +9,15 @@ import {
 export { SerialErrorCode };
 export type { SerialErrorCauseContext, SerialErrorContextMap };
 
-interface ErrorConstructorWithCaptureStackTrace extends ErrorConstructor {
-  captureStackTrace?: (
+interface V8ErrorCaptureStackTrace {
+  captureStackTrace?(
     targetObject: object,
     constructorOpt?: abstract new (...args: never[]) => unknown,
-  ) => void;
+  ): void;
 }
 
-const ErrorWithCaptureStackTrace =
-  Error as ErrorConstructorWithCaptureStackTrace;
+const ErrorWithCaptureStackTrace = Error as typeof Error &
+  V8ErrorCaptureStackTrace;
 
 /**
  * Custom error class for serial port operations.

--- a/packages/web-serial-rxjs/src/errors/serial-error.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error.ts
@@ -9,6 +9,16 @@ import {
 export { SerialErrorCode };
 export type { SerialErrorCauseContext, SerialErrorContextMap };
 
+interface ErrorConstructorWithCaptureStackTrace extends ErrorConstructor {
+  captureStackTrace?: (
+    targetObject: object,
+    constructorOpt?: abstract new (...args: never[]) => unknown,
+  ) => void;
+}
+
+const ErrorWithCaptureStackTrace =
+  Error as ErrorConstructorWithCaptureStackTrace;
+
 /**
  * Custom error class for serial port operations.
  *
@@ -106,10 +116,8 @@ export class SerialError<
     }
 
     // Maintains proper stack trace for where our error was thrown (only available on V8)
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((Error as any).captureStackTrace) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (Error as any).captureStackTrace(this, SerialError);
+    if (ErrorWithCaptureStackTrace.captureStackTrace) {
+      ErrorWithCaptureStackTrace.captureStackTrace(this, SerialError);
     }
   }
 

--- a/packages/web-serial-rxjs/src/internal/branded-numbers.ts
+++ b/packages/web-serial-rxjs/src/internal/branded-numbers.ts
@@ -1,0 +1,50 @@
+declare const baudRateBrand: unique symbol;
+/** Validated serial port baud rate (safe integer > 0). */
+export type BaudRate = number & { readonly [baudRateBrand]: true };
+
+declare const serialPortBufferSizeBrand: unique symbol;
+/** Validated W3C {@link SerialOptions} `bufferSize`. */
+export type SerialPortBufferSize = number & {
+  readonly [serialPortBufferSizeBrand]: true;
+};
+
+declare const receiveReplayBufferSizeBrand: unique symbol;
+/** Validated receive replay chunk count limit. */
+export type ReceiveReplayBufferSize = number & {
+  readonly [receiveReplayBufferSizeBrand]: true;
+};
+
+declare const maxCharsBrand: unique symbol;
+/** Validated character limit for buffers (`0` means unlimited). */
+export type MaxChars = number & { readonly [maxCharsBrand]: true };
+
+declare const maxLinesBrand: unique symbol;
+/** Validated line count limit for terminal display (`0` means unlimited). */
+export type MaxLines = number & { readonly [maxLinesBrand]: true };
+
+/** @internal Brand a validated baud rate. */
+export function brandBaudRate(value: number): BaudRate {
+  return value as BaudRate;
+}
+
+/** @internal Brand a validated serial port buffer size. */
+export function brandSerialPortBufferSize(value: number): SerialPortBufferSize {
+  return value as SerialPortBufferSize;
+}
+
+/** @internal Brand a validated receive replay buffer size. */
+export function brandReceiveReplayBufferSize(
+  value: number,
+): ReceiveReplayBufferSize {
+  return value as ReceiveReplayBufferSize;
+}
+
+/** @internal Brand a validated max character limit. */
+export function brandMaxChars(value: number): MaxChars {
+  return value as MaxChars;
+}
+
+/** @internal Brand a validated max line limit. */
+export function brandMaxLines(value: number): MaxLines {
+  return value as MaxLines;
+}

--- a/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
+++ b/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
@@ -1,4 +1,5 @@
 import { createNewlineTokenizer } from '../../internal/newline-tokenizer';
+import type { MaxChars } from '../../internal/branded-numbers';
 
 /**
  * Options for {@link createLineBuffer}.
@@ -37,6 +38,11 @@ export interface LineBuffer {
   clear(): void;
 }
 
+/** @internal Resolved limits for {@link createLineBuffer}. */
+export interface LineBufferLimits {
+  maxChars: MaxChars;
+}
+
 /**
  * Streaming UTF-16 text to newline-delimited lines for {@link createSerialSession}.
  * Supports `\r\n` and `\n` per #237; a lone `\r` that is not the last character
@@ -46,10 +52,12 @@ export interface LineBuffer {
  *
  * @internal
  */
-export function createLineBuffer(options?: LineBufferOptions): LineBuffer {
-  const limits: Required<LineBufferOptions> = {
-    ...DEFAULT_LINE_BUFFER_OPTIONS,
-    ...options,
+export function createLineBuffer(
+  options?: LineBufferOptions | LineBufferLimits,
+): LineBuffer {
+  const limits: LineBufferLimits = {
+    maxChars:
+      options?.maxChars ?? (DEFAULT_LINE_BUFFER_OPTIONS.maxChars as MaxChars),
   };
 
   const tokenizer = createNewlineTokenizer('line');

--- a/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
+++ b/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
@@ -1,5 +1,6 @@
 import { createNewlineTokenizer } from '../../internal/newline-tokenizer';
 import type { MaxChars } from '../../internal/branded-numbers';
+import { brandMaxChars } from '../../internal/branded-numbers';
 
 /**
  * Options for {@link createLineBuffer}.
@@ -56,8 +57,9 @@ export function createLineBuffer(
   options?: LineBufferOptions | LineBufferLimits,
 ): LineBuffer {
   const limits: LineBufferLimits = {
-    maxChars:
-      options?.maxChars ?? (DEFAULT_LINE_BUFFER_OPTIONS.maxChars as MaxChars),
+    maxChars: brandMaxChars(
+      options?.maxChars ?? DEFAULT_LINE_BUFFER_OPTIONS.maxChars,
+    ),
   };
 
   const tokenizer = createNewlineTokenizer('line');

--- a/packages/web-serial-rxjs/src/session/internal/receive-replay-buffer.ts
+++ b/packages/web-serial-rxjs/src/session/internal/receive-replay-buffer.ts
@@ -1,4 +1,8 @@
 import { Observable, Subject } from 'rxjs';
+import type {
+  MaxChars,
+  ReceiveReplayBufferSize,
+} from '../../internal/branded-numbers';
 
 /**
  * Options for {@link createReceiveReplayBuffer}.
@@ -7,11 +11,11 @@ import { Observable, Subject } from 'rxjs';
  */
 export interface ReceiveReplayBufferOptions {
   /** Maximum number of chunks to retain. */
-  bufferSize: number;
+  bufferSize: ReceiveReplayBufferSize;
   /**
    * Maximum total characters across retained chunks. `0` disables the limit.
    */
-  maxChars: number;
+  maxChars: MaxChars;
 }
 
 /** Result of {@link ReceiveReplayBuffer.next}. */

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -311,13 +311,11 @@ export const DEFAULT_SERIAL_SESSION_OPTIONS = {
 } satisfies ResolvedSerialSessionOptions;
 
 /** Resolved W3C connection fields for {@link ResolvedSerialSessionOptions}. */
-export type ResolvedSerialSessionConnectionOptions = {
+export type ResolvedSerialSessionConnectionOptions = Required<
+  Omit<SerialSessionConnectionFields, 'baudRate' | 'bufferSize'>
+> & {
   baudRate: BaudRate;
-  dataBits: SerialSessionConnectionFields['dataBits'];
-  stopBits: SerialSessionConnectionFields['stopBits'];
-  parity: SerialSessionConnectionFields['parity'];
   bufferSize: SerialPortBufferSize;
-  flowControl: SerialSessionConnectionFields['flowControl'];
 };
 
 /**
@@ -352,10 +350,11 @@ export function resolveConnectionOptions(
   }
 
   return {
-    dataBits: merged.dataBits,
-    stopBits: merged.stopBits,
-    parity: merged.parity,
-    flowControl: merged.flowControl,
+    dataBits: merged.dataBits ?? DEFAULT_SERIAL_SESSION_OPTIONS.dataBits,
+    stopBits: merged.stopBits ?? DEFAULT_SERIAL_SESSION_OPTIONS.stopBits,
+    parity: merged.parity ?? DEFAULT_SERIAL_SESSION_OPTIONS.parity,
+    flowControl:
+      merged.flowControl ?? DEFAULT_SERIAL_SESSION_OPTIONS.flowControl,
     baudRate: brandBaudRate(baudRate),
     bufferSize: brandSerialPortBufferSize(
       bufferSize ?? DEFAULT_SERIAL_SESSION_OPTIONS.bufferSize,

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -1,3 +1,15 @@
+import {
+  brandBaudRate,
+  brandMaxChars,
+  brandMaxLines,
+  brandReceiveReplayBufferSize,
+  brandSerialPortBufferSize,
+  type BaudRate,
+  type MaxChars,
+  type MaxLines,
+  type ReceiveReplayBufferSize,
+  type SerialPortBufferSize,
+} from '../internal/branded-numbers';
 import type { TerminalBufferOptions } from '../terminal/create-terminal-buffer';
 import { DEFAULT_TERMINAL_BUFFER_OPTIONS } from '../terminal/create-terminal-buffer';
 import { SerialError } from '../errors/serial-error';
@@ -136,9 +148,16 @@ const DEFAULT_RECEIVE_REPLAY: Required<SerialSessionReceiveReplayOptions> = {
  * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS}
  *         when `bufferSize` or `maxChars` are out of range.
  */
+/** Resolved receive replay options with validated branded numeric fields. */
+export type ResolvedSerialSessionReceiveReplayOptions = {
+  enabled: boolean;
+  bufferSize: ReceiveReplayBufferSize;
+  maxChars: MaxChars;
+};
+
 export function resolveReceiveReplayOptions(
   options?: SerialSessionReceiveReplayOptions,
-): Required<SerialSessionReceiveReplayOptions> {
+): ResolvedSerialSessionReceiveReplayOptions {
   const merged: Required<SerialSessionReceiveReplayOptions> = {
     ...DEFAULT_RECEIVE_REPLAY,
     ...options,
@@ -168,7 +187,11 @@ export function resolveReceiveReplayOptions(
     );
   }
 
-  return merged;
+  return {
+    enabled: merged.enabled,
+    bufferSize: brandReceiveReplayBufferSize(bufferSize),
+    maxChars: brandMaxChars(maxChars),
+  };
 }
 
 /**
@@ -177,9 +200,15 @@ export function resolveReceiveReplayOptions(
  * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS}
  *         when `maxLines` or `maxChars` are out of range.
  */
+/** Resolved terminal buffer options with validated branded numeric fields. */
+export type ResolvedTerminalBufferOptions = {
+  maxLines: MaxLines;
+  maxChars: MaxChars;
+};
+
 export function resolveTerminalBufferOptions(
   options?: TerminalBufferOptions,
-): Required<TerminalBufferOptions> {
+): ResolvedTerminalBufferOptions {
   const merged: Required<TerminalBufferOptions> = {
     ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
     ...options,
@@ -201,7 +230,10 @@ export function resolveTerminalBufferOptions(
     );
   }
 
-  return merged;
+  return {
+    maxLines: brandMaxLines(maxLines),
+    maxChars: brandMaxChars(maxChars),
+  };
 }
 
 /**
@@ -210,9 +242,14 @@ export function resolveTerminalBufferOptions(
  * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS}
  *         when `maxChars` is out of range.
  */
+/** Resolved line buffer options with validated branded numeric fields. */
+export type ResolvedLineBufferOptions = {
+  maxChars: MaxChars;
+};
+
 export function resolveLineBufferOptions(
   options?: LineBufferOptions,
-): Required<LineBufferOptions> {
+): ResolvedLineBufferOptions {
   const merged: Required<LineBufferOptions> = {
     ...DEFAULT_LINE_BUFFER_OPTIONS,
     ...options,
@@ -227,7 +264,9 @@ export function resolveLineBufferOptions(
     );
   }
 
-  return merged;
+  return {
+    maxChars: brandMaxChars(maxChars),
+  };
 }
 
 /**
@@ -236,12 +275,22 @@ export function resolveLineBufferOptions(
  * required; `filters` remains optional.
  */
 export type ResolvedSerialSessionOptions = Required<
-  Omit<SerialSessionOptions, 'filters' | 'receiveReplay' | 'terminalBuffer' | 'lineBuffer'>
+  Omit<
+    SerialSessionOptions,
+    | 'filters'
+    | 'receiveReplay'
+    | 'terminalBuffer'
+    | 'lineBuffer'
+    | 'baudRate'
+    | 'bufferSize'
+  >
 > & {
+  baudRate: BaudRate;
+  bufferSize: SerialPortBufferSize;
   filters?: SerialPortFilter[];
-  receiveReplay: Required<SerialSessionReceiveReplayOptions>;
-  terminalBuffer: Required<TerminalBufferOptions>;
-  lineBuffer: Required<LineBufferOptions>;
+  receiveReplay: ResolvedSerialSessionReceiveReplayOptions;
+  terminalBuffer: ResolvedTerminalBufferOptions;
+  lineBuffer: ResolvedLineBufferOptions;
 };
 
 /**
@@ -250,20 +299,26 @@ export type ResolvedSerialSessionOptions = Required<
  * @internal
  */
 export const DEFAULT_SERIAL_SESSION_OPTIONS = {
-  baudRate: 9600,
+  baudRate: brandBaudRate(9600),
   dataBits: 8,
   stopBits: 1,
   parity: 'none',
-  bufferSize: 255,
+  bufferSize: brandSerialPortBufferSize(255),
   flowControl: 'none',
-  receiveReplay: { ...DEFAULT_RECEIVE_REPLAY },
-  terminalBuffer: { ...DEFAULT_TERMINAL_BUFFER_OPTIONS },
-  lineBuffer: { ...DEFAULT_LINE_BUFFER_OPTIONS },
+  receiveReplay: resolveReceiveReplayOptions(),
+  terminalBuffer: resolveTerminalBufferOptions(),
+  lineBuffer: resolveLineBufferOptions(),
 } satisfies ResolvedSerialSessionOptions;
 
 /** Resolved W3C connection fields for {@link ResolvedSerialSessionOptions}. */
-export type ResolvedSerialSessionConnectionOptions =
-  Required<SerialSessionConnectionFields>;
+export type ResolvedSerialSessionConnectionOptions = {
+  baudRate: BaudRate;
+  dataBits: SerialSessionConnectionFields['dataBits'];
+  stopBits: SerialSessionConnectionFields['stopBits'];
+  parity: SerialSessionConnectionFields['parity'];
+  bufferSize: SerialPortBufferSize;
+  flowControl: SerialSessionConnectionFields['flowControl'];
+};
 
 /**
  * Merge and validate W3C connection fields from {@link SerialSessionOptions}.
@@ -277,7 +332,7 @@ export function resolveConnectionOptions(
     'baudRate' | 'dataBits' | 'stopBits' | 'parity' | 'bufferSize' | 'flowControl'
   >,
 ): ResolvedSerialSessionConnectionOptions {
-  const merged: ResolvedSerialSessionConnectionOptions = {
+  const merged = {
     baudRate: DEFAULT_SERIAL_SESSION_OPTIONS.baudRate,
     dataBits: DEFAULT_SERIAL_SESSION_OPTIONS.dataBits,
     stopBits: DEFAULT_SERIAL_SESSION_OPTIONS.stopBits,
@@ -296,7 +351,14 @@ export function resolveConnectionOptions(
     );
   }
 
-  return merged;
+  return {
+    dataBits: merged.dataBits,
+    stopBits: merged.stopBits,
+    parity: merged.parity,
+    flowControl: merged.flowControl,
+    baudRate: brandBaudRate(baudRate),
+    bufferSize: brandSerialPortBufferSize(merged.bufferSize),
+  };
 }
 
 /**

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -342,7 +342,7 @@ export function resolveConnectionOptions(
     ...options,
   };
 
-  const { baudRate } = merged;
+  const { baudRate, bufferSize } = merged;
 
   if (!Number.isSafeInteger(baudRate) || baudRate <= 0) {
     throw new SerialError(
@@ -357,7 +357,9 @@ export function resolveConnectionOptions(
     parity: merged.parity,
     flowControl: merged.flowControl,
     baudRate: brandBaudRate(baudRate),
-    bufferSize: brandSerialPortBufferSize(merged.bufferSize),
+    bufferSize: brandSerialPortBufferSize(
+      bufferSize ?? DEFAULT_SERIAL_SESSION_OPTIONS.bufferSize,
+    ),
   };
 }
 

--- a/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
+++ b/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
@@ -1,4 +1,10 @@
 import { type Observable, map, scan, shareReplay } from 'rxjs';
+import {
+  brandMaxChars,
+  brandMaxLines,
+  type MaxChars,
+  type MaxLines,
+} from '../internal/branded-numbers';
 import { createNewlineTokenizer } from '../internal/newline-tokenizer';
 
 /** @internal Folded state between {@link createTerminalBuffer} emissions. */
@@ -42,8 +48,8 @@ export function terminalDisplayText(state: TerminalBufferState): string {
 
 /** Resolved limits for {@link trimTerminalState}. `0` means unlimited. */
 export interface TerminalBufferLimits {
-  maxLines: number;
-  maxChars: number;
+  maxLines: MaxLines;
+  maxChars: MaxChars;
 }
 
 /** @internal Count newline-terminated rows in `completed`. */
@@ -155,9 +161,11 @@ export const DEFAULT_TERMINAL_BUFFER_OPTIONS: Required<TerminalBufferOptions> =
 function resolveTerminalBufferLimits(
   options?: TerminalBufferOptions,
 ): TerminalBufferLimits {
+  const maxLines = options?.maxLines ?? DEFAULT_TERMINAL_BUFFER_OPTIONS.maxLines;
+  const maxChars = options?.maxChars ?? DEFAULT_TERMINAL_BUFFER_OPTIONS.maxChars;
   return {
-    ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
-    ...options,
+    maxLines: brandMaxLines(maxLines),
+    maxChars: brandMaxChars(maxChars),
   };
 }
 


### PR DESCRIPTION
## Summary

resolver 後の内部数値フィールドに branded type を導入し、`baudRate` / `bufferSize` / `maxChars` などのドメイン意味の混同を compile-time で防止します。あわせて `SerialError` の `captureStackTrace` 周辺の explicit `any` を型安全なインターフェースに置換します。公開 API の入力シグネチャは `number` のまま維持し、non-breaking です。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #407
- Parent: #391

## What changed?

- `internal/branded-numbers.ts` を新規追加（`BaudRate`, `SerialPortBufferSize`, `ReceiveReplayBufferSize`, `MaxChars`, `MaxLines`）
- `resolve*Options` と `ResolvedSerialSessionOptions` で branded type を使用
- 内部 buffer モジュール（`receive-replay-buffer`, `line-buffer`, `create-terminal-buffer`）で branded limits を使用
- `SerialError` の `captureStackTrace` から explicit `any` を除去

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `pnpm exec nx run web-serial-rxjs:test`
2. `pnpm exec nx run web-serial-rxjs:build`
3. 型チェックで examples がエラーなしであることを確認

## Environment (if relevant)

- Browser: N/A（型リファクタリングのみ）
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: workspace

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)