### PR TITLE
refactor(example-angular): replace getters with computed signals

### DIFF
--- a/apps/example-angular/src/app/app.html
+++ b/apps/example-angular/src/app/app.html
@@ -41,20 +41,20 @@
         <button
           class="btn btn-primary"
           (click)="handleConnect()"
-          [disabled]="!browserSupported || isConnected() || connecting"
+          [disabled]="!browserSupported || isConnected() || connecting()"
         >
           接続
         </button>
         <button
           class="btn btn-secondary"
           (click)="handleDisconnect()"
-          [disabled]="!isConnected() || disconnecting"
+          [disabled]="!isConnected() || disconnecting()"
         >
           切断
         </button>
       </div>
-      <div class="status-message" [ngClass]="status.type">
-        {{ status.message }}
+      <div class="status-message" [ngClass]="status().type">
+        {{ status().message }}
       </div>
     </section>
 
@@ -101,7 +101,7 @@
         <button
           class="btn btn-secondary"
           (click)="clearReceivedData()"
-          [disabled]="!hasReceivedData"
+          [disabled]="!hasReceivedData()"
         >
           クリア
         </button>

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, DestroyRef, inject, signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
@@ -60,19 +60,17 @@ export class App {
       });
   }
 
-  get connecting(): boolean {
-    return this.state().status === SerialSessionStatus.Connecting;
-  }
+  readonly connecting = computed(
+    () => this.state().status === SerialSessionStatus.Connecting,
+  );
 
-  get disconnecting(): boolean {
-    return this.state().status === SerialSessionStatus.Disconnecting;
-  }
+  readonly disconnecting = computed(
+    () => this.state().status === SerialSessionStatus.Disconnecting,
+  );
 
-  get hasReceivedData(): boolean {
-    return this.receivedData().length > 0;
-  }
+  readonly hasReceivedData = computed(() => this.receivedData().length > 0);
 
-  get status(): { type: StatusType; message: string } {
+  readonly status = computed((): { type: StatusType; message: string } => {
     const error = this.errorMessage();
     if (error) {
       return { type: 'error', message: `エラー: ${error}` };
@@ -95,7 +93,7 @@ export class App {
       default:
         return { type: 'info', message: 'シリアルポートに接続していません。' };
     }
-  }
+  });
 
   handleConnect(): void {
     this.resetTerminalView();

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -1,12 +1,13 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, DestroyRef, inject, signal } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, linkedSignal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import {
   SerialSessionStatus,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
+import { map } from 'rxjs';
 import { SerialClientService } from './services/serial-client.service';
 
 type StatusType = 'info' | 'success' | 'error';
@@ -22,43 +23,41 @@ export class App {
   sendInput = '';
 
   private readonly serialService = inject(SerialClientService);
-  private readonly destroyRef = inject(DestroyRef);
 
   readonly browserSupported = this.serialService.isBrowserSupported();
-  readonly state = signal<SerialSessionState>({
-    status: SerialSessionStatus.Idle,
+  readonly state = toSignal(this.serialService.state$, {
+    initialValue: {
+      status: SerialSessionStatus.Idle,
+    } satisfies SerialSessionState,
   });
-  readonly isConnected = signal(false);
-  readonly receivedData = signal('');
-  readonly errorMessage = signal<string | null>(null);
+  readonly isConnected = toSignal(this.serialService.isConnected$, {
+    initialValue: false,
+  });
+  private readonly terminalText = toSignal(this.serialService.terminalText$, {
+    initialValue: '',
+  });
+  readonly receivedData = linkedSignal({
+    source: () => this.terminalText(),
+    computation: (text) => text,
+  });
+  private readonly lastError = toSignal(
+    this.serialService.errors$.pipe(
+      map((error): string | null => error.message),
+    ),
+    { initialValue: null },
+  );
 
-  constructor() {
-    this.serialService.state$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((state) => {
-        this.state.set(state);
-        if (
-          state.status === SerialSessionStatus.Connected ||
-          state.status === SerialSessionStatus.Idle
-        ) {
-          this.errorMessage.set(null);
-        }
-      });
-
-    this.serialService.isConnected$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((v) => this.isConnected.set(v));
-
-    this.serialService.terminalText$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((text) => this.receivedData.set(text));
-
-    this.serialService.errors$
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((error) => {
-        this.errorMessage.set(error.message);
-      });
-  }
+  readonly errorMessage = computed(() => {
+    const status = this.state().status;
+    if (
+      status === SerialSessionStatus.Connected ||
+      status === SerialSessionStatus.Idle ||
+      status === SerialSessionStatus.Connecting
+    ) {
+      return null;
+    }
+    return this.lastError();
+  });
 
   readonly connecting = computed(
     () => this.state().status === SerialSessionStatus.Connecting,
@@ -97,7 +96,6 @@ export class App {
 
   handleConnect(): void {
     this.resetTerminalView();
-    this.errorMessage.set(null);
     this.serialService.connect$(this.baudRate).subscribe({
       error: (error: unknown) => {
         console.error('接続エラー:', error);


### PR DESCRIPTION
## Summary
App コンポーネントの派生状態（connecting / disconnecting / hasReceivedData / status）を getter から computed Signal に移行し、Angular Signals の推奨パターンに合わせました。加えて、RxJS Observable との手動同期を `toSignal` / `linkedSignal` / `computed` に整理し、`constructor` 内の subscribe を削除しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #424

## What changed?
- `App` の 4 つの getter を `computed` Signal に置き換え
- テンプレートのバインディングを Signal 呼び出し構文 `()` に更新
- `state$` / `isConnected$` / `terminalText$` / `errors$` を `toSignal` で Signal 化
- `errorMessage` を writable `signal` から `computed` に変更（Connected / Idle / Connecting 時は非表示）
- `receivedData` を `linkedSignal` に変更（`terminalText$` 追従 + クリア時の即時 UI 更新を維持）
- `constructor` 内の手動 `subscribe` と `DestroyRef` / `takeUntilDestroyed` を削除

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `npx nx serve example-angular` でアプリを起動
2. Chromium ブラウザで接続・切断を実行し、ボタンの disabled 状態とステータスメッセージが正しく変化することを確認
3. データ受信後に「クリア」ボタンが有効になることを確認
4. 「クリア」ボタン押下後、受信データが即座に消えることを確認
5. エラー発生後に再接続した際、接続開始時にエラーメッセージが消えることを確認

## Environment (if relevant)
- Browser: Chrome / Edge / Opera など Chromium ベース
- OS: macOS / Windows / Linux

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)