### PR TITLE
test(web-serial-rxjs): confirm getCurrentPort remains removed

### DIFF
--- a/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
@@ -349,7 +349,7 @@ const isConnected = computed(
 
 `SerialSession.getCurrentPort()` was a raw `SerialPort` escape hatch. Calling `port.close()` or `writable.getWriter()` on the returned port could conflict with the session lifecycle and break internal runtime invariants.
 
-A usage audit ([#437](https://github.com/gurezo/web-serial-rxjs/issues/437)) found no production callers in this repository. Device identification is covered by `state.portInfo`, so **`getCurrentPort()` has been removed** from the public API.
+A usage audit ([#437](https://github.com/gurezo/web-serial-rxjs/issues/437)) found no production callers in this repository. Device identification is covered by `state.portInfo`, so **`getCurrentPort()` has been removed** from the public API ([#448](https://github.com/gurezo/web-serial-rxjs/pull/448)). Phase 1 parent issue [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) / child issue [#474](https://github.com/gurezo/web-serial-rxjs/issues/474) also track this removal as a completion criterion.
 
 ### Audit results
 

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
@@ -349,7 +349,7 @@ const isConnected = computed(
 
 `SerialSession.getCurrentPort()` は raw `SerialPort` を返す escape hatch でした。利用者が `port.close()` や `writable.getWriter()` を直接呼び出すと、session が管理する lifecycle と競合し、internal runtime invariant を破壊する可能性がありました。
 
-利用状況監査（[#437](https://github.com/gurezo/web-serial-rxjs/issues/437)）の結果、本リポジトリ内のライブラリ・example コードに `getCurrentPort()` の実利用はなく、デバイス識別は `state.portInfo` で代替可能と判断し、**public API から削除**しました。
+利用状況監査（[#437](https://github.com/gurezo/web-serial-rxjs/issues/437)）の結果、本リポジトリ内のライブラリ・example コードに `getCurrentPort()` の実利用はなく、デバイス識別は `state.portInfo` で代替可能と判断し、**public API から削除**しました（[#448](https://github.com/gurezo/web-serial-rxjs/pull/448)）。Phase 1 の親 Issue [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) / 子 Issue [#474](https://github.com/gurezo/web-serial-rxjs/issues/474) でも、同じ削除方針を完了条件として追跡しています。
 
 ### 監査結果
 

--- a/packages/web-serial-rxjs/tests/session/get-current-port-removal-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/get-current-port-removal-audit.test.ts
@@ -12,13 +12,6 @@ import {
  * (Issues #437 / #474, PR #448).
  * Keep in sync with MIGRATION_V3 §7.
  */
-type AssertFalse<T extends false> = T;
-type HasGetCurrentPort = 'getCurrentPort' extends keyof SerialSession
-  ? true
-  : false;
-
-type _GetCurrentPortRemoved = AssertFalse<HasGetCurrentPort>;
-
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageSrcRoot = join(__dirname, '../../src');
@@ -49,6 +42,14 @@ describe('getCurrentPort removal audit (#474)', () => {
     );
     expect(publicIndexSource).not.toContain('getRuntimePort');
     expect(sessionIndexSource).not.toContain('getRuntimePort');
+  });
+
+  it('excludes getCurrentPort from keyof SerialSession at the type level', () => {
+    type HasGetCurrentPort = 'getCurrentPort' extends keyof SerialSession
+      ? true
+      : false;
+    const removed: HasGetCurrentPort = false;
+    expect(removed).toBe(false);
   });
 
   it('does not expose getCurrentPort on createSerialSession() return value', () => {

--- a/packages/web-serial-rxjs/tests/session/get-current-port-removal-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/get-current-port-removal-audit.test.ts
@@ -1,0 +1,63 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import {
+  createSerialSession,
+  type SerialSession,
+} from '../../src/index';
+
+/**
+ * Regression guard for raw SerialPort escape-hatch removal
+ * (Issues #437 / #474, PR #448).
+ * Keep in sync with MIGRATION_V3 §7.
+ */
+type AssertFalse<T extends false> = T;
+type HasGetCurrentPort = 'getCurrentPort' extends keyof SerialSession
+  ? true
+  : false;
+
+type _GetCurrentPortRemoved = AssertFalse<HasGetCurrentPort>;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageSrcRoot = join(__dirname, '../../src');
+
+const PUBLIC_SURFACE_SOURCES = [
+  'index.ts',
+  'session/serial-session.ts',
+  'session/create-serial-session.ts',
+  'session/index.ts',
+] as const;
+
+describe('getCurrentPort removal audit (#474)', () => {
+  it('keeps getCurrentPort out of the public session surface sources', () => {
+    for (const relativePath of PUBLIC_SURFACE_SOURCES) {
+      const source = readFileSync(join(packageSrcRoot, relativePath), 'utf8');
+      expect(source, relativePath).not.toContain('getCurrentPort');
+    }
+  });
+
+  it('does not export getRuntimePort from the public barrel', () => {
+    const publicIndexSource = readFileSync(
+      join(packageSrcRoot, 'index.ts'),
+      'utf8',
+    );
+    const sessionIndexSource = readFileSync(
+      join(packageSrcRoot, 'session/index.ts'),
+      'utf8',
+    );
+    expect(publicIndexSource).not.toContain('getRuntimePort');
+    expect(sessionIndexSource).not.toContain('getRuntimePort');
+  });
+
+  it('does not expose getCurrentPort on createSerialSession() return value', () => {
+    const session = createSerialSession({ baudRate: 115200 });
+    expect(
+      Object.prototype.hasOwnProperty.call(session, 'getCurrentPort'),
+    ).toBe(false);
+    expect(
+      Object.getOwnPropertyNames(session).includes('getCurrentPort'),
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## PR Title (Conventional Commits)
test(web-serial-rxjs): confirm getCurrentPort remains removed

## Summary
`getCurrentPort()` は PR #448 で既に削除済みです。Issue #474 の完了条件を再監査し、公開 API への回帰を防ぐテストと Phase 1 向けの移行ガイド追記でクローズします。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Parent: #472
- Fixes #474
- Related: #437 / #448

## What changed?
- `getCurrentPort` / `getRuntimePort` が公開 surface に戻らないことを保証する回帰テストを追加
- `keyof SerialSession` と `createSerialSession()` 戻り値から `getCurrentPort` が除外されていることを検証
- 移行ガイド（EN/JA）§7 に Phase 1 の親 #472 / 子 #474 への参照を追記

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: なし（削除済み状態の維持）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `npx nx test web-serial-rxjs` が pass すること
2. `npx nx lint web-serial-rxjs` がエラーなく完了すること
3. `npx nx build web-serial-rxjs` が成功すること
4. `SerialSession` / 公開 barrel に `getCurrentPort` が存在しないこと

## Environment (if relevant)
- 本変更は検証・回帰テスト・ドキュメント追記のため、Chromium 実機確認は不要

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)