### PR TITLE
refactor(web-serial-rxjs): audit SerialErrorCode runtime emission coverage

### DIFF
--- a/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.ja.md
@@ -257,6 +257,8 @@ session.errors$.subscribe((error) => {
 
 上記と同じ文字列のユニオン型に加え、**定数オブジェクト** `SerialErrorCode`（例: `SerialErrorCode.READ_FAILED` は `'READ_FAILED'`）が export され、補完やタイポ防止に使えます。従来どおり文字列リテラルで型注釈・比較しても問題ありません。enum から const object への宣言変更は [v3 移行ガイド](./MIGRATION_V3.ja.md) を参照してください。
 
+全 19 code の runtime emission coverage は [v3 移行ガイド §8](./MIGRATION_V3.ja.md#8-serialerrorcode-runtime-emission-監査) で監査済みです。
+
 | Code                     | `context` の形 | emit されるタイミング                                              |
 | ------------------------ | -------------- | ------------------------------------------------------------------ |
 | `LINE_BUFFER_OVERFLOW`   | `{ maxChars: number }` | `lines$` の未完成 tail が `lineBuffer.maxChars` を超過。先頭データを破棄（non-fatal） |
@@ -264,13 +266,14 @@ session.errors$.subscribe((error) => {
 | `PORT_OPEN_FAILED` など cause 系 | `{ cause: unknown }` | 下表の各タイミング。`error.is(code)` で narrow してから `context.cause` を参照 |
 | その他                   | `undefined`    | 下表の各タイミング                                                 |
 
+### Implemented（v3.x で emit される）
+
 | Code                     | emit されるタイミング                                              |
 | ------------------------ | ------------------------------------------------------------------ |
-| `BROWSER_NOT_SUPPORTED`  | 生成時／`connect$` 時に `navigator.serial` が無い                  |
-| `PORT_NOT_AVAILABLE`     | 要求ポートにアクセスできない                                       |
+| `BROWSER_NOT_SUPPORTED`  | `connect$` 時に `navigator.serial` が無い                          |
 | `PORT_OPEN_FAILED`       | `port.open()` が reject                                            |
 | `PORT_ALREADY_OPEN`      | `'idle'` / `'error'` 以外で `connect$` を呼んだ                    |
-| `PORT_NOT_OPEN`          | 許可されない状態で `send$` / `disconnect$` を呼んだ                |
+| `PORT_NOT_OPEN`          | 許可されない状態で `send$` または `disconnect$` を呼んだ           |
 | `READ_FAILED`            | 内部 read pump でエラーが発生                                      |
 | `WRITE_FAILED`           | `port.writable.getWriter().write()` が reject                      |
 | `CONNECTION_LOST`        | `port.close()` 失敗または接続中に切断                              |
@@ -280,6 +283,12 @@ session.errors$.subscribe((error) => {
 | `INVALID_LINE_BUFFER_OPTIONS` | `lineBuffer.maxChars` が範囲外（セッション生成時） |
 | `INVALID_CONNECTION_OPTIONS` | `baudRate` が範囲外（セッション生成時） |
 | `OPERATION_CANCELLED`    | ユーザーがポート選択ダイアログをキャンセル                         |
-| `OPERATION_TIMEOUT`      | 内部操作がタイムアウト                                             |
 | `SESSION_DISPOSED`       | `dispose$` 後に `connect$` または `send$` を呼んだ                 |
-| `UNKNOWN`                | 分類不能なエラー。`context.cause` を確認                           |
+| `UNKNOWN`                | dispose / disconnect の分類不能 fallback。`context.cause` を確認     |
+
+### Reserved（v3.x では emit されない・次回 major で削除予定）
+
+| Code                     | 備考                                                               |
+| ------------------------ | ------------------------------------------------------------------ |
+| `PORT_NOT_AVAILABLE`     | **非推奨。** `getPorts` 系 API 未実装のため到達不能。ポート取得失敗は `PORT_OPEN_FAILED` / `OPERATION_CANCELLED` を使用 |
+| `OPERATION_TIMEOUT`      | **非推奨。** timeout / transaction API 未実装のため到達不能        |

--- a/packages/web-serial-rxjs/docs/API_REFERENCE.md
+++ b/packages/web-serial-rxjs/docs/API_REFERENCE.md
@@ -257,6 +257,8 @@ session.errors$.subscribe((error) => {
 
 The same union is available as a **const object** `SerialErrorCode` (e.g. `SerialErrorCode.READ_FAILED` is `'READ_FAILED'`) for IDE completion and to avoid string typos. String literals stay valid for types and runtime comparisons. See [Migrating to v3](./MIGRATION_V3.md) for the enum-to-const declaration change.
 
+Runtime emission coverage for all 19 codes is audited in [Migrating to v3 §8](./MIGRATION_V3.md#8-serialerrorcode-runtime-emission-audit).
+
 | Code                     | `context` shape | When it is emitted                                                  |
 | ------------------------ | --------------- | ------------------------------------------------------------------- |
 | `LINE_BUFFER_OVERFLOW`   | `{ maxChars: number }` | `lines$` incomplete tail exceeded `lineBuffer.maxChars`; leading data discarded (non-fatal). |
@@ -264,13 +266,14 @@ The same union is available as a **const object** `SerialErrorCode` (e.g. `Seria
 | Cause-bearing codes (e.g. `PORT_OPEN_FAILED`) | `{ cause: unknown }` | See table below. Narrow with `error.is(code)` before reading `context.cause`. |
 | Other codes              | `undefined`     | See table below.                                                    |
 
+### Implemented (emitted in v3.x)
+
 | Code                     | When it is emitted                                                  |
 | ------------------------ | ------------------------------------------------------------------- |
-| `BROWSER_NOT_SUPPORTED`  | Session construction / `connect$` without `navigator.serial`.       |
-| `PORT_NOT_AVAILABLE`     | Requested port cannot be accessed.                                  |
+| `BROWSER_NOT_SUPPORTED`  | `connect$` without `navigator.serial`.                              |
 | `PORT_OPEN_FAILED`       | `port.open()` rejected.                                             |
 | `PORT_ALREADY_OPEN`      | `connect$` called while not in `'idle'` / `'error'`.                |
-| `PORT_NOT_OPEN`          | `send$` called while not `'connected'`.                             |
+| `PORT_NOT_OPEN`          | `send$` or `disconnect$` called in an invalid session state.        |
 | `READ_FAILED`            | Internal read pump errored.                                         |
 | `WRITE_FAILED`           | `port.writable.getWriter().write()` rejected.                       |
 | `CONNECTION_LOST`        | `port.close()` failed or the port dropped mid-session.              |
@@ -280,6 +283,12 @@ The same union is available as a **const object** `SerialErrorCode` (e.g. `Seria
 | `INVALID_LINE_BUFFER_OPTIONS` | `lineBuffer.maxChars` was out of range at session creation. |
 | `INVALID_CONNECTION_OPTIONS` | `baudRate` was out of range at session creation. |
 | `OPERATION_CANCELLED`    | User cancelled the port picker.                                     |
-| `OPERATION_TIMEOUT`      | Internal operation timed out.                                       |
 | `SESSION_DISPOSED`       | `connect$` or `send$` called after `dispose$`.                       |
-| `UNKNOWN`                | Unclassified failure; see `context.cause`.                          |
+| `UNKNOWN`                | Unclassified dispose / disconnect fallback; see `context.cause`.    |
+
+### Reserved (not emitted in v3.x; scheduled for removal in next major)
+
+| Code                     | Notes                                                               |
+| ------------------------ | ------------------------------------------------------------------- |
+| `PORT_NOT_AVAILABLE`     | **Deprecated.** Unreachable without a `getPorts` API. Use `PORT_OPEN_FAILED` / `OPERATION_CANCELLED` for port acquisition failures. |
+| `OPERATION_TIMEOUT`      | **Deprecated.** Unreachable without a timeout / transaction API.    |

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.ja.md
@@ -393,6 +393,62 @@ session.state$.subscribe((state) => {
 
 ---
 
+## 8. `SerialErrorCode` runtime emission 監査
+
+public API contract として定義されている `SerialErrorCode` のうち、一部は v3.x の runtime implementation から emit されていませんでした。到達不能な error handling を防ぐため、全 19 code の emission coverage を監査し（[#438](https://github.com/gurezo/web-serial-rxjs/issues/438)）、結果を本セクションと [API リファレンス](./API_REFERENCE.ja.md#serialerror--serialerrorcode) に反映しました。
+
+### 分類
+
+| 分類 | 件数 | 説明 |
+| --- | --- | --- |
+| **Implemented** | 17 | v3.x で runtime から emit される（または factory 時に throw される） |
+| **Reserved** | 2 | public API に存在するが v3.x では emit されない。次回 major version で削除予定 |
+
+### Reserved code（v3.x では emit されない）
+
+| Code | 理由 | 代替 |
+| --- | --- | --- |
+| `PORT_NOT_AVAILABLE` | 現行実装は `navigator.serial.requestPort` のみ使用。`getPorts` 系 API 未実装のため emit 経路がない | ポート取得失敗は `PORT_OPEN_FAILED` または `OPERATION_CANCELLED` を参照 |
+| `OPERATION_TIMEOUT` | timeout / prompt detection / transaction API が未実装 | 該当なし（将来 API 追加時に再評価） |
+
+v3.x では `@deprecated` 注記のみ付与し、runtime 値と export は維持します。削除は次回 major version に集約します。
+
+### Implemented code 一覧
+
+| Code | emit 箇所 | fatal / non-fatal | `context` | テスト |
+| --- | --- | --- | --- | --- |
+| `BROWSER_NOT_SUPPORTED` | `connect$`（`navigator.serial` なし） | non-fatal | `undefined` | 統合 |
+| `PORT_OPEN_FAILED` | `connect$`（`port.open()` reject） | fatal | `{ cause }` | 統合 |
+| `PORT_ALREADY_OPEN` | `connect$`（`'idle'` / `'error'` 以外） | non-fatal | `undefined` | 統合 |
+| `PORT_NOT_OPEN` | `send$` / `disconnect$`（不正状態） | non-fatal | `undefined` | 統合 |
+| `READ_FAILED` | read pump エラー | fatal | `{ cause }` | 統合 |
+| `WRITE_FAILED` | `send$` 書き込み失敗 | non-fatal | `{ cause }` | 統合 |
+| `CONNECTION_LOST` | `port.close()` 失敗 / ストリーム切断 | fatal | `{ cause }` | 統合 |
+| `INVALID_FILTER_OPTIONS` | `createSerialSession` factory | throw | `undefined` | 単体 + 統合 |
+| `OPERATION_CANCELLED` | `requestPort` ダイアログキャンセル | fatal | `{ cause }` | 統合 |
+| `LINE_BUFFER_OVERFLOW` | `lines$` tail 超過 | non-fatal | `{ maxChars }` | 統合 |
+| `INVALID_RECEIVE_REPLAY_OPTIONS` | factory | throw | `undefined` | 単体 + 統合 |
+| `INVALID_TERMINAL_BUFFER_OPTIONS` | factory | throw | `undefined` | 単体 |
+| `INVALID_LINE_BUFFER_OPTIONS` | factory | throw | `undefined` | 単体 |
+| `INVALID_CONNECTION_OPTIONS` | factory | throw | `undefined` | 単体 + 統合 |
+| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` 超過 | non-fatal | `{ maxChars, bufferSize }` | 統合 |
+| `SESSION_DISPOSED` | `dispose$` 後の `connect$` / `send$` | fatal | `undefined` | 統合 |
+| `UNKNOWN` | dispose / disconnect の分類不能 fallback | fatal | `{ cause }` | 単体 |
+
+fatal / non-fatal の判定は `reportError` 経由の `ERROR_SEVERITY` に従います。factory throw の `INVALID_*` code は `reportError` を通らず、呼び出し元に直接 throw されます。
+
+### 移行チェックリスト
+
+- [ ] `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` 向けの error handling を削除する（v3.x では到達しない）。
+- [ ] ポート取得失敗は `PORT_OPEN_FAILED` / `OPERATION_CANCELLED` で処理する。
+- [ ] 全 code の emit 条件は [API リファレンス – SerialError / SerialErrorCode](./API_REFERENCE.ja.md#serialerror--serialerrorcode) を参照する。
+
+### 後続作業
+
+validation error（`INVALID_*`）への structured context 追加は [#439](https://github.com/gurezo/web-serial-rxjs/issues/439) で実施予定です。
+
+---
+
 ## 関連ドキュメント
 
 - [v1 から v2 への移行](./MIGRATION_V2.ja.md)

--- a/packages/web-serial-rxjs/docs/MIGRATION_V3.md
+++ b/packages/web-serial-rxjs/docs/MIGRATION_V3.md
@@ -393,6 +393,62 @@ Operations such as `getSignals()` / `setSignals()` that previously required a ra
 
 ---
 
+## 8. `SerialErrorCode` runtime emission audit
+
+Some members of the public `SerialErrorCode` contract were not emitted by the v3.x runtime. To prevent unreachable error-handling branches, all 19 codes were audited ([#438](https://github.com/gurezo/web-serial-rxjs/issues/438)) and the results are recorded here and in the [API Reference](./API_REFERENCE.md#serialerror--serialerrorcode).
+
+### Classification
+
+| Category | Count | Description |
+| --- | --- | --- |
+| **Implemented** | 17 | Emitted at runtime in v3.x (or thrown at factory time) |
+| **Reserved** | 2 | Present in the public API but not emitted in v3.x; scheduled for removal in the next major version |
+
+### Reserved codes (not emitted in v3.x)
+
+| Code | Reason | Alternative |
+| --- | --- | --- |
+| `PORT_NOT_AVAILABLE` | Current implementation uses only `navigator.serial.requestPort`; no `getPorts` API path exists | Use `PORT_OPEN_FAILED` or `OPERATION_CANCELLED` for port acquisition failures |
+| `OPERATION_TIMEOUT` | No timeout / prompt detection / transaction API yet | None (revisit when a future API is added) |
+
+v3.x adds `@deprecated` annotations only; runtime values and exports are unchanged. Removal is deferred to the next major version.
+
+### Implemented codes
+
+| Code | Emit location | fatal / non-fatal | `context` | Tests |
+| --- | --- | --- | --- | --- |
+| `BROWSER_NOT_SUPPORTED` | `connect$` (no `navigator.serial`) | non-fatal | `undefined` | integration |
+| `PORT_OPEN_FAILED` | `connect$` (`port.open()` reject) | fatal | `{ cause }` | integration |
+| `PORT_ALREADY_OPEN` | `connect$` (not in `'idle'` / `'error'`) | non-fatal | `undefined` | integration |
+| `PORT_NOT_OPEN` | `send$` / `disconnect$` (invalid state) | non-fatal | `undefined` | integration |
+| `READ_FAILED` | read pump error | fatal | `{ cause }` | integration |
+| `WRITE_FAILED` | `send$` write failure | non-fatal | `{ cause }` | integration |
+| `CONNECTION_LOST` | `port.close()` failure / stream drop | fatal | `{ cause }` | integration |
+| `INVALID_FILTER_OPTIONS` | `createSerialSession` factory | throw | `undefined` | unit + integration |
+| `OPERATION_CANCELLED` | `requestPort` dialog cancelled | fatal | `{ cause }` | integration |
+| `LINE_BUFFER_OVERFLOW` | `lines$` tail overflow | non-fatal | `{ maxChars }` | integration |
+| `INVALID_RECEIVE_REPLAY_OPTIONS` | factory | throw | `undefined` | unit + integration |
+| `INVALID_TERMINAL_BUFFER_OPTIONS` | factory | throw | `undefined` | unit |
+| `INVALID_LINE_BUFFER_OPTIONS` | factory | throw | `undefined` | unit |
+| `INVALID_CONNECTION_OPTIONS` | factory | throw | `undefined` | unit + integration |
+| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` overflow | non-fatal | `{ maxChars, bufferSize }` | integration |
+| `SESSION_DISPOSED` | `connect$` / `send$` after `dispose$` | fatal | `undefined` | integration |
+| `UNKNOWN` | unclassified dispose / disconnect fallback | fatal | `{ cause }` | unit |
+
+Fatal vs non-fatal follows `ERROR_SEVERITY` inside `reportError`. Factory-thrown `INVALID_*` codes bypass `reportError` and throw directly to the caller.
+
+### Migration checklist
+
+- [ ] Remove error handling for `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` (unreachable in v3.x).
+- [ ] Handle port acquisition failures with `PORT_OPEN_FAILED` / `OPERATION_CANCELLED`.
+- [ ] See [API Reference – SerialError / SerialErrorCode](./API_REFERENCE.md#serialerror--serialerrorcode) for per-code emit conditions.
+
+### Follow-up
+
+Structured context for validation errors (`INVALID_*`) is planned in [#439](https://github.com/gurezo/web-serial-rxjs/issues/439).
+
+---
+
 ## See also
 
 - [Migrating from v1 to v2](./MIGRATION_V2.md)

--- a/packages/web-serial-rxjs/src/errors/serial-error-code.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error-code.ts
@@ -28,30 +28,34 @@ export const SerialErrorCode = {
   /**
    * Browser does not support the Web Serial API.
    *
-   * This error occurs when attempting to use serial port functionality in a browser
-   * that doesn't support the Web Serial API. Supported desktop browsers are Chrome,
-   * Edge, Opera, and Firefox 151+. Safari and mobile browsers are not supported.
+   * Emitted on `connect$` when `navigator.serial` is unavailable.
    *
    * **Suggested action**: Inform the user to use a supported browser.
+   *
+   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/438 | Issue #438}
    */
   BROWSER_NOT_SUPPORTED: 'BROWSER_NOT_SUPPORTED',
 
   /**
    * Serial port is not available.
    *
-   * This error occurs when a requested port cannot be accessed, such as when
-   * getting previously granted ports fails or when the port is already in use
-   * by another application.
+   * **Reserved — not emitted in v3.x.** The current implementation uses only
+   * `navigator.serial.requestPort`; there is no `getPorts` API path. Scheduled
+   * for removal in the next major version.
    *
-   * **Suggested action**: Check if the port is available or being used by another application.
+   * **Suggested action**: Handle port acquisition failures with
+   * {@link SerialErrorCode.PORT_OPEN_FAILED} or
+   * {@link SerialErrorCode.OPERATION_CANCELLED} instead.
+   *
+   * @deprecated Not emitted at runtime in v3.x. Will be removed in the next major version.
+   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/438 | Issue #438}
    */
   PORT_NOT_AVAILABLE: 'PORT_NOT_AVAILABLE',
 
   /**
    * Failed to open the serial port.
    *
-   * This error occurs when the port cannot be opened, typically due to incorrect
-   * connection parameters, hardware issues, or permission problems.
+   * Emitted on `connect$` when `port.open()` rejects.
    *
    * **Suggested action**: Verify connection parameters and check hardware connections.
    */
@@ -60,8 +64,8 @@ export const SerialErrorCode = {
   /**
    * Serial port is already open.
    *
-   * This error occurs when attempting to open a port that is already connected.
-   * Only one connection can be active at a time per SerialClient instance.
+   * Emitted on `connect$` when the session is not in `'idle'` or `'error'`
+   * (non-fatal; session state is unchanged).
    *
    * **Suggested action**: Disconnect the current port before connecting a new one.
    */
@@ -70,10 +74,10 @@ export const SerialErrorCode = {
   /**
    * Serial port is not open.
    *
-   * This error occurs when attempting to read from or write to a port that hasn't
-   * been opened yet. The port must be connected before performing I/O operations.
+   * Emitted when `send$` or `disconnect$` is called in an invalid session
+   * state (for example before `connect$` completes).
    *
-   * **Suggested action**: Call {@link SerialClient.connect} before reading or writing.
+   * **Suggested action**: Call {@link SerialSession.connect$} before sending data.
    */
   PORT_NOT_OPEN: 'PORT_NOT_OPEN',
 
@@ -132,8 +136,12 @@ export const SerialErrorCode = {
   /**
    * Operation timed out before completion.
    *
-   * This error occurs when an operation waits for a condition (for example, prompt
-   * detection) and the timeout period elapses first.
+   * **Reserved — not emitted in v3.x.** No timeout / prompt detection /
+   * transaction API exists yet. Scheduled for removal in the next major version
+   * unless a future API adopts this code.
+   *
+   * @deprecated Not emitted at runtime in v3.x. Will be removed in the next major version.
+   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/438 | Issue #438}
    */
   OPERATION_TIMEOUT: 'OPERATION_TIMEOUT',
 
@@ -220,9 +228,9 @@ export const SerialErrorCode = {
   /**
    * Unknown error occurred.
    *
-   * This error code is used for errors that don't fit into any other category.
-   * The original error details may be available in the error's message or
-   * {@link SerialError.context | context.cause} property.
+   * Emitted as a fallback when dispose or disconnect encounters an error that
+   * cannot be classified more specifically. The underlying failure is on
+   * {@link SerialError.context | context.cause}.
    *
    * **Suggested action**: Check the error message and `context.cause` for more details.
    */

--- a/packages/web-serial-rxjs/tests/errors/serial-error-code-emission.test.ts
+++ b/packages/web-serial-rxjs/tests/errors/serial-error-code-emission.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+
+/**
+ * Regression guard for the SerialErrorCode emission audit (Issue #438).
+ * Keep in sync with MIGRATION_V3 §8 and API_REFERENCE.
+ */
+const IMPLEMENTED_CODES = [
+  SerialErrorCode.BROWSER_NOT_SUPPORTED,
+  SerialErrorCode.PORT_OPEN_FAILED,
+  SerialErrorCode.PORT_ALREADY_OPEN,
+  SerialErrorCode.PORT_NOT_OPEN,
+  SerialErrorCode.READ_FAILED,
+  SerialErrorCode.WRITE_FAILED,
+  SerialErrorCode.CONNECTION_LOST,
+  SerialErrorCode.INVALID_FILTER_OPTIONS,
+  SerialErrorCode.OPERATION_CANCELLED,
+  SerialErrorCode.LINE_BUFFER_OVERFLOW,
+  SerialErrorCode.INVALID_RECEIVE_REPLAY_OPTIONS,
+  SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
+  SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS,
+  SerialErrorCode.INVALID_CONNECTION_OPTIONS,
+  SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
+  SerialErrorCode.SESSION_DISPOSED,
+  SerialErrorCode.UNKNOWN,
+] as const;
+
+const RESERVED_CODES = [
+  SerialErrorCode.PORT_NOT_AVAILABLE,
+  SerialErrorCode.OPERATION_TIMEOUT,
+] as const;
+
+describe('SerialErrorCode emission audit (#438)', () => {
+  it('defines exactly 19 codes', () => {
+    expect(Object.values(SerialErrorCode)).toHaveLength(19);
+  });
+
+  it('classifies every code as implemented or reserved', () => {
+    const classified = new Set<string>([
+      ...IMPLEMENTED_CODES,
+      ...RESERVED_CODES,
+    ]);
+    expect(classified.size).toBe(19);
+    for (const code of Object.values(SerialErrorCode)) {
+      expect(classified.has(code)).toBe(true);
+    }
+  });
+
+  it('marks reserved codes as not implemented at runtime in v3.x', () => {
+    expect(RESERVED_CODES).toEqual([
+      SerialErrorCode.PORT_NOT_AVAILABLE,
+      SerialErrorCode.OPERATION_TIMEOUT,
+    ]);
+  });
+});

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -570,6 +570,25 @@ describe('createSerialSession', () => {
       });
     });
 
+    it('rejects connect$ with PORT_ALREADY_OPEN while connected without changing state$', async () => {
+      const { stream } = makeStream();
+      const port = makeMockPort(stream);
+      installNavigator(port);
+
+      const session = createSerialSession();
+      await firstValueFrom(session.connect$());
+
+      const errorsPromise = firstValueFrom(session.errors$);
+      await expect(firstValueFrom(session.connect$())).rejects.toMatchObject({
+        name: 'SerialError',
+        code: SerialErrorCode.PORT_ALREADY_OPEN,
+      });
+
+      const emitted = await errorsPromise;
+      expect(emitted.code).toBe(SerialErrorCode.PORT_ALREADY_OPEN);
+      expect(await firstValueFrom(session.state$)).toEqual(connectedState());
+    });
+
     it('disconnect$ completes immediately when state is idle', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
       (globalThis as any).navigator = { serial: {} };


### PR DESCRIPTION
## Summary

`SerialErrorCode` 全19件の runtime emission を監査し、v3.x で emit されない `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` を Reserved として明文化しました。API ドキュメントと実装の差分を解消し、不足していた emission テストを補完します。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Parent: #430
- Fixes #438

## What changed?

- MIGRATION_V3 に §8（SerialErrorCode emission audit）を追加
- API_REFERENCE の SerialErrorCode 表を Implemented / Reserved に整理
- `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` に `@deprecated` 注記と JSDoc を更新
- `PORT_ALREADY_OPEN` の統合テストと emission audit regression guard を追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

`@deprecated` 注記のみ追加。runtime 値と export は不変です。Reserved code の削除は次回 major version に集約します。

## How to test

1. `npx nx test web-serial-rxjs` が pass すること
2. MIGRATION_V3 §8 と API_REFERENCE の Reserved セクションを確認する
3. 接続済み状態で `connect$` を再呼び出し、`PORT_ALREADY_OPEN` が non-fatal で emit されること

## Environment (if relevant)

- 本変更は監査・ドキュメント・テスト追加のため、Chromium 実機確認は不要

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)