### PR TITLE
refactor(web-serial-rxjs): remove deprecated session convenience apis

### DIFF
--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -17,7 +17,6 @@ interface MockCore {
   stateSubject: BehaviorSubject<webSerialRxjs.SerialSessionState>;
   receiveSubject: Subject<string>;
   errorsSubject: Subject<webSerialRxjs.SerialError>;
-  isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
@@ -31,7 +30,6 @@ const createMockCore = (): MockCore => {
   });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<webSerialRxjs.SerialError>();
-  const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
@@ -48,7 +46,8 @@ const createMockCore = (): MockCore => {
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    isConnected$: isConnectedSubject.asObservable(),
+    receiveReplay$: receiveSubject.asObservable(),
+    lines$: receiveSubject.asObservable(),
   };
 
   return {
@@ -56,7 +55,6 @@ const createMockCore = (): MockCore => {
     stateSubject,
     receiveSubject,
     errorsSubject,
-    isConnectedSubject,
     connect$,
     disconnect$,
     dispose$,

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -6,7 +6,7 @@ import type {
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BehaviorSubject, distinctUntilChanged, map, of, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { App } from './App';
 
@@ -30,16 +30,11 @@ const createMockSession = (): MockSession => {
   const receiveSubject = new Subject<string>();
   const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
-  const isConnected$ = stateSubject.pipe(
-    map((s) => s.status === SS.Connected),
-    distinctUntilChanged(),
-  );
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -53,9 +48,6 @@ const createMockSession = (): MockSession => {
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
-    isConnected$,
-    portInfo$: portInfoSubject.asObservable(),
-    getPortInfo: () => portInfoSubject.getValue(),
   };
 
   return {

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -22,7 +22,6 @@ interface MockCore {
   stateSubject: BehaviorSubject<SerialSessionState>;
   receiveSubject: Subject<string>;
   errorsSubject: Subject<SerialError>;
-  isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
@@ -34,7 +33,6 @@ const createMockCore = (supported = true): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
-  const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
@@ -51,7 +49,8 @@ const createMockCore = (supported = true): MockCore => {
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    isConnected$: isConnectedSubject.asObservable(),
+    receiveReplay$: receiveSubject.asObservable(),
+    lines$: receiveSubject.asObservable(),
   };
 
   return {
@@ -59,7 +58,6 @@ const createMockCore = (supported = true): MockCore => {
     stateSubject,
     receiveSubject,
     errorsSubject,
-    isConnectedSubject,
     connect$,
     disconnect$,
     dispose$,

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -21,7 +21,6 @@ interface MockCore {
   stateSubject: BehaviorSubject<SerialSessionState>;
   receiveSubject: Subject<string>;
   errorsSubject: Subject<SerialError>;
-  isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
@@ -33,7 +32,6 @@ const createMockCore = (supported = true): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
-  const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
@@ -50,7 +48,8 @@ const createMockCore = (supported = true): MockCore => {
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    isConnected$: isConnectedSubject.asObservable(),
+    receiveReplay$: receiveSubject.asObservable(),
+    lines$: receiveSubject.asObservable(),
   };
 
   return {
@@ -58,7 +57,6 @@ const createMockCore = (supported = true): MockCore => {
     stateSubject,
     receiveSubject,
     errorsSubject,
-    isConnectedSubject,
     connect$,
     disconnect$,
     dispose$,

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { App } from './app.js';
@@ -7,10 +7,6 @@ const createMockSession = () => {
   const state$ = new BehaviorSubject({ status: 'idle' });
   const receive$ = new Subject();
   const errors$ = new Subject();
-  const isConnected$ = state$.pipe(
-    map((s) => s.status === 'connected'),
-    distinctUntilChanged(),
-  );
   return {
     isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
@@ -21,7 +17,6 @@ const createMockSession = () => {
     receive$,
     terminalText$: receive$,
     errors$,
-    isConnected$,
   };
 };
 

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -1,4 +1,4 @@
-import { BehaviorSubject, Subject, distinctUntilChanged, map, of } from 'rxjs';
+import { BehaviorSubject, Subject, of } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { App } from './app.js';
@@ -13,17 +13,12 @@ interface MockSession {
   receive$: Subject<string>;
   terminalText$: Subject<string>;
   errors$: Subject<{ message: string }>;
-  isConnected$: ReturnType<typeof map>;
 }
 
 const createMockSession = (): MockSession => {
   const state$ = new BehaviorSubject<{ status: string }>({ status: 'idle' });
   const receive$ = new Subject<string>();
   const errors$ = new Subject<{ message: string }>();
-  const isConnected$ = state$.pipe(
-    map((s) => s.status === 'connected'),
-    distinctUntilChanged(),
-  );
   return {
     isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
@@ -34,7 +29,6 @@ const createMockSession = (): MockSession => {
     receive$,
     terminalText$: receive$,
     errors$,
-    isConnected$,
   };
 };
 

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -5,7 +5,7 @@ import type {
 } from '@gurezo/web-serial-rxjs';
 import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { mount } from '@vue/test-utils';
-import { BehaviorSubject, distinctUntilChanged, map, of, Subject } from 'rxjs';
+import { BehaviorSubject, of, Subject } from 'rxjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // @ts-expect-error - Vue SFC file, types are defined in vue-shims.d.ts
 import App from './App.vue';
@@ -30,10 +30,6 @@ const createMockSession = (): MockSession => {
   const receiveSubject = new Subject<string>();
   const linesSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
-  const isConnected$ = stateSubject.pipe(
-    map((s) => s.status === SS.Connected),
-    distinctUntilChanged(),
-  );
   const connect$ = vi.fn(() => {
     stateSubject.next({ status: SS.Connecting });
     stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
@@ -47,7 +43,6 @@ const createMockSession = (): MockSession => {
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
   const isBrowserSupported = vi.fn(() => true);
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const session: SerialSession = {
     isBrowserSupported,
@@ -61,9 +56,6 @@ const createMockSession = (): MockSession => {
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
     receiveReplay$: receiveSubject.asObservable(),
     lines$: linesSubject.asObservable(),
-    isConnected$,
-    portInfo$: portInfoSubject.asObservable(),
-    getPortInfo: () => portInfoSubject.getValue(),
   };
 
   return {

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -21,7 +21,6 @@ interface MockCore {
   stateSubject: BehaviorSubject<SerialSessionState>;
   receiveSubject: Subject<string>;
   errorsSubject: Subject<SerialError>;
-  isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
@@ -33,7 +32,6 @@ const createMockCore = (supported = true): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
-  const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
@@ -50,7 +48,8 @@ const createMockCore = (supported = true): MockCore => {
     errors$: errorsSubject.asObservable(),
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable()).text$,
-    isConnected$: isConnectedSubject.asObservable(),
+    receiveReplay$: receiveSubject.asObservable(),
+    lines$: receiveSubject.asObservable(),
   };
 
   return {
@@ -58,7 +57,6 @@ const createMockCore = (supported = true): MockCore => {
     stateSubject,
     receiveSubject,
     errorsSubject,
-    isConnectedSubject,
     connect$,
     disconnect$,
     dispose$,

--- a/libs/examples-shared/src/create-serial-session-controller.spec.ts
+++ b/libs/examples-shared/src/create-serial-session-controller.spec.ts
@@ -20,7 +20,6 @@ interface MockCore {
   stateSubject: BehaviorSubject<SerialSessionState>;
   receiveSubject: Subject<string>;
   errorsSubject: Subject<SerialError>;
-  isConnectedSubject: BehaviorSubject<boolean>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
@@ -32,7 +31,6 @@ const createMockCore = (supported = true): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
-  const isConnectedSubject = new BehaviorSubject(false);
   const connect$ = vi.fn(() => of(undefined));
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
@@ -50,7 +48,8 @@ const createMockCore = (supported = true): MockCore => {
     receive$: receiveSubject.asObservable(),
     terminalText$: webSerialRxjs.createTerminalBuffer(receiveSubject.asObservable())
       .text$,
-    isConnected$: isConnectedSubject.asObservable(),
+    receiveReplay$: receiveSubject.asObservable(),
+    lines$: receiveSubject.asObservable(),
   };
 
   return {
@@ -58,7 +57,6 @@ const createMockCore = (supported = true): MockCore => {
     stateSubject,
     receiveSubject,
     errorsSubject,
-    isConnectedSubject,
     connect$,
     disconnect$,
     dispose$,

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -13,7 +13,7 @@
  * `state$` (canonical lifecycle discriminated union) + `errors$` (error event
  * channel) + `receive$` + `terminalText$` + `lines$` without rebuilding state,
  * read loops, or write queues. Derive convenience booleans from `state$`
- * narrowing; `isConnected$` is deprecated in v3.x.
+ * narrowing.
  *
  * - {@link createSerialSession} - factory for a {@link SerialSession}
  * - {@link createTerminalBuffer} - terminal-style display text from {@link SerialSession.receive$}

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -1,10 +1,4 @@
-import {
-  BehaviorSubject,
-  distinctUntilChanged,
-  map,
-  Observable,
-  Subject,
-} from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
@@ -86,7 +80,6 @@ export function createSerialSession(
   const errorsSubject = new Subject<SerialError>();
   const sendQueue = createSendQueue();
   const textEncoder = new TextEncoder();
-  const portInfoSubject = new BehaviorSubject<SerialPortInfo | null>(null);
 
   const isDisposed = (): boolean =>
     controller.status === SerialSessionStatus.Disposed;
@@ -110,7 +103,6 @@ export function createSerialSession(
     resolvedOptions,
     sendQueue,
     receivePipeline,
-    portInfoSubject,
     errorsSubject,
     isDisposed,
     reportError: (error, options) =>
@@ -123,7 +115,6 @@ export function createSerialSession(
     errorsSubject,
     sendQueue,
     isDisposed,
-    updatePortInfo: lifecycle.updatePortInfo,
     teardownPump: lifecycle.teardownPump,
     closePortSafely: lifecycle.closePortSafely,
   });
@@ -136,11 +127,6 @@ export function createSerialSession(
     receive$,
     resolvedOptions.terminalBuffer,
   ).text$;
-  const isConnected$ = controller.state$.pipe(
-    map((state) => state.status === SerialSessionStatus.Connected),
-    distinctUntilChanged(),
-  );
-  const portInfo$ = portInfoSubject.asObservable();
 
   return {
     isBrowserSupported(): boolean {
@@ -149,7 +135,6 @@ export function createSerialSession(
     connect$: lifecycle.connect$,
     disconnect$: lifecycle.disconnect$,
     dispose$: lifecycle.dispose$,
-    destroy$: lifecycle.dispose$,
     send$(data: SerialPayload): Observable<void> {
       if (isDisposed()) {
         return new Observable<void>((subscriber) => {
@@ -171,11 +156,6 @@ export function createSerialSession(
       });
     },
     state$: controller.state$,
-    isConnected$,
-    portInfo$,
-    getPortInfo(): SerialPortInfo | null {
-      return portInfoSubject.getValue();
-    },
     errors$,
     receive$,
     terminalText$,

--- a/packages/web-serial-rxjs/src/session/internal/session-error-reporter.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-error-reporter.ts
@@ -25,7 +25,6 @@ export interface SessionErrorReporterDeps {
   errorsSubject: Subject<SerialError>;
   sendQueue: SendQueue;
   isDisposed: () => boolean;
-  updatePortInfo: (port: SerialPort | null) => void;
   teardownPump: (pump: ReadPump | null) => Promise<void>;
   closePortSafely: (port: SerialPort | null) => Promise<void>;
 }
@@ -49,7 +48,6 @@ export function createSessionErrorReporter(deps: SessionErrorReporterDeps): {
     errorsSubject,
     sendQueue,
     isDisposed,
-    updatePortInfo,
     teardownPump,
     closePortSafely,
   } = deps;
@@ -93,7 +91,6 @@ export function createSessionErrorReporter(deps: SessionErrorReporterDeps): {
       const pump = getRuntimePump(runtime);
       controller.transition(createErrorRuntime(serialError));
       sendQueue.clear();
-      updatePortInfo(null);
       void teardownPump(pump).then(() => closePortSafely(portToClose));
     }
     return serialError;

--- a/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
@@ -1,4 +1,4 @@
-import { type BehaviorSubject, Observable, type Subject } from 'rxjs';
+import { Observable, type Subject } from 'rxjs';
 import { SerialError } from '../../errors/serial-error';
 import { SerialErrorCode } from '../../errors/serial-error-code';
 import { buildRequestOptions } from './build-request-options';
@@ -34,7 +34,6 @@ export interface SessionLifecycleDeps {
   resolvedOptions: ResolvedSerialSessionOptions;
   sendQueue: SendQueue;
   receivePipeline: ReceivePipeline;
-  portInfoSubject: BehaviorSubject<SerialPortInfo | null>;
   errorsSubject: Subject<SerialError>;
   isDisposed: () => boolean;
   reportError: (
@@ -57,7 +56,6 @@ export interface SessionLifecycle {
   writeToPort: (payload: Uint8Array) => Promise<void>;
   teardownPump: (pump: ReadPump | null) => Promise<void>;
   closePortSafely: (port: SerialPort | null) => Promise<void>;
-  updatePortInfo: (port: SerialPort | null) => void;
 }
 
 /**
@@ -71,16 +69,11 @@ export function createSessionLifecycle(
     resolvedOptions,
     sendQueue,
     receivePipeline,
-    portInfoSubject,
     errorsSubject,
     isDisposed,
     reportError,
     createDisposedError,
   } = deps;
-
-  const updatePortInfo = (port: SerialPort | null): void => {
-    portInfoSubject.next(port ? port.getInfo() : null);
-  };
 
   const teardownPump = async (pump: ReadPump | null): Promise<void> => {
     receivePipeline.clearReplay();
@@ -121,7 +114,6 @@ export function createSessionLifecycle(
       const pump = getRuntimePump(snapshot);
       await teardownPump(pump);
       await closePortSafely(portToClose);
-      updatePortInfo(null);
     }
 
     receivePipeline.clearLineBuffer();
@@ -131,7 +123,6 @@ export function createSessionLifecycle(
     controller.complete();
     errorsSubject.complete();
     receivePipeline.complete();
-    portInfoSubject.complete();
   };
 
   const dispose$ = (): Observable<void> =>
@@ -299,7 +290,6 @@ export function createSessionLifecycle(
           return;
         }
         controller.transition(createConnectedRuntime(selectedPort, pump));
-        updatePortInfo(selectedPort);
         subscriber.next();
         subscriber.complete();
       };
@@ -365,7 +355,6 @@ export function createSessionLifecycle(
             try {
               await portToClose.close();
             } catch (error) {
-              updatePortInfo(null);
               const serialError = reportError(error, {
                 fallbackCode: SerialErrorCode.CONNECTION_LOST,
                 messagePrefix: 'Failed to close port',
@@ -374,7 +363,6 @@ export function createSessionLifecycle(
               return;
             }
           }
-          updatePortInfo(null);
           if (!isDisposed()) {
             controller.transition(createIdleRuntime());
           }
@@ -399,6 +387,5 @@ export function createSessionLifecycle(
     writeToPort,
     teardownPump,
     closePortSafely,
-    updatePortInfo,
   };
 }

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -95,18 +95,6 @@ export interface SerialSession {
   dispose$(): Observable<void>;
 
   /**
-   * Alias for {@link dispose$}.
-   *
-   * @deprecated Prefer {@link dispose$}. This alias is retained for backward
-   *   compatibility and is scheduled for removal in the next major version.
-   *
-   * @returns An Observable that completes when disposal has finished.
-   *
-   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/433 | Issue #433}
-   */
-  destroy$(): Observable<void>;
-
-  /**
    * Canonical lifecycle source for the session.
    *
    * Reactive session lifecycle state as a discriminated union. Replays the
@@ -116,52 +104,6 @@ export interface SerialSession {
    * separate streams.
    */
   readonly state$: Observable<SerialSessionState>;
-
-  /**
-   * `true` when {@link state$} has `status: 'connected'`, `false` otherwise.
-   *
-   * Derived from `state$` with `distinctUntilChanged` so UIs can bind
-   * connect/disabled flags without reimplementing the comparison.
-   *
-   * @deprecated Prefer narrowing {@link state$} with
-   *   {@link SerialSessionStatus.Connected}. Retained for backward compatibility;
-   *   scheduled for removal in the next major version.
-   *
-   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/435 | Issue #435}
-   */
-  readonly isConnected$: Observable<boolean>;
-
-  /**
-   * The active port’s {@link SerialPort.getInfo} snapshot, or `null` when no
-   * port is open (including {@link SerialSessionStatus.Idle},
-   * {@link SerialSessionStatus.Error}, and {@link SerialSessionStatus.Unsupported}).
-   *
-   * Emits the current value on subscribe. Use with {@link state$} to know when
-   * the value is valid for your UI.
-   *
-   * @deprecated Prefer narrowing {@link state$} with
-   *   {@link SerialSessionStatus.Connected} and using `state.portInfo`.
-   *   Retained for backward compatibility; scheduled for removal in the next
-   *   major version.
-   *
-   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/434 | Issue #434}
-   */
-  readonly portInfo$: Observable<SerialPortInfo | null>;
-
-  /**
-   * Synchronous read of the last {@link portInfo$} value.
-   *
-   * @deprecated Prefer narrowing {@link state$} with
-   *   {@link SerialSessionStatus.Connected} and using `state.portInfo`.
-   *   Retained for backward compatibility; scheduled for removal in the next
-   *   major version.
-   *
-   * @returns The same as {@link SerialPort.getInfo} for the open port, or
-   *   `null` when not connected.
-   *
-   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/434 | Issue #434}
-   */
-  getPortInfo(): SerialPortInfo | null;
 
   /**
    * Canonical fatal / non-fatal error channel.

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -138,16 +138,8 @@ describe('createSerialSession', () => {
       expect(typeof session.connect$).toBe('function');
       expect(typeof session.disconnect$).toBe('function');
       expect(typeof session.dispose$).toBe('function');
-      // destroy$ remains the same function reference as dispose$ during v3.x deprecation.
-      expect(typeof session.destroy$).toBe('function');
-      expect(session.destroy$).toBe(session.dispose$);
       expect(typeof session.send$).toBe('function');
-      expect(typeof session.getPortInfo).toBe('function');
       expect(session.state$).toBeDefined();
-      // isConnected$ remains available during v3.x deprecation.
-      expect(session.isConnected$).toBeDefined();
-      // portInfo$ and getPortInfo remain available during v3.x deprecation.
-      expect(session.portInfo$).toBeDefined();
       expect(session.errors$).toBeDefined();
       expect(session.receive$).toBeDefined();
       expect(session.terminalText$).toBeDefined();
@@ -249,85 +241,6 @@ describe('createSerialSession', () => {
       } else {
         throw new Error('expected error state');
       }
-    });
-  });
-
-  describe('isConnected$', () => {
-    it('replays false on subscribe when state is unsupported', async () => {
-      const session = createSerialSession();
-
-      expect(await firstValueFrom(session.isConnected$)).toBe(false);
-    });
-
-    it('replays false on subscribe when state is idle', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
-      (globalThis as any).navigator = { serial: {} };
-
-      const session = createSerialSession();
-
-      expect(await firstValueFrom(session.isConnected$)).toBe(false);
-    });
-
-    it('is true when connected and false after disconnect$ returns to idle', async () => {
-      const { stream } = makeStream();
-      const port = makeMockPort(stream);
-      installNavigator(port);
-
-      const session = createSerialSession();
-      const connectedBools = lastValueFrom(
-        session.isConnected$.pipe(take(3), toArray()),
-      );
-
-      await firstValueFrom(session.connect$());
-      await firstValueFrom(session.disconnect$());
-
-      expect(await connectedBools).toEqual([false, true, false]);
-    });
-
-    it('is false when state$ is error', async () => {
-      const requestPort = vi
-        .fn()
-        .mockRejectedValue(new DOMException('user cancel', 'NotFoundError'));
-      Object.defineProperty(globalThis, 'navigator', {
-        configurable: true,
-        writable: true,
-        value: { serial: { requestPort, getPorts: vi.fn() } },
-      });
-
-      const session = createSerialSession();
-
-      await expect(firstValueFrom(session.connect$())).rejects.toBeInstanceOf(
-        SerialError,
-      );
-
-      expect(await firstValueFrom(session.isConnected$)).toBe(false);
-    });
-
-    it('keeps isConnected$ in sync with state$ while connected', async () => {
-      const { stream } = makeStream();
-      const port = makeMockPort(stream);
-      installNavigator(port);
-
-      const session = createSerialSession();
-      await firstValueFrom(session.connect$());
-
-      const state = await firstValueFrom(session.state$);
-      expect(state.status).toBe(S.Connected);
-      expect(await firstValueFrom(session.isConnected$)).toBe(true);
-    });
-
-    it('clears isConnected$ together with state$ on disconnect', async () => {
-      const { stream } = makeStream();
-      const port = makeMockPort(stream);
-      installNavigator(port);
-
-      const session = createSerialSession();
-      await firstValueFrom(session.connect$());
-      await firstValueFrom(session.disconnect$());
-
-      const state = await firstValueFrom(session.state$);
-      expect(state.status).toBe(S.Idle);
-      expect(await firstValueFrom(session.isConnected$)).toBe(false);
     });
   });
 
@@ -623,18 +536,8 @@ describe('createSerialSession', () => {
     });
   });
 
-  describe('portInfo$ and getPortInfo', () => {
-    it('replays null before connect', async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
-      (globalThis as any).navigator = { serial: {} };
-
-      const session = createSerialSession();
-
-      expect(session.getPortInfo()).toBeNull();
-      expect(await firstValueFrom(session.portInfo$)).toBeNull();
-    });
-
-    it('keeps state.portInfo in sync with getPortInfo() while connected', async () => {
+  describe('state$.portInfo', () => {
+    it('exposes SerialPort.getInfo on connected state and drops it on disconnect', async () => {
       const { stream } = makeStream();
       const port = makeMockPort(stream);
       installNavigator(port);
@@ -642,77 +545,37 @@ describe('createSerialSession', () => {
       const session = createSerialSession();
       await firstValueFrom(session.connect$());
 
-      const state = await firstValueFrom(session.state$);
-      expect(state.status).toBe(S.Connected);
-      if (state.status === S.Connected) {
-        expect(state.portInfo).toEqual(stubPortInfo);
-        expect(session.getPortInfo()).toEqual(state.portInfo);
+      const connected = await firstValueFrom(session.state$);
+      expect(port.getInfo).toHaveBeenCalled();
+      expect(connected).toEqual(connectedState());
+      if (connected.status === S.Connected) {
+        expect(connected.portInfo).toEqual(stubPortInfo);
       } else {
         throw new Error('expected connected state');
       }
-    });
 
-    it('clears state.portInfo and getPortInfo() together on disconnect', async () => {
-      const { stream } = makeStream();
-      const port = makeMockPort(stream);
-      installNavigator(port);
-
-      const session = createSerialSession();
-      await firstValueFrom(session.connect$());
       await firstValueFrom(session.disconnect$());
 
-      const state = await firstValueFrom(session.state$);
-      expect(state.status).toBe(S.Idle);
-      expect(session.getPortInfo()).toBeNull();
-      expect(await firstValueFrom(session.portInfo$)).toBeNull();
+      const idle = await firstValueFrom(session.state$);
+      expect(idle).toEqual({ status: S.Idle });
+      expect(idle).not.toHaveProperty('portInfo');
     });
 
-    it('exposes SerialPort.getInfo after connect and clears on disconnect', async () => {
-      const { stream } = makeStream();
-      const port = makeMockPort(stream);
-      installNavigator(port);
-
-      const session = createSerialSession();
-      const infoDuringConnect = firstValueFrom(
-        session.portInfo$.pipe(take(2), toArray()),
-      );
-
-      await firstValueFrom(session.connect$());
-
-      expect(port.getInfo).toHaveBeenCalled();
-      expect(session.getPortInfo()).toEqual(stubPortInfo);
-
-      const infos = await infoDuringConnect;
-      expect(infos[0]).toBeNull();
-      expect(infos[1]).toEqual(stubPortInfo);
-
-      const nullAfterDisconnect = firstValueFrom(
-        session.portInfo$.pipe(
-          filter((p): p is null => p === null),
-          take(1),
-        ),
-      );
-      await firstValueFrom(session.disconnect$());
-
-      expect(session.getPortInfo()).toBeNull();
-      expect(await nullAfterDisconnect).toBeNull();
-    });
-
-    it('clears port info when the read pump errors fatally', async () => {
+    it('drops portInfo when the read pump errors fatally', async () => {
       const { stream, controller } = makeStream();
       const port = makeMockPort(stream);
       installNavigator(port);
 
       const session = createSerialSession();
       await firstValueFrom(session.connect$());
-      expect(session.getPortInfo()).toEqual(stubPortInfo);
 
       const errorPromise = firstValueFrom(session.errors$);
       controller.error(new Error('device unplugged'));
       await errorPromise;
 
-      expect(session.getPortInfo()).toBeNull();
-      expect(await firstValueFrom(session.portInfo$)).toBeNull();
+      const state = await firstValueFrom(session.state$);
+      expect(state.status).toBe(S.Error);
+      expect(state).not.toHaveProperty('portInfo');
     });
   });
 
@@ -1550,8 +1413,7 @@ describe('createSerialSession', () => {
     });
   });
 
-  // dispose$ is canonical; destroy$ alias behavior is retained for v3.x backward compatibility.
-  describe('dispose$ and deprecated destroy$ alias', () => {
+  describe('dispose$', () => {
     it('transitions idle -> disposed and completes state$', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
       (globalThis as any).navigator = { serial: {} };
@@ -1579,13 +1441,10 @@ describe('createSerialSession', () => {
       const errors = lastValueFrom(session.errors$.pipe(toArray()));
       const receive = lastValueFrom(session.receive$.pipe(toArray()));
       const lines = lastValueFrom(session.lines$.pipe(toArray()));
-      const portInfo = lastValueFrom(session.portInfo$.pipe(toArray()));
-      const isConnected = lastValueFrom(session.isConnected$.pipe(toArray()));
 
       await firstValueFrom(session.dispose$());
 
       expect(port.close).toHaveBeenCalledTimes(1);
-      expect(session.getPortInfo()).toBeNull();
       await expect(states).resolves.toEqual([
         connectedState(),
         { status: S.Disposed },
@@ -1593,8 +1452,6 @@ describe('createSerialSession', () => {
       await expect(errors).resolves.toEqual([]);
       await expect(receive).resolves.toEqual([]);
       await expect(lines).resolves.toEqual([]);
-      await expect(portInfo).resolves.toEqual([stubPortInfo, null]);
-      await expect(isConnected).resolves.toEqual([true, false]);
     });
 
     it('cancels connect and disposes when called while connecting', async () => {
@@ -1654,13 +1511,11 @@ describe('createSerialSession', () => {
       );
     });
 
-    // destroy$ must stay idempotent via the same implementation as dispose$.
-    it('is idempotent for dispose$ and destroy$', async () => {
+    it('is idempotent', async () => {
       const session = createSerialSession();
 
       await firstValueFrom(session.dispose$());
       await expect(firstValueFrom(session.dispose$())).resolves.toBeUndefined();
-      await expect(firstValueFrom(session.destroy$())).resolves.toBeUndefined();
     });
 
     it('rejects connect$ and send$ after dispose with SESSION_DISPOSED', async () => {


### PR DESCRIPTION
## PR Title (Conventional Commits)
`refactor(web-serial-rxjs): remove deprecated session convenience apis`

## Summary
親 Issue #472 の Sub-issue #473 として、誤認を招く重複公開 API を削除し、セッション状態は `state$`、破棄は `dispose$()` に統一しました。README / 移行ガイド / Example 本文の更新は #478 に委ねます。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [x] Breaking change

## Related issues
- Fixes #473
- Related to #472
- Follow-up docs: #478

## What changed?
- `SerialSession` から `destroy$()` / `isConnected$` / `portInfo$` / `getPortInfo()` を削除
- `createSerialSession` の配線と、専用だった `portInfoSubject` / `updatePortInfo` を削除
- 単体テストを `state$` / `dispose$()` ベースへ置換
- ワークスペース内の `SerialSession` テストモックを型適合

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `SerialSession` から 4 API を削除。接続状態とポート情報は `state$` のみ、破棄は `dispose$()` のみ。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes:
    | 削除 API | 移行先 |
    | --- | --- |
    | `destroy$()` | `dispose$()` |
    | `isConnected$` | `state$.status === SerialSessionStatus.Connected`（または `state$` から derive） |
    | `portInfo$` | Connected 時の `state.portInfo` |
    | `getPortInfo()` | Connected 時の `state.portInfo` |

BREAKING CHANGE: `destroy$()`, `isConnected$`, `portInfo$`, and `getPortInfo()` are removed from `SerialSession`. Use `dispose$()` and `state$` instead.

## How to test
1. `pnpm exec nx run web-serial-rxjs:lint`
2. `pnpm exec nx test web-serial-rxjs`
3. `pnpm exec nx test examples-shared`
4. `pnpm exec nx build web-serial-rxjs`
5. （任意）`pnpm exec nx run-many -t test -p example-react,example-vue,example-svelte,example-angular,example-vanilla-ts,example-vanilla-js`

## Environment (if relevant)
- Browser: N/A（単体テスト / ビルド検証）
- OS: macOS
- web-serial-rxjs version (for verification): branch `refactor/web-serial-rxjs-remove-deprecated-session-apis`
- RxJS version: workspace 依存どおり

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed（#478 で実施予定）
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)