### PR TITLE
refactor(web-serial-rxjs): deprecate destroy$ alias in favor of dispose$

### DIFF
--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -110,7 +110,7 @@ v3 では **`SerialSessionStatus`** が lifecycle 文字列定数（例: `Serial
 - `{ status: 'disconnecting' }` — `disconnect$` 実行中。
 - `{ status: 'unsupported' }` — `navigator.serial` が存在しない環境でセッションを生成した場合。
 - `{ status: 'error', error }` — 致命的な失敗。`error` は `errors$` に流れた `SerialError` と同一インスタンス。
-- `{ status: 'disposed' }` — `dispose$` / `destroy$` によりセッションが永久破棄された。
+- `{ status: 'disposed' }` — `dispose$` によりセッションが永久破棄された。
 
 比較例:
 
@@ -135,6 +135,7 @@ interface SerialSession {
   connect$(): Observable<void>;
   disconnect$(): Observable<void>;
   dispose$(): Observable<void>;
+  /** @deprecated {@link dispose$} を使用してください。次回 major version で削除予定です。 */
   destroy$(): Observable<void>;
 
   readonly state$: Observable<SerialSessionState>;
@@ -165,11 +166,15 @@ interface SerialSession {
 
 read pump を停止してポートを閉じます。すでに idle の場合もそのまま complete します。状態遷移は `connected → disconnecting → idle`。`'error'` からも呼べて、ポートをテアダウンして `idle` に戻します。`disconnect$` 後もセッションは再利用可能です。永久破棄には `dispose$` を使います。
 
-### `dispose$(): Observable<void>` / `destroy$(): Observable<void>`
+### `dispose$(): Observable<void>`
 
-セッションを永久破棄します。アクティブな接続があれば `disconnect$` と同様にポートと read pump を teardown し、`state$` に `'disposed'` を emit したうえで、すべてのセッション Observable（`state$`、`errors$`、`receive$`、`lines$`、`terminalText$`、`receiveReplay$`、`portInfo$`、`isConnected$`）を complete します。複数回呼んでも安全で、2 回目以降は即 complete します。`destroy$` は `dispose$` のエイリアスです。
+セッションを永久破棄します。アクティブな接続があれば `disconnect$` と同様にポートと read pump を teardown し、`state$` に `'disposed'` を emit したうえで、すべてのセッション Observable（`state$`、`errors$`、`receive$`、`lines$`、`terminalText$`、`receiveReplay$`、`portInfo$`、`isConnected$`）を complete します。複数回呼んでも安全で、2 回目以降は即 complete します。
 
 dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で失敗します。`disconnect$` は即 complete します。baud rate 変更時の session 作り替えなどでは、破棄したインスタンスを再利用せず新しい `SerialSession` を作成してください。
+
+### `destroy$(): Observable<void>`
+
+**非推奨** — `dispose$()` のエイリアスです。v3.x では後方互換のため残っていますが、次回 major version で削除予定です。詳細は [v3 移行ガイド – destroy$ の非推奨化](./MIGRATION_V3.ja.md#4-destroy-の非推奨化) を参照してください。
 
 ### `state$: Observable<SerialSessionState>`
 
@@ -243,5 +248,5 @@ session.errors$.subscribe((error) => {
 | `INVALID_CONNECTION_OPTIONS` | `baudRate` が範囲外（セッション生成時） |
 | `OPERATION_CANCELLED`    | ユーザーがポート選択ダイアログをキャンセル                         |
 | `OPERATION_TIMEOUT`      | 内部操作がタイムアウト                                             |
-| `SESSION_DISPOSED`       | `dispose$` / `destroy$` 後に `connect$` または `send$` を呼んだ    |
+| `SESSION_DISPOSED`       | `dispose$` 後に `connect$` または `send$` を呼んだ                 |
 | `UNKNOWN`                | 分類不能なエラー。`context.cause` を確認                           |

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -135,6 +135,7 @@ interface SerialSession {
   connect$(): Observable<void>;
   disconnect$(): Observable<void>;
   dispose$(): Observable<void>;
+  /** @deprecated Use {@link dispose$}. Scheduled for removal in the next major version. */
   destroy$(): Observable<void>;
 
   readonly state$: Observable<SerialSessionState>;
@@ -165,11 +166,15 @@ Opens a user-selected serial port and starts the internal read pump. Completes o
 
 Stops the read pump and closes the port. Safe to call when already idle or while a disconnect is already in progress. When called during `'connecting'`, cancels the in-flight `connect$()` (closes any opened port) and returns to `'idle'` without reaching `'connected'`. Transitions `connected → disconnecting → idle`. When called from `'error'` it still tears the port down and returns to `idle`. The session remains reusable after `disconnect$`; use `dispose$` for permanent teardown.
 
-### `dispose$(): Observable<void>` / `destroy$(): Observable<void>`
+### `dispose$(): Observable<void>`
 
-Permanently tears down the session. Closes any active connection (same port/pump cleanup as `disconnect$`), emits `'disposed'` on `state$`, and **completes every session observable** (`state$`, `errors$`, `receive$`, `lines$`, `terminalText$`, `receiveReplay$`, `portInfo$`, `isConnected$`). Safe to call multiple times; subsequent calls complete immediately. `destroy$` is an alias for `dispose$`.
+Permanently tears down the session. Closes any active connection (same port/pump cleanup as `disconnect$`), emits `'disposed'` on `state$`, and **completes every session observable** (`state$`, `errors$`, `receive$`, `lines$`, `terminalText$`, `receiveReplay$`, `portInfo$`, `isConnected$`). Safe to call multiple times; subsequent calls complete immediately.
 
 After disposal, `connect$` and `send$` fail with `SerialErrorCode.SESSION_DISPOSED`. `disconnect$` completes immediately. Create a new `SerialSession` instead of reusing a disposed instance (for example when replacing a session after a baud-rate change).
+
+### `destroy$(): Observable<void>`
+
+**Deprecated** — alias for `dispose$()`. Retained for backward compatibility in v3.x; scheduled for removal in the next major version. See [Migrating to v3 – destroy$ deprecation](./MIGRATION_V3.md#4-destroy-deprecation).
 
 ### `state$: Observable<SerialSessionState>`
 
@@ -243,5 +248,5 @@ The same union is available as a **const object** `SerialErrorCode` (e.g. `Seria
 | `INVALID_CONNECTION_OPTIONS` | `baudRate` was out of range at session creation. |
 | `OPERATION_CANCELLED`    | User cancelled the port picker.                                     |
 | `OPERATION_TIMEOUT`      | Internal operation timed out.                                       |
