### PR TITLE
chore(web-serial-rxjs): bump package version to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs/workspace",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## PR Title (Conventional Commits)

chore(web-serial-rxjs): bump package version to 3.0.0

## Summary

`@gurezo/web-serial-rxjs` とルート `package.json` のバージョンを 3.0.0 に bump する。#391 で取り込んだ v3 破壊的変更（`SerialErrorCode` const object 化、`state$` discriminated union 化など）を npm 公開可能な MAJOR リリースとして切り出すためのバージョン更新です。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [x] Breaking change

## Related issues

- Fixes #426

## What changed?

- `packages/web-serial-rxjs/package.json` の `version` を `2.4.0` → `3.0.0` に更新
- ルート `package.json` の `version` を `2.4.0` → `3.0.0` に更新

## API / Compatibility

- [x] Public API changes (export / function signature / behavior)
  - Details: v3 破壊的変更は #391 系 PR で既に main に取り込み済み
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: [`packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md`](packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md) を参照

## How to test

1. 両 `package.json` の `version` が `3.0.0` であることを確認する
2. `pnpm run publish:test` で tarball version が `3.0.0` であることを確認する
3. マージ後、`git tag -a v3.0.0 -m "Release v3.0.0" && git push origin v3.0.0` で release workflow が起動することを確認する

## Environment (if relevant)

- Browser: N/A (version bump only)
- OS: macOS
- web-serial-rxjs version (for verification): 3.0.0
- RxJS version: N/A

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)