### PR TITLE
feat(web-serial-rxjs): add isConnectedSessionState type predicate

### DIFF
--- a/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md
+++ b/packages/web-serial-rxjs/docs/ADVANCED_USAGE.ja.md
@@ -57,6 +57,19 @@ isConnected$.subscribe((isOpen) => {
 
 **`isConnected$`** は v3.x で非推奨です。多段階の UI では下記の [state$ 駆動の UI](#state-駆動の-ui) のように `state$` 全体を使う方が分かりやすいです。
 
+RxJS pipeline 内で `portInfo` など connected 専用フィールドにアクセスする場合は、`filter()` と `isConnectedSessionState` を組み合わせてください。inline の status 比較では TypeScript の narrowing は行われません。
+
+```typescript
+import { filter } from 'rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
+```
+
 ## 1 行送信（`sendLine` / `sendLine$` 相当）
 
 対話シェルでは CRLF 終端の 1 行を期待することが多いです。ライブラリに API を増やさず、`send$` の薄いラッパーにします。

--- a/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md
+++ b/packages/web-serial-rxjs/docs/ADVANCED_USAGE.md
@@ -59,6 +59,19 @@ isConnected$.subscribe((isOpen) => {
 
 **`isConnected$`** is deprecated in v3.x. For full lifecycle UI, prefer driving from `state$` directly (see [State-driven UI](#state-driven-ui) below).
 
+When you need connected-only fields such as `portInfo` inside an RxJS pipeline, use `isConnectedSessionState` with `filter()` — inline status comparisons do not narrow types in TypeScript:
+
+```typescript
+import { filter } from 'rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
+```
+
 ## Send line (`sendLine` / `sendLine$` pattern)
 
 Interactive shells often expect a full line terminated by CRLF. Wrap `send$` in a small helper instead of adding API to the library:

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -115,13 +115,36 @@ v3 では **`SerialSessionStatus`** が lifecycle 文字列定数（例: `Serial
 比較例:
 
 ```typescript
-import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { filter } from 'rxjs';
+import { isConnectedSessionState, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 
 session.state$.subscribe((state) => {
   if (state.status === SerialSessionStatus.Connected) {
     console.log(state.portInfo);
   }
 });
+
+// RxJS pipeline では type predicate を使うと ConnectedSessionState が保持される
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
+```
+
+### `isConnectedSessionState(state)`
+
+`ConnectedSessionState` 用の type predicate です。RxJS の `filter()` と組み合わせて pipeline 内の discriminated union narrowing を保持します。inline の `filter((s) => s.status === SerialSessionStatus.Connected)` では TypeScript の narrowing は行われません。
+
+```typescript
+import { filter } from 'rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
 ```
 
 v2 からの移行は [v3 移行ガイド](./MIGRATION_V3.ja.md) を参照してください。

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -115,13 +115,36 @@ v3 exposes **`SerialSessionStatus`** as lifecycle string constants (e.g. `Serial
 Example:
 
 ```typescript
-import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { filter } from 'rxjs';
+import { isConnectedSessionState, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 
 session.state$.subscribe((state) => {
   if (state.status === SerialSessionStatus.Connected) {
     console.log(state.portInfo);
   }
 });
+
+// RxJS pipelines: use the type predicate so TypeScript keeps ConnectedSessionState
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
+```
+
+### `isConnectedSessionState(state)`
+
+Type predicate for `ConnectedSessionState`. Use with RxJS `filter()` to preserve discriminated union narrowing in pipelines. Inline `filter((s) => s.status === SerialSessionStatus.Connected)` does not narrow types in TypeScript.
+
+```typescript
+import { filter } from 'rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
 ```
 
 See [Migrating to v3](./MIGRATION_V3.md) for the v2 string migration.

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
@@ -301,6 +301,21 @@ const isConnected$ = session.state$.pipe(
 );
 ```
 
+### RxJS `filter` で connected state を narrowing する場合
+
+pipeline 内で `portInfo` など connected 専用フィールドにアクセスするには、`filter()` と `isConnectedSessionState` を組み合わせます。inline の `filter((s) => s.status === SerialSessionStatus.Connected)` では TypeScript の narrowing は行われません。
+
+```typescript
+import { filter } from 'rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
+```
+
 ### Angular Signals で boolean を derive する場合
 
 ```typescript

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.md
@@ -301,6 +301,21 @@ const isConnected$ = session.state$.pipe(
 );
 ```
 
+### RxJS `filter` with connected-state narrowing
+
+When you need `portInfo` or other connected-only fields inside a pipeline, use `isConnectedSessionState` with `filter()`. Inline `filter((s) => s.status === SerialSessionStatus.Connected)` does not narrow types in TypeScript.
+
+```typescript
+import { filter } from 'rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+
+session.state$
+  .pipe(filter(isConnectedSessionState))
+  .subscribe((state) => {
+    console.log(state.portInfo);
+  });
+```
+
 ### Deriving a boolean with Angular Signals
 
 ```typescript

--- a/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.ja.md
@@ -86,7 +86,7 @@ TypeDoc のトップページから、まず以下を参照してください。
 ### 最小サンプル
 
 ```typescript
-import { createSerialSession, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { createSerialSession, isConnectedSessionState } from '@gurezo/web-serial-rxjs';
 import { filter } from 'rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
@@ -98,7 +98,7 @@ if (!session.isBrowserSupported()) {
 session.lines$.subscribe(console.log);
 session.errors$.subscribe(console.error);
 session.state$
-  .pipe(filter((s) => s.status === SerialSessionStatus.Connected))
+  .pipe(filter(isConnectedSessionState))
   .subscribe((state) => {
     console.log(state.portInfo);
   });

--- a/packages/web-serial-rxjs/docs/OVERVIEW.md
+++ b/packages/web-serial-rxjs/docs/OVERVIEW.md
@@ -86,7 +86,7 @@ Each `state$` emission has a `status` field. Prefer the **const object** (e.g. `
 ### Minimal example
 
 ```typescript
-import { createSerialSession, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { createSerialSession, isConnectedSessionState } from '@gurezo/web-serial-rxjs';
 import { filter } from 'rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
@@ -98,7 +98,7 @@ if (!session.isBrowserSupported()) {
 session.lines$.subscribe(console.log);
 session.errors$.subscribe(console.error);
 session.state$
-  .pipe(filter((s) => s.status === SerialSessionStatus.Connected))
+  .pipe(filter(isConnectedSessionState))
   .subscribe((state) => {
     console.log(state.portInfo);
   });

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -25,6 +25,7 @@
  * - {@link SerialConnectionOptions} - `port.open` connection parameters (excluding filters)
  * - {@link SerialSessionStatus} - lifecycle status literals for `state$.status`
  * - {@link SerialSessionState} - discriminated union emitted by `state$`
+ * - {@link isConnectedSessionState} - type predicate for connected `state$` narrowing in RxJS pipelines
  * - {@link SerialError} / {@link SerialErrorCode} - unified error surface
  * - {@link SerialErrorContextMap} - structured metadata per error code
  *
@@ -47,8 +48,10 @@
  *
  * @example
  * ```typescript
+ * import { filter } from 'rxjs';
  * import {
  *   createSerialSession,
+ *   isConnectedSessionState,
  *   SerialSessionStatus,
  *   SerialErrorCode,
  * } from '@gurezo/web-serial-rxjs';
@@ -63,6 +66,11 @@
  *       console.log('port:', state.portInfo);
  *     }
  *   });
+ *   session.state$
+ *     .pipe(filter(isConnectedSessionState))
+ *     .subscribe((state) => {
+ *       console.log('port:', state.portInfo);
+ *     });
  *   session.receive$.subscribe((chunk) => console.log('rx:', chunk));
  *   session.errors$.subscribe((error) => {
  *     if (error.is(SerialErrorCode.READ_FAILED)) {

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -78,7 +78,7 @@
 
 export { assertNever } from './internal/assert-never';
 
-export { createSerialSession, SerialSessionStatus, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions, MAX_RECEIVE_REPLAY_BUFFER_SIZE, MAX_RECEIVE_REPLAY_MAX_CHARS } from './session';
+export { createSerialSession, SerialSessionStatus, isConnectedSessionState, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions, MAX_RECEIVE_REPLAY_BUFFER_SIZE, MAX_RECEIVE_REPLAY_MAX_CHARS } from './session';
 export type {
   SerialSession,
   SerialSessionState,

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -12,6 +12,7 @@ export {
 } from './serial-session-options';
 export type { SerialPayload, SerialConnectionOptions } from '../types';
 export { SerialSessionStatus } from './serial-session-state';
+export { isConnectedSessionState } from './is-connected-session-state';
 export type {
   SerialSessionState,
   IdleSessionState,

--- a/packages/web-serial-rxjs/src/session/is-connected-session-state.ts
+++ b/packages/web-serial-rxjs/src/session/is-connected-session-state.ts
@@ -1,0 +1,19 @@
+import {
+  type ConnectedSessionState,
+  type SerialSessionState,
+  SerialSessionStatus,
+} from './serial-session-state';
+
+/**
+ * Type predicate for {@link ConnectedSessionState}.
+ *
+ * Use with RxJS `filter()` to preserve discriminated union narrowing in
+ * pipelines so `portInfo` and other connected-only fields stay typed.
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/436 | Issue #436}
+ */
+export function isConnectedSessionState(
+  state: SerialSessionState,
+): state is ConnectedSessionState {
+  return state.status === SerialSessionStatus.Connected;
+}

--- a/packages/web-serial-rxjs/tests/session/is-connected-session-state.test.ts
+++ b/packages/web-serial-rxjs/tests/session/is-connected-session-state.test.ts
@@ -1,0 +1,54 @@
+import { filter, firstValueFrom, of } from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { isConnectedSessionState } from '../../src/session/is-connected-session-state';
+import {
+  SerialSessionStatus,
+  type SerialSessionState,
+} from '../../src/session/serial-session-state';
+
+const S = SerialSessionStatus;
+
+const stubPortInfo: SerialPortInfo = {
+  usbVendorId: 0x1a86,
+  usbProductId: 0x7523,
+};
+
+describe('isConnectedSessionState', () => {
+  const connected: SerialSessionState = {
+    status: S.Connected,
+    portInfo: stubPortInfo,
+  };
+
+  const nonConnectedStates: SerialSessionState[] = [
+    { status: S.Idle },
+    { status: S.Connecting },
+    { status: S.Disconnecting },
+    { status: S.Unsupported },
+    {
+      status: S.Error,
+      error: new SerialError(SerialErrorCode.UNKNOWN, 'test'),
+    },
+    { status: S.Disposed },
+  ];
+
+  it('returns true for connected state', () => {
+    expect(isConnectedSessionState(connected)).toBe(true);
+  });
+
+  it.each(nonConnectedStates.map((state) => [state.status, state] as const))(
+    'returns false for %s state',
+    (_status, state) => {
+      expect(isConnectedSessionState(state)).toBe(false);
+    },
+  );
+
+  it('narrows state in RxJS filter pipelines', async () => {
+    const state = await firstValueFrom(
+      of<SerialSessionState>(connected).pipe(filter(isConnectedSessionState)),
+    );
+
+    expect(state.portInfo).toEqual(stubPortInfo);
+  });
+});


### PR DESCRIPTION
## Summary
`isConnected$` 非推奨化後、RxJS pipeline で `state$` の discriminated union narrowing を保持するため、`isConnectedSessionState` type predicate を追加しました。破壊的変更はありません。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #436
- Parent: #430

## What changed?
- `isConnectedSessionState` 関数を追加し public export しました
- 全 lifecycle state に対する predicate 単体テストと RxJS `filter` 統合テストを追加しました
- API リファレンス・移行ガイド・利用例ドキュメント（英日）を更新しました

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `isConnectedSessionState(state): state is ConnectedSessionState` を新規 export
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec vitest run --project web-serial-rxjs` でテストが通ることを確認
2. `pnpm nx run web-serial-rxjs:build` で `dist/index.d.ts` に `isConnectedSessionState` が含まれることを確認
3. ドキュメントの `filter(isConnectedSessionState)` 例で TypeScript が `state.portInfo` にアクセスできることを確認

## Environment (if relevant)
- Browser: N/A（ライブラリ API 追加のみ）
- OS: macOS
- web-serial-rxjs version (for verification): 3.0.0（作業ブランチ）
- RxJS version: ^7.8.0

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)