-| `SESSION_DISPOSED`       | `connect$` or `send$` called after `dispose$` / `destroy$`.         |
+| `SESSION_DISPOSED`       | `connect$` or `send$` called after `dispose$`.                       |
 | `UNKNOWN`                | Unclassified failure; see `context.cause`.                          |

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
@@ -180,8 +180,44 @@ session.errors$.subscribe((error) => {
 
 ---
 
+## 4. `destroy$` の非推奨化
+
+`SerialSession` は `dispose$()` と `destroy$()` の両方を公開しています。これらは同一関数であり、`destroy$` は legacy エイリアスです。lifecycle terminology（`dispose`、`disposed`、`SESSION_DISPOSED`）はすでに **`dispose$`** を canonical API として使用しています。
+
+後方互換のため `destroy$()` は v3.x に残っていますが、**非推奨**です。次回 major version で削除予定です。
+
+### v2 / 旧パターン（非推奨）
+
+```typescript
+session.destroy$().subscribe({
+  complete: () => console.log('session destroyed'),
+});
+```
+
+### v3 推奨パターン
+
+```typescript
+session.dispose$().subscribe({
+  complete: () => console.log('session disposed'),
+});
+```
+
+### 移行チェックリスト
+
+- [ ] `session.destroy$()` を `session.dispose$()` に置き換える。
+- [ ] TypeScript の `@deprecated` 警告が出たら `dispose$` へ移行する。
+- [ ] 新規コードとドキュメントでは `dispose$` を使用する。
+
+### v3.x での互換性
+
+- `destroy$` は v3.x では引き続き利用可能で、`dispose$` と同じ実装に委譲します。
+- ランタイム挙動は変更されません。非推奨化されるのはエイリアスのみです。
+
+---
+
 ## 関連ドキュメント
 
 - [v1 から v2 への移行](./MIGRATION_V2.ja.md)
 - [API リファレンス – SerialSessionState / SerialSessionStatus](./API_REFERENCE.ja.md#serialsessionstate--serialsessionstatus)
 - [API リファレンス – SerialError / SerialErrorCode](./API_REFERENCE.ja.md#serialerror--serialerrorcode)
+- [API リファレンス – dispose$ / destroy$](./API_REFERENCE.ja.md#dispose-observablevoid)

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.md
@@ -180,8 +180,44 @@ session.errors$.subscribe((error) => {
 
 ---
 
+## 4. `destroy$` deprecation
+
+`SerialSession` exposes both `dispose$()` and `destroy$()`. They are the same function — `destroy$` is a legacy alias. Lifecycle terminology (`dispose`, `disposed`, `SESSION_DISPOSED`) already uses **`dispose$`** as the canonical API.
+
+`destroy$()` remains in v3.x for backward compatibility but is **deprecated** and scheduled for removal in the next major version.
+
+### v2 / legacy pattern (deprecated)
+
+```typescript
+session.destroy$().subscribe({
+  complete: () => console.log('session destroyed'),
+});
+```
+
+### v3 recommended pattern
+
+```typescript
+session.dispose$().subscribe({
+  complete: () => console.log('session disposed'),
+});
+```
+
+### Migration checklist
+
+- [ ] Replace `session.destroy$()` with `session.dispose$()`.
+- [ ] Address TypeScript `@deprecated` warnings by migrating to `dispose$`.
+- [ ] Prefer `dispose$` in new code and documentation.
+
+### Compatibility in v3.x
+
+- `destroy$` remains available in v3.x and delegates to the same implementation as `dispose$`.
+- Runtime behavior is unchanged; only the alias is deprecated.
+
+---
+
 ## See also
 
 - [Migrating from v1 to v2](./MIGRATION_V2.md)
 - [API Reference – SerialSessionState / SerialSessionStatus](./API_REFERENCE.md#serialsessionstate--serialsessionstatus)
 - [API Reference – SerialError / SerialErrorCode](./API_REFERENCE.md#serialerror--serialerrorcode)
+- [API Reference – dispose$ / destroy$](./API_REFERENCE.md#dispose-observablevoid)

--- a/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
@@ -59,7 +59,7 @@ TypeDoc のトップページから、まず以下を参照してください。
 | `errors$` | **Canonical error event channel** — 接続・読み取り・書き込み・クローズのすべての `SerialError`（fatal / non-fatal）。 |
 | `connect$()` | ポート選択 → オープン → 内部 read pump 開始。 |
 | `disconnect$()` | ポートを閉じ、pump を停止。セッションは `idle` に戻り再利用可能。 |
-| `dispose$()` / `destroy$()` | セッションを**永久破棄**。接続を閉じ、すべての Observable を complete し、再利用不可にする。`dispose$` を優先し、`destroy$` はエイリアス。 |
+| `dispose$()` | セッションを**永久破棄**。接続を閉じ、すべての Observable を complete し、再利用不可にする。 |
 | `send$(string \| Uint8Array)` | 送信を **FIFO** で直列化（並行 `send$` も呼び出し順）。 |
 | `isBrowserSupported()` | `connect$` の前に使う、Web Serial 利用可否の同期的な `boolean`。 |
 

--- a/packages/web-serial-rxjs/docs/OVERVIEW.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.md
@@ -59,7 +59,7 @@ This library is framework-agnostic and can be used with:
 | `errors$` | **Canonical error event channel** — all `SerialError` instances from connect / read / write / close (fatal and non-fatal). |
 | `connect$()` | **Open** a user-selected port and start the internal read pump. |
 | `disconnect$()` | **Close** the port and stop the pump. The session stays reusable (`idle`). |
-| `dispose$()` / `destroy$()` | **Permanently tear down** the session: close any active connection, complete all observables, and prevent reuse. Prefer `dispose$`; `destroy$` is an alias. |
+| `dispose$()` | **Permanently tear down** the session: close any active connection, complete all observables, and prevent reuse. |
 | `send$(string \| Uint8Array)` | **Enqueue** outgoing data; writes are **FIFO-ordered** when multiple `send$` run concurrently. |
 | `isBrowserSupported()` | Synchronous `boolean` for Web Serial availability before `connect$`. |
 

--- a/packages/web-serial-rxjs/docs/QUICK_START.ja.md
+++ b/packages/web-serial-rxjs/docs/QUICK_START.ja.md
@@ -70,7 +70,7 @@ session.disconnect$().subscribe({
 
 ## 破棄する
 
-baud rate 変更で session を作り替えるなど、セッション自体を完全に手放すときは `dispose$` を呼びます。アクティブな接続を閉じ、すべての Observable を complete します。（`destroy$` は `dispose$` のエイリアスです。）
+baud rate 変更で session を作り替えるなど、セッション自体を完全に手放すときは `dispose$` を呼びます。アクティブな接続を閉じ、すべての Observable を complete します。
 
 ```typescript
 session.dispose$().subscribe({

--- a/packages/web-serial-rxjs/docs/QUICK_START.md
+++ b/packages/web-serial-rxjs/docs/QUICK_START.md
@@ -72,7 +72,7 @@ session.disconnect$().subscribe({
 
 ## Dispose
 
-Call `dispose$` when you are done with the session entirely—for example before replacing it after a baud-rate change. This closes any active connection and completes all observables. (`destroy$` is an alias for `dispose$`.)
+Call `dispose$` when you are done with the session entirely—for example before replacing it after a baud-rate change. This closes any active connection and completes all observables.
 
 ```typescript
 session.dispose$().subscribe({

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -97,7 +97,12 @@ export interface SerialSession {
   /**
    * Alias for {@link dispose$}.
    *
+   * @deprecated Prefer {@link dispose$}. This alias is retained for backward
+   *   compatibility and is scheduled for removal in the next major version.
+   *
    * @returns An Observable that completes when disposal has finished.
+   *
+   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/433 | Issue #433}
    */
   destroy$(): Observable<void>;
 

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -138,6 +138,7 @@ describe('createSerialSession', () => {
       expect(typeof session.connect$).toBe('function');
       expect(typeof session.disconnect$).toBe('function');
       expect(typeof session.dispose$).toBe('function');
+      // destroy$ remains the same function reference as dispose$ during v3.x deprecation.
       expect(typeof session.destroy$).toBe('function');
       expect(session.destroy$).toBe(session.dispose$);
       expect(typeof session.send$).toBe('function');
@@ -1457,7 +1458,8 @@ describe('createSerialSession', () => {
     });
   });
 
-  describe('dispose$ and destroy$', () => {
+  // dispose$ is canonical; destroy$ alias behavior is retained for v3.x backward compatibility.
+  describe('dispose$ and deprecated destroy$ alias', () => {
     it('transitions idle -> disposed and completes state$', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
       (globalThis as any).navigator = { serial: {} };
@@ -1561,6 +1563,7 @@ describe('createSerialSession', () => {
       );
     });
 
+    // destroy$ must stay idempotent via the same implementation as dispose$.
     it('is idempotent for dispose$ and destroy$', async () => {
       const session = createSerialSession();
 


### PR DESCRIPTION
## Summary
`SerialSession.destroy$()` エイリアスを非推奨化し、lifecycle terminology を `dispose$` に統一する移行準備を行いました。挙動変更はなく、v3.x では `@deprecated` 付与とドキュメント更新のみです。削除は次回 major version に集約します。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Parent #430
- Closes #433

## What changed?
- `SerialSession.destroy$()` に `@deprecated` を付与し、`dispose$` への移行を JSDoc で案内
- `MIGRATION_V3` に `destroy$` 非推奨化セクションを追加（EN / JA）
- API リファレンス・概要・クイックスタートを `dispose$` canonical API に合わせて更新
- v3.x 後方互換のため `destroy$` エイリアス実装とテストは維持

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `destroy$()` に `@deprecated` を追加。ランタイム挙動・シグネチャは不変。
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: `destroy$()` → `dispose$()` に置き換え。次回 major version で `destroy$` 削除予定。

## How to test
1. `npx nx test web-serial-rxjs` を実行し、全テストが pass することを確認
2. `session.destroy$()` を使用するコードで TypeScript deprecation 警告が表示されることを確認
3. `session.destroy$` が `session.dispose$` と同一参照であり、dispose 後に `SESSION_DISPOSED` となる既存挙動が変わらないことを確認

## Environment (if relevant)
- 該当なし（挙動変更なし）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)