### PR TITLE
refactor(web-serial-rxjs): remove errorReporterRef late assignment

### DIFF
--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -4,10 +4,10 @@ import { SerialErrorCode } from '../errors/serial-error-code';
 import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
 import type { SerialPayload } from '../types';
 import { hasWebSerialSupport } from './internal/has-web-serial-support';
+import { createPortTeardown } from './internal/port-teardown';
 import { createReceivePipeline } from './internal/receive-pipeline';
 import { createSessionErrorReporter } from './internal/session-error-reporter';
 import { createSessionLifecycle } from './internal/session-lifecycle';
-import { normalizeSerialError } from './normalize-serial-error';
 import { createSendQueue } from './send-queue';
 import type { SerialSession } from './serial-session';
 import {
@@ -84,19 +84,26 @@ export function createSerialSession(
   const isDisposed = (): boolean =>
     controller.status === SerialSessionStatus.Disposed;
 
-  const errorReporterRef: {
-    reportError?: (
-      error: unknown,
-      options: Parameters<typeof normalizeSerialError>[1],
-    ) => SerialError;
-    createDisposedError?: () => SerialError;
-  } = {};
+  const receivePipeline = createReceivePipeline({ resolvedOptions });
 
-  const receivePipeline = createReceivePipeline({
-    resolvedOptions,
-    reportError: (error, options) =>
-      errorReporterRef.reportError!(error, options),
+  const { teardownPump, closePortSafely } = createPortTeardown({
+    receivePipeline,
   });
+
+  const { reportError, createDisposedError } = createSessionErrorReporter({
+    controller,
+    errorsSubject,
+    sendQueue,
+    isDisposed,
+    teardownPump,
+    closePortSafely,
+  });
+
+  // Route receive-side buffer overflows through the single reportError entry
+  // point. The subscription completes when the pipeline completes on dispose.
+  receivePipeline.bufferErrors$.subscribe((error) =>
+    reportError(error, { fallbackCode: error.code }),
+  );
 
   const lifecycle = createSessionLifecycle({
     controller,
@@ -105,21 +112,11 @@ export function createSerialSession(
     receivePipeline,
     errorsSubject,
     isDisposed,
-    reportError: (error, options) =>
-      errorReporterRef.reportError!(error, options),
-    createDisposedError: () => errorReporterRef.createDisposedError!(),
+    teardownPump,
+    closePortSafely,
+    reportError,
+    createDisposedError,
   });
-
-  const { reportError, createDisposedError } = createSessionErrorReporter({
-    controller,
-    errorsSubject,
-    sendQueue,
-    isDisposed,
-    teardownPump: lifecycle.teardownPump,
-    closePortSafely: lifecycle.closePortSafely,
-  });
-  errorReporterRef.reportError = reportError;
-  errorReporterRef.createDisposedError = createDisposedError;
 
   const { receive$, lines$, receiveReplay$ } = receivePipeline;
   const errors$ = errorsSubject.asObservable();

--- a/packages/web-serial-rxjs/src/session/internal/port-teardown.ts
+++ b/packages/web-serial-rxjs/src/session/internal/port-teardown.ts
@@ -1,0 +1,57 @@
+import type { ReadPump } from '../read-pump';
+import type { ReceivePipeline } from './receive-pipeline';
+
+/**
+ * Dependencies for {@link createPortTeardown}.
+ *
+ * @internal
+ */
+export interface PortTeardownDeps {
+  receivePipeline: ReceivePipeline;
+}
+
+/**
+ * Port and pump teardown primitives for {@link createSerialSession}.
+ *
+ * These are extracted from the session lifecycle so that both the lifecycle
+ * and the error reporter can depend on them without forming a construction
+ * cycle: the error reporter needs `teardownPump` / `closePortSafely` for fatal
+ * cleanup, while the lifecycle needs the error reporter for `reportError`.
+ *
+ * @internal
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/476 | Issue #476}
+ */
+export interface PortTeardown {
+  teardownPump: (pump: ReadPump | null) => Promise<void>;
+  closePortSafely: (port: SerialPort | null) => Promise<void>;
+}
+
+/**
+ * @internal
+ */
+export function createPortTeardown(deps: PortTeardownDeps): PortTeardown {
+  const { receivePipeline } = deps;
+
+  const teardownPump = async (pump: ReadPump | null): Promise<void> => {
+    receivePipeline.clearReplay();
+    receivePipeline.clearLineBuffer();
+    if (pump) {
+      await pump.stop();
+    }
+  };
+
+  const closePortSafely = async (port: SerialPort | null): Promise<void> => {
+    if (!port) {
+      return;
+    }
+    try {
+      await port.close();
+    } catch {
+      // The read pump may already have errored the stream, which makes
+      // close() reject. We ignore it here because disconnect$ has a
+      // dedicated error path for close failures initiated by the user.
+    }
+  };
+
+  return { teardownPump, closePortSafely };
+}

--- a/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
+++ b/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
@@ -12,7 +12,6 @@ import {
   createReceiveReplayBuffer,
   type ReceiveReplayBuffer,
 } from './receive-replay-buffer';
-import type { NormalizeSerialErrorOptions } from '../normalize-serial-error';
 import type { ResolvedSerialSessionOptions } from '../serial-session-options';
 
 /**
@@ -22,10 +21,6 @@ import type { ResolvedSerialSessionOptions } from '../serial-session-options';
  */
 export interface ReceivePipelineDeps {
   resolvedOptions: ResolvedSerialSessionOptions;
-  reportError: (
-    error: unknown,
-    options: NormalizeSerialErrorOptions,
-  ) => SerialError;
 }
 
 /**
@@ -38,6 +33,14 @@ export interface ReceivePipeline {
   receive$: Observable<string>;
   lines$: Observable<string>;
   receiveReplay$: Observable<string>;
+  /**
+   * Buffer-overflow errors produced while decoding chunks. The factory pipes
+   * these into the session's single `reportError` entry point so the receive
+   * pipeline stays decoupled from error reporting and initialization order.
+   *
+   * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/476 | Issue #476}
+   */
+  bufferErrors$: Observable<SerialError>;
   clearReplay: () => void;
   startLiveReceiveReplay: () => void;
   clearLineBuffer: () => void;
@@ -51,14 +54,16 @@ export interface ReceivePipeline {
 export function createReceivePipeline(
   deps: ReceivePipelineDeps,
 ): ReceivePipeline {
-  const { resolvedOptions, reportError } = deps;
+  const { resolvedOptions } = deps;
 
   const receiveSubject = new Subject<string>();
   const linesSubject = new Subject<string>();
+  const bufferErrorsSubject = new Subject<SerialError>();
   const lineBuffer: LineBuffer = createLineBuffer(resolvedOptions.lineBuffer);
 
   const receive$ = receiveSubject.asObservable();
   const lines$ = linesSubject.asObservable();
+  const bufferErrors$ = bufferErrorsSubject.asObservable();
 
   const receiveReplayStream$ = resolvedOptions.receiveReplay.enabled
     ? new BehaviorSubject<Observable<string>>(receive$)
@@ -104,7 +109,7 @@ export function createReceivePipeline(
     if (activeReceiveReplay) {
       const { overflowed } = activeReceiveReplay.next(text);
       if (overflowed) {
-        reportError(
+        bufferErrorsSubject.next(
           new SerialError(
             SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
             'Receive replay buffer exceeded configured limits; oldest chunks were discarded',
@@ -114,22 +119,18 @@ export function createReceivePipeline(
               bufferSize: resolvedOptions.receiveReplay.bufferSize,
             },
           ),
-          {
-            fallbackCode: SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
-          },
         );
       }
     }
     const { lines, overflowed } = lineBuffer.feed(text);
     if (overflowed) {
-      reportError(
+      bufferErrorsSubject.next(
         new SerialError(
           SerialErrorCode.LINE_BUFFER_OVERFLOW,
           'Line buffer exceeded maxChars; leading data was discarded',
           undefined,
           { maxChars: resolvedOptions.lineBuffer.maxChars },
         ),
-        { fallbackCode: SerialErrorCode.LINE_BUFFER_OVERFLOW },
       );
     }
     for (const line of lines) {
@@ -140,6 +141,7 @@ export function createReceivePipeline(
   const complete = (): void => {
     receiveSubject.complete();
     linesSubject.complete();
+    bufferErrorsSubject.complete();
     receiveReplayStream$?.complete();
   };
 
@@ -147,6 +149,7 @@ export function createReceivePipeline(
     receive$,
     lines$,
     receiveReplay$,
+    bufferErrors$,
     clearReplay,
     startLiveReceiveReplay,
     clearLineBuffer,

--- a/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
+++ b/packages/web-serial-rxjs/src/session/internal/receive-pipeline.ts
@@ -35,7 +35,7 @@ export interface ReceivePipeline {
   receiveReplay$: Observable<string>;
   /**
    * Buffer-overflow errors produced while decoding chunks. The factory pipes
-   * these into the session's single `reportError` entry point so the receive
+   * these into the session's single error-reporting entry point so the receive
    * pipeline stays decoupled from error reporting and initialization order.
    *
    * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/476 | Issue #476}

--- a/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
@@ -36,6 +36,8 @@ export interface SessionLifecycleDeps {
   receivePipeline: ReceivePipeline;
   errorsSubject: Subject<SerialError>;
   isDisposed: () => boolean;
+  teardownPump: (pump: ReadPump | null) => Promise<void>;
+  closePortSafely: (port: SerialPort | null) => Promise<void>;
   reportError: (
     error: unknown,
     options: NormalizeSerialErrorOptions,
@@ -54,8 +56,6 @@ export interface SessionLifecycle {
   disconnect$: () => Observable<void>;
   dispose$: () => Observable<void>;
   writeToPort: (payload: Uint8Array) => Promise<void>;
-  teardownPump: (pump: ReadPump | null) => Promise<void>;
-  closePortSafely: (port: SerialPort | null) => Promise<void>;
 }
 
 /**
@@ -71,30 +71,11 @@ export function createSessionLifecycle(
     receivePipeline,
     errorsSubject,
     isDisposed,
+    teardownPump,
+    closePortSafely,
     reportError,
     createDisposedError,
   } = deps;
-
-  const teardownPump = async (pump: ReadPump | null): Promise<void> => {
-    receivePipeline.clearReplay();
-    receivePipeline.clearLineBuffer();
-    if (pump) {
-      await pump.stop();
-    }
-  };
-
-  const closePortSafely = async (port: SerialPort | null): Promise<void> => {
-    if (!port) {
-      return;
-    }
-    try {
-      await port.close();
-    } catch {
-      // The read pump may already have errored the stream, which makes
-      // close() reject. We ignore it here because disconnect$ has a
-      // dedicated error path for close failures initiated by the user.
-    }
-  };
 
   const teardownFromSnapshot = async (
     snapshot: SessionRuntime,
@@ -385,7 +366,5 @@ export function createSessionLifecycle(
     disconnect$,
     dispose$,
     writeToPort,
-    teardownPump,
-    closePortSafely,
   };
 }

--- a/packages/web-serial-rxjs/tests/session/error-reporter-ref-removal-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/error-reporter-ref-removal-audit.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression guard for removing the late-assigned error reporter reference
+ * (Issues #472 / #476).
+ *
+ * The factory must wire every dependency in a single forward direction, so
+ * there is no mutable `errorReporterRef` placeholder and no non-null
+ * assertions that assume initialization order. Keep in sync with the receive
+ * pipeline decoupling (`bufferErrors$`) and `port-teardown.ts`.
+ */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const sessionSrcRoot = join(__dirname, '../../src/session');
+
+function readSessionSource(relativePath: string): string {
+  return readFileSync(join(sessionSrcRoot, relativePath), 'utf8');
+}
+
+describe('errorReporterRef removal audit (#476)', () => {
+  it('does not reintroduce the late-assigned error reporter reference', () => {
+    const source = readSessionSource('create-serial-session.ts');
+
+    expect(source).not.toContain('errorReporterRef');
+  });
+
+  it('does not assume initialization order via non-null assertions', () => {
+    const source = readSessionSource('create-serial-session.ts');
+
+    expect(source).not.toContain('reportError!');
+    expect(source).not.toContain('createDisposedError!');
+  });
+
+  it('keeps the receive pipeline decoupled from reportError', () => {
+    const source = readSessionSource('internal/receive-pipeline.ts');
+
+    expect(source).not.toContain('reportError');
+    expect(source).toContain('bufferErrors$');
+  });
+});

--- a/packages/web-serial-rxjs/tests/session/port-teardown.test.ts
+++ b/packages/web-serial-rxjs/tests/session/port-teardown.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPortTeardown } from '../../src/session/internal/port-teardown';
+import type { ReadPump } from '../../src/session/read-pump';
+import type { ReceivePipeline } from '../../src/session/internal/receive-pipeline';
+
+function createReceivePipelineStub(
+  calls: string[],
+): Pick<ReceivePipeline, 'clearReplay' | 'clearLineBuffer'> {
+  return {
+    clearReplay: vi.fn(() => {
+      calls.push('clearReplay');
+    }),
+    clearLineBuffer: vi.fn(() => {
+      calls.push('clearLineBuffer');
+    }),
+  };
+}
+
+function createPumpStub(calls: string[], stopError?: unknown): ReadPump {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(async () => {
+      calls.push('stop');
+      if (stopError) {
+        throw stopError;
+      }
+    }),
+    get isRunning(): boolean {
+      return false;
+    },
+  };
+}
+
+describe('createPortTeardown (#476)', () => {
+  it('clears the receive buffers before stopping the pump', async () => {
+    const calls: string[] = [];
+    const receivePipeline = createReceivePipelineStub(calls);
+    const { teardownPump } = createPortTeardown({
+      receivePipeline: receivePipeline as ReceivePipeline,
+    });
+    const pump = createPumpStub(calls);
+
+    await teardownPump(pump);
+
+    expect(calls).toEqual(['clearReplay', 'clearLineBuffer', 'stop']);
+  });
+
+  it('still clears the receive buffers when no pump is active', async () => {
+    const calls: string[] = [];
+    const receivePipeline = createReceivePipelineStub(calls);
+    const { teardownPump } = createPortTeardown({
+      receivePipeline: receivePipeline as ReceivePipeline,
+    });
+
+    await teardownPump(null);
+
+    expect(calls).toEqual(['clearReplay', 'clearLineBuffer']);
+  });
+
+  it('resolves when the port closes successfully', async () => {
+    const receivePipeline = createReceivePipelineStub([]);
+    const { closePortSafely } = createPortTeardown({
+      receivePipeline: receivePipeline as ReceivePipeline,
+    });
+    const close = vi.fn(async () => undefined);
+    const port = { close } as unknown as SerialPort;
+
+    await expect(closePortSafely(port)).resolves.toBeUndefined();
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('swallows rejections from port.close()', async () => {
+    const receivePipeline = createReceivePipelineStub([]);
+    const { closePortSafely } = createPortTeardown({
+      receivePipeline: receivePipeline as ReceivePipeline,
+    });
+    const port = {
+      close: vi.fn(async () => {
+        throw new Error('already errored');
+      }),
+    } as unknown as SerialPort;
+
+    await expect(closePortSafely(port)).resolves.toBeUndefined();
+  });
+
+  it('is a no-op when the port is null', async () => {
+    const receivePipeline = createReceivePipelineStub([]);
+    const { closePortSafely } = createPortTeardown({
+      receivePipeline: receivePipeline as ReceivePipeline,
+    });
+
+    await expect(closePortSafely(null)).resolves.toBeUndefined();
+  });
+});

--- a/packages/web-serial-rxjs/tests/session/receive-pipeline.test.ts
+++ b/packages/web-serial-rxjs/tests/session/receive-pipeline.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { createReceivePipeline } from '../../src/session/internal/receive-pipeline';
+import { resolveSerialSessionOptions } from '../../src/session/serial-session-options';
+
+describe('createReceivePipeline bufferErrors$ (#476)', () => {
+  it('emits replay overflow before line overflow within one chunk', () => {
+    const pipeline = createReceivePipeline({
+      resolvedOptions: resolveSerialSessionOptions({
+        receiveReplay: { enabled: true, bufferSize: 1, maxChars: 0 },
+        lineBuffer: { maxChars: 3 },
+      }),
+    });
+
+    const codes: SerialErrorCode[] = [];
+    pipeline.bufferErrors$.subscribe((error) => codes.push(error.code));
+
+    pipeline.startLiveReceiveReplay();
+    // First chunk stays within both limits; the second chunk trips the replay
+    // buffer (bufferSize 1) and the line tail (maxChars 3) in one handleChunk.
+    pipeline.handleChunk('aa');
+    pipeline.handleChunk('bb');
+
+    expect(codes).toEqual([
+      SerialErrorCode.RECEIVE_REPLAY_BUFFER_OVERFLOW,
+      SerialErrorCode.LINE_BUFFER_OVERFLOW,
+    ]);
+  });
+
+  it('completes bufferErrors$ when the pipeline completes', () => {
+    const pipeline = createReceivePipeline({
+      resolvedOptions: resolveSerialSessionOptions(),
+    });
+
+    let completed = false;
+    pipeline.bufferErrors$.subscribe({
+      complete: () => {
+        completed = true;
+      },
+    });
+
+    pipeline.complete();
+
+    expect(completed).toBe(true);
+  });
+});


### PR DESCRIPTION
## PR Title (Conventional Commits)

`refactor(web-serial-rxjs): remove errorReporterRef late assignment`

## Summary

`createSerialSession()` の組み立てにあった `errorReporterRef` への後代入と、初期化順を前提とした non-null assertion を解消しました。依存を一方向に組み立て直し、factory 生成時点で全必須依存が確定するようにしています。公開エラー通知仕様（`errors$` の内容・エラー型・エラーコード）は変更していません。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #476
- Parent: #472

## What changed?

- `session-lifecycle.ts` にあった `teardownPump` / `closePortSafely` を新規 `internal/port-teardown.ts` (`createPortTeardown`) に切り出し、lifecycle は deps 経由で受け取るようにした
- `receive-pipeline.ts` から `reportError` 依存を削除し、buffer overflow を内部 `Subject`（`bufferErrors$`）へ emit するように変更。factory が `reportError` 確定後に subscribe する
- `create-serial-session.ts` の `errorReporterRef` と 3 箇所の non-null assertion (`reportError!` / `createDisposedError!`) を削除し、`receivePipeline → createPortTeardown → createSessionErrorReporter → bufferErrors$ 接続 → createSessionLifecycle` の一方向で組み立て
- 監査テスト・`port-teardown` unit テスト・`receive-pipeline` の `bufferErrors$` テストを追加

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
- [x] This change is backward compatible
- [ ] This change introduces a breaking change

公開 API・`errors$` の挙動に変更はありません。変更はすべて `internal` の配線と private な初期化順に閉じています。

## How to test

1. `npx nx run web-serial-rxjs:lint`
2. `npx nx run web-serial-rxjs:test`
3. `npx nx run web-serial-rxjs:build`

いずれも成功すること。特に `tests/session/create-serial-session.test.ts` の `errors$` 統合テスト（overflow・fatal cleanup・同一エラーインスタンス）と、追加した `error-reporter-ref-removal-audit` / `port-teardown` / `receive-pipeline` テストが green であることを確認。

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)