### PR TITLE
refactor(web-serial-rxjs): unify session state write source

### DIFF
--- a/packages/web-serial-rxjs/src/session/session-runtime.ts
+++ b/packages/web-serial-rxjs/src/session/session-runtime.ts
@@ -265,8 +265,11 @@ export function createSessionRuntimeController(
       return false;
     }
 
+    // Project before mutating: `runtimeToPublicState` reads `port.getInfo()`,
+    // so a throwing projection must not leave the runtime ahead of `state$`.
+    const publicState = runtimeToPublicState(next);
     runtime = next;
-    subject.next(runtimeToPublicState(next));
+    subject.next(publicState);
     return true;
   };
 

--- a/packages/web-serial-rxjs/tests/session/session-runtime.test.ts
+++ b/packages/web-serial-rxjs/tests/session/session-runtime.test.ts
@@ -395,6 +395,29 @@ describe('session-runtime', () => {
       });
     });
 
+    describe('atomic publication', () => {
+      it('keeps runtime and state$ unchanged when the projection throws', async () => {
+        const controller = createSessionRuntimeController(createIdleRuntime());
+        const failingPort = {
+          getInfo: () => {
+            throw new Error('port revoked');
+          },
+        } as unknown as SerialPort;
+        controller.transition(createConnectingRuntime(() => undefined));
+
+        expect(() =>
+          controller.transition(
+            createConnectedRuntime(failingPort, createMockPump()),
+          ),
+        ).toThrow('port revoked');
+
+        expect(controller.status).toBe(S.Connecting);
+        await expect(firstValueFrom(controller.state$)).resolves.toEqual<
+          SerialSessionState
+        >({ status: S.Connecting });
+      });
+    });
+
     describe('runtime narrowing', () => {
       it('connected runtime always has port and pump', () => {
         const port = createMockPort();

--- a/packages/web-serial-rxjs/tests/session/session-state-write-source-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/session-state-write-source-audit.test.ts
@@ -1,0 +1,109 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { createSerialSession, type SerialSession } from '../../src/index';
+
+/**
+ * Regression guard for the single session state write source
+ * (Issues #472 / #475, PR #479).
+ *
+ * `state$` is the canonical lifecycle source: it is written only by
+ * `SessionRuntimeController.transition` through one `BehaviorSubject`.
+ * Keep in sync with MIGRATION_V3 §5 and §6.
+ */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageSrcRoot = join(__dirname, '../../src');
+const sessionSrcRoot = join(packageSrcRoot, 'session');
+
+/** Duplicate lifecycle state APIs and their backing subjects, removed in #479. */
+const REMOVED_STATE_MIRRORS = [
+  'isConnected$',
+  'portInfo$',
+  'getPortInfo',
+  'isConnectedSubject',
+  'portInfoSubject',
+] as const;
+
+const PUBLIC_SURFACE_SOURCES = [
+  'index.ts',
+  'session/serial-session.ts',
+  'session/create-serial-session.ts',
+  'session/index.ts',
+] as const;
+
+/** The only module allowed to own the writable lifecycle subject. */
+const LIFECYCLE_SUBJECT_OWNER = 'session-runtime.ts';
+
+function listSessionSources(): readonly string[] {
+  return readdirSync(sessionSrcRoot, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith('.ts'))
+    .sort();
+}
+
+function readSessionSource(relativePath: string): string {
+  return readFileSync(join(sessionSrcRoot, relativePath), 'utf8');
+}
+
+describe('session state write source audit (#475)', () => {
+  it('keeps removed state mirrors out of the public session surface sources', () => {
+    for (const relativePath of PUBLIC_SURFACE_SOURCES) {
+      const source = readFileSync(join(packageSrcRoot, relativePath), 'utf8');
+      for (const name of REMOVED_STATE_MIRRORS) {
+        expect(source, `${relativePath} / ${name}`).not.toContain(name);
+      }
+    }
+  });
+
+  it('excludes removed state mirrors from keyof SerialSession', () => {
+    type HasIsConnected = 'isConnected$' extends keyof SerialSession
+      ? true
+      : false;
+    type HasPortInfo = 'portInfo$' extends keyof SerialSession ? true : false;
+    type HasGetPortInfo = 'getPortInfo' extends keyof SerialSession
+      ? true
+      : false;
+
+    const isConnectedRemoved: HasIsConnected = false;
+    const portInfoRemoved: HasPortInfo = false;
+    const getPortInfoRemoved: HasGetPortInfo = false;
+
+    expect([
+      isConnectedRemoved,
+      portInfoRemoved,
+      getPortInfoRemoved,
+    ]).toEqual([false, false, false]);
+  });
+
+  it('does not expose removed state mirrors on createSerialSession() return value', () => {
+    const session = createSerialSession({ baudRate: 115200 });
+    const ownProperties = Object.getOwnPropertyNames(session);
+
+    for (const name of REMOVED_STATE_MIRRORS) {
+      expect(ownProperties, name).not.toContain(name);
+    }
+  });
+
+  it('declares the writable lifecycle subject in exactly one module', () => {
+    const owners = listSessionSources().filter((relativePath) =>
+      readSessionSource(relativePath).includes(
+        'BehaviorSubject<SerialSessionState>',
+      ),
+    );
+
+    expect(owners).toEqual([LIFECYCLE_SUBJECT_OWNER]);
+  });
+
+  it('routes every lifecycle write outside the runtime module through transition()', () => {
+    for (const relativePath of listSessionSources()) {
+      if (relativePath === LIFECYCLE_SUBJECT_OWNER) {
+        continue;
+      }
+      const source = readSessionSource(relativePath);
+
+      expect(source, relativePath).not.toContain('runtimeToPublicState');
+      expect(source, relativePath).not.toContain('stateSubject');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

セッションのライフサイクル状態の書き込み元を `SessionRuntimeController.transition` の 1 箇所に確定させました。遷移中に公開状態が部分更新される経路を塞ぎ、単一情報源であることを回帰テストで固定しています。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #475
- Parent: #472

## What changed?

- `transition()` で公開状態を先に射影してから runtime を更新するよう変更。`runtimeToPublicState` は `port.getInfo()` を呼ぶため、従来は射影が例外を投げると内部 runtime だけが進み `state$` が取り残される窓がありました
- 射影が失敗した場合に runtime と `state$` の双方が変化しないことを検証する単体テストを追加
- `state$` を単一情報源として固定する監査テスト `session-state-write-source-audit.test.ts` を追加（#480 の `getCurrentPort` 監査と同じ方式）
  - 公開サーフェスに `isConnected$` / `portInfo$` / `getPortInfo` / `isConnectedSubject` / `portInfoSubject` が再登場しないこと
  - `keyof SerialSession` および `createSerialSession()` の戻り値から除外されていること
  - 書き込み可能なライフサイクル Subject の宣言が `session-runtime.ts` の 1 モジュールのみであること
  - 他モジュールが `runtimeToPublicState` / `stateSubject` を直接触らず `transition()` を経由すること

### 監査結果（コード変更が不要だった項目）

#479 の時点で以下は既に達成済みであることを確認しました。

| 種別 | 現状 |
| --- | --- |
| 接続状態を保持する Subject / boolean / cache | なし（`isConnectedSessionState` は型 predicate のみ） |
| ポート情報を保持する Subject / cache / getter 用変数 | なし（`Connected.portInfo` と内部 `SessionRuntime.port` のみ） |
| 公開状態の書き込み | `createSessionRuntimeController().transition` のみ |
| 非接続状態でのポート情報 | `Idle` / `Disconnecting` / `Error` / `Disposed` は `portInfo` を持たない |

`receive$` / `lines$` / `errors$` の Subject はデータ・イベント経路であり、ライフサイクル状態ではないため対象外です。

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details: 公開 API の追加・削除はありません（該当 API の削除は #479 で完了済み）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. `npx nx run web-serial-rxjs:test` — 291 tests passed
2. `npx nx run web-serial-rxjs:lint`
3. `npx nx run web-serial-rxjs:build`
4. 回帰ガードの有効性確認: `session-runtime.ts` の射影と runtime 更新の順序を元に戻すと `atomic publication` のテストが失敗すること

## Environment (if relevant)

- Browser: Chrome / Edge / Opera / etc. (version: N/A — 単体テストのみ)
- OS: macOS
- web-serial-rxjs version (for verification): 3.1.1
- RxJS version: ^7.8.0

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed（ドキュメント更新は #478 で対応）
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)