### PR TITLE
docs(web-serial-rxjs): unify typedoc api reference as english canonical docs

### DIFF
--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
@@ -112,7 +112,7 @@ Guide の source は `guide/{en,ja}/` に配置済み。legacy flat パスは #4
 | `docs/api/**`、`docs/guide/**` | しない（CI 生成 artifact） |
 | `docs/.gitignore` | する（生成物を除外） |
 
-- ローカル生成: `pnpm run docs`（#457 まで現行 TypeDoc 設定）
+- ローカル生成: `pnpm run docs`（TypeDoc は `docs/api/` に出力）
 - 公開: `.github/workflows/deploy-docs.yml` が `./docs` を Pages artifact としてアップロード
 - ルート `docs/` 配下は**編集しない**（`docs/.gitignore` を除く）
 
@@ -131,7 +131,7 @@ Guide の source は `guide/{en,ja}/` に配置済み。legacy flat パスは #4
 
 - [x] **#455** — 日本語 Guide を `guide/ja/` へ移行・更新
 - [x] **#456** — English Guide を `guide/en/` へ移行・更新
-- [ ] **#457** — TypeDoc `out` を `../../docs/api` に変更。`projectDocuments` は英語 Guide のみ
+- [x] **#457** — TypeDoc `out` を `../../docs/api` に変更。`projectDocuments` は英語 Guide のみ
 - [ ] **#458** — `docs/guide/{ja,en}/` をビルドし、Guide ↔ API Reference の導線を追加
 - [ ] **#151** — `docs/` artifact を Firebase へデプロイ（内部パスは再定義しない）
 

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.md
@@ -112,7 +112,7 @@ Guide source files live under `guide/{en,ja}/`. Legacy flat Guide paths were rem
 | `docs/api/**`, `docs/guide/**` | No (CI-generated artifact) |
 | `docs/.gitignore` | Yes (ignores all generated content) |
 
-- Local generation: `pnpm run docs` (current TypeDoc config until #457).
+- Local generation: `pnpm run docs` (TypeDoc outputs to `docs/api/`).
 - Publishing: `.github/workflows/deploy-docs.yml` uploads `./docs` as the Pages artifact.
 - **Do not edit** files under root `docs/` except `docs/.gitignore`.
 
@@ -131,7 +131,7 @@ Guide source files live under `guide/{en,ja}/`. Legacy flat Guide paths were rem
 
 - [x] **#455** — Move and update Japanese Guide files into `guide/ja/`
 - [x] **#456** — Move and update English Guide files into `guide/en/`
-- [ ] **#457** — Set TypeDoc `out` to `../../docs/api`; limit `projectDocuments` to English Guide only
+- [x] **#457** — Set TypeDoc `out` to `../../docs/api`; limit `projectDocuments` to English Guide only
 - [ ] **#458** — Build `docs/guide/{ja,en}/`, add site index, link Guide ↔ API Reference
 - [ ] **#151** — Deploy `docs/` artifact to Firebase without redefining internal paths
 

--- a/packages/web-serial-rxjs/src/session/serial-session-state.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-state.ts
@@ -45,7 +45,7 @@ export interface ConnectingSessionState {
   readonly status: typeof SerialSessionStatus.Connecting;
 }
 
-/** @see {@link SerialSessionState} */
+/** Connected lifecycle variant with narrowed {@link SerialPortInfo} access via `portInfo`. */
 export interface ConnectedSessionState {
   readonly status: typeof SerialSessionStatus.Connected;
   readonly portInfo: SerialPortInfo;
@@ -73,7 +73,8 @@ export interface DisposedSessionState {
 }
 
 /**
- * Discriminated union emitted by {@link SerialSession.state$}.
+ * Discriminated union emitted by {@link SerialSession.state$} — the
+ * canonical lifecycle source.
  *
  * Each variant carries the lifecycle `status` plus optional detail fields
  * (`portInfo` when connected, `error` when in a fatal error state).

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -107,10 +107,12 @@ export interface SerialSession {
   destroy$(): Observable<void>;
 
   /**
-   * Reactive session lifecycle state as a discriminated union.
+   * Canonical lifecycle source for the session.
    *
-   * Replays the current state on subscribe. Switch on `state.status` and
-   * use the per-variant fields (`portInfo`, `error`) instead of correlating
+   * Reactive session lifecycle state as a discriminated union. Replays the
+   * current state on subscribe. Switch on `state.status` and use the
+   * per-variant fields (`portInfo` when {@link SerialSessionStatus.Connected},
+   * `error` when {@link SerialSessionStatus.Error}) instead of correlating
    * separate streams.
    */
   readonly state$: Observable<SerialSessionState>;
@@ -162,7 +164,7 @@ export interface SerialSession {
   getPortInfo(): SerialPortInfo | null;
 
   /**
-   * Primary error channel.
+   * Canonical fatal / non-fatal error channel.
    *
    * All {@link SerialError} instances produced by the session (connect /
    * read / write / close) are multiplexed here. This is the main channel,

--- a/packages/web-serial-rxjs/typedoc.json
+++ b/packages/web-serial-rxjs/typedoc.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["./src/index.ts"],
-  "out": "../../docs",
+  "out": "../../docs/api",
   "tsconfig": "./tsconfig.lib.json",
   "exclude": [
     "**/*.spec.ts",
@@ -20,7 +20,7 @@
   "name": "web-serial-rxjs API Documentation",
   "includeVersion": false,
   "gitRevision": "main",
-  "projectDocuments": ["./docs/guide/en/**/*.md", "./docs/ARCHITECTURE.md"],
+  "projectDocuments": ["./docs/guide/en/**/*.md"],
   "searchInDocuments": true,
   "sourceLinkExternal": true,
   "markdownLinkExternal": true,


### PR DESCRIPTION
## Summary
TypeDoc API Reference を英語 canonical documentation として統一し、生成先を `docs/api/` に移行した。公開 API の JSDoc は英語のみとし、v3 の `state$` / `errors$` モデルに沿った API Reference を TypeDoc で生成できるようにした。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #457
- Parent: #453

## What changed?
- TypeDoc `out` を `../../docs/api` に変更
- `projectDocuments` を英語 Guide（`guide/en/**/*.md`）のみに限定（`ARCHITECTURE.md` を除外）
- 公開 API JSDoc の `state$` / `errors$` 用語を v3 lifecycle model に整合
- ARCHITECTURE チェックリストで #457 を完了に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs` を実行し、`docs/api/` 配下に TypeDoc 成果物が生成されることを確認
2. `docs/api/modules.html` から `SerialSession`, `createSerialSession`, `SerialError` を参照できることを確認
3. `state$` / `errors$` の説明が Guide（`guide/en/overview.md`）と用語・位置付けが一致していることを確認
4. deprecated API（`isConnected$`, `portInfo$`, `destroy$` 等）に `@deprecated` が表示されることを確認

## Environment (if relevant)
- Browser: N/A（ドキュメント生成のみ）
- OS: macOS
- web-serial-rxjs version (for verification): 3.0.0
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)