### PR TITLE
docs(web-serial-rxjs): update docs for phase 1 removed apis

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -23,7 +23,7 @@ Web Serial API を最小限の Session 指向 RxJS API でラップする TypeSc
 
 ## 機能
 
-- **Session 指向のリアクティブ API**: 1 つの `SerialSession` が `state$`（canonical lifecycle discriminated union）/ `errors$`（error event channel）/ `receive$` / `lines$` と convenience stream の `isConnected$`、`connect$` / `disconnect$` / `send$` を公開
+- **Session 指向のリアクティブ API**: 1 つの `SerialSession` が `state$`（canonical lifecycle discriminated union）/ `errors$`（error event channel）/ `receive$` / `lines$` と `connect$` / `disconnect$` / `dispose$` / `send$` を公開
 - **UTF-8 テキストストリーム**: `receive$` は内部でストリーミング `TextDecoder` を用いてデコード済み。マルチバイト文字がチャンクにまたがっても正しく結合されます
 - **順序保証された送信キュー**: 並行する `send$` 呼び出しも内部キューで FIFO 処理され、呼び出し順に書き込まれます
 - **統一エラーチャネル**: すべての I/O エラーは `SerialError` に正規化され `errors$` に多重化されます

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A TypeScript library that wraps the Web Serial API with a minimal, session-orien
 
 ## Features
 
-- **Session-oriented reactive API**: a single `SerialSession` exposes `state$` (canonical lifecycle discriminated union), `errors$` (error event channel), `receive$`, `lines$`, plus convenience streams such as `isConnected$`, and `connect$`, `disconnect$`, and `send$`
+- **Session-oriented reactive API**: a single `SerialSession` exposes `state$` (canonical lifecycle discriminated union), `errors$` (error event channel), `receive$`, `lines$`, and `connect$`, `disconnect$`, `dispose$`, and `send$`
 - **UTF-8 text stream**: `receive$` is already decoded with a streaming `TextDecoder`, so multi-byte characters split across chunks are joined correctly
 - **Ordered send queue**: concurrent `send$` calls are serialised internally in call order, without the caller having to manage a writer
 - **Unified error channel**: every I/O error is normalised into `SerialError` and multiplexed on `errors$`

--- a/apps/example-react/README.md
+++ b/apps/example-react/README.md
@@ -1,6 +1,6 @@
 # React Example
 
-This is a minimal React example for the v2 `SerialSession` API (Web Serial). The `useSerialSession` hook maps `state$` / `errors$` into React state and binds **`receivedData`** to `session.terminalText$` so `\r` redraws (e.g. `ls -la`) stay aligned. Use **`lines$`** only for newline-delimited logs or parsers, not as the primary terminal view.
+This is a minimal React example for the `SerialSession` API (Web Serial). The `useSerialSession` hook maps `state$` / `errors$` into React state and binds **`receivedData`** to `session.terminalText$` so `\r` redraws (e.g. `ls -la`) stay aligned. Use **`lines$`** only for newline-delimited logs or parsers, not as the primary terminal view.
 
 **Using the library**: See the repository [Quick Start](../../packages/web-serial-rxjs/docs/guide/en/quick-start.md) ([日本語](../../packages/web-serial-rxjs/docs/guide/ja/quick-start.md)) and [SerialSession overview](../../packages/web-serial-rxjs/docs/guide/en/overview.md) ([日本語](../../packages/web-serial-rxjs/docs/guide/ja/overview.md)).
 

--- a/apps/example-svelte/README.md
+++ b/apps/example-svelte/README.md
@@ -1,6 +1,6 @@
 # Svelte Example
 
-This is a minimal Svelte example for the v2 `SerialSession` API. `useSerialSession` wraps `state$` / `errors$` into stores, derives `isConnected` from `state.status`, and binds **`receivedData`** to `session.terminalText$` for `\r`-safe terminal display.
+This is a minimal Svelte example for the `SerialSession` API. `useSerialSession` wraps `state$` / `errors$` into stores, derives `isConnected` from `state.status`, and binds **`receivedData`** to `session.terminalText$` for `\r`-safe terminal display.
 
 **Using the library**: See the repository [Quick Start](../../packages/web-serial-rxjs/docs/guide/en/quick-start.md) ([日本語](../../packages/web-serial-rxjs/docs/guide/ja/quick-start.md)) and [SerialSession overview](../../packages/web-serial-rxjs/docs/guide/en/overview.md) ([日本語](../../packages/web-serial-rxjs/docs/guide/ja/overview.md)).
 

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -23,11 +23,11 @@ Web Serial API は**デスクトップ**ブラウザでのみサポートされ�
 
 ## 接続状態（ライフサイクル UI）
 
-ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。`isConnected$` は v3.x では引き続き利用可能ですが **非推奨** です。詳細は [v3 移行ガイド](./docs/guide/ja/migration-v3.md#6-isconnected-の非推奨化) を参照してください。
+ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。セッション破棄には **`dispose$()`** を使用します（購読により実行されます）。詳細は [v3 移行ガイド – Phase 1 API 削除](./docs/guide/ja/migration-v3.md#phase-1-api-削除) を参照してください。
 
 ## 接続中のポート情報（デバイス識別）
 
-`connect$` 成功後、`state$` を `state.status === SerialSessionStatus.Connected` で handling する場合は **`state.portInfo`** を canonical API として使用してください。`getPortInfo()` と `portInfo$` は v3.x では引き続き利用可能ですが **非推奨** です。`state$` の narrowing へ移行してください。`getCurrentPort()` は削除されました。詳細は [v3 移行ガイド](./docs/guide/ja/migration-v3.md#7-getcurrentport-の削除) を参照してください。
+`connect$` 成功後、`state$` を `state.status === SerialSessionStatus.Connected` で handling する場合は **`state.portInfo`** を canonical API として使用してください。生の `SerialPort` は公開しません。削除された convenience API（`isConnected$`、`portInfo$`、`getPortInfo()`、`destroy$()`、`getCurrentPort()`）と置換先は [v3 移行ガイド](./docs/guide/ja/migration-v3.md#phase-1-api-削除) を参照してください。
 
 ## 受信の replay（`receive$` と `receiveReplay$`）
 

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -23,11 +23,11 @@ Supported desktop browsers:
 
 ## Connection state (lifecycle UI)
 
-Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. `isConnected$` remains available in v3.x but is **deprecated** — see [Migrating to v3](./docs/guide/en/migration-v3.md#6-isconnected-deprecation).
+Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. Session teardown uses **`dispose$()`** (subscribe to run it). See [Migrating to v3 – Phase 1 removals](./docs/guide/en/migration-v3.md#phase-1-api-removals).
 
 ## Port info (device identification)
 
-After a successful `connect$`, use `state.portInfo` when handling `state$` with `state.status === SerialSessionStatus.Connected` — this is the canonical API. `getPortInfo()` and `portInfo$` remain available in v3.x but are **deprecated**; migrate to `state$` narrowing. `getCurrentPort()` has been removed; see [Migrating to v3 – getCurrentPort() removal](./docs/guide/en/migration-v3.md#7-getcurrentport-removal).
+After a successful `connect$`, use `state.portInfo` when handling `state$` with `state.status === SerialSessionStatus.Connected` — this is the canonical API. Raw `SerialPort` is not exposed. Removed convenience APIs (`isConnected$`, `portInfo$`, `getPortInfo()`, `destroy$()`, `getCurrentPort()`) and their replacements are documented in [Migrating to v3](./docs/guide/en/migration-v3.md#phase-1-api-removals).
 
 ## Receive replay (`receive$` vs `receiveReplay$`)
 

--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -40,4 +40,4 @@ When migrating existing code:
 
 - **`state$`** — canonical lifecycle source. Branch on `state.status` with `SerialSessionStatus`; use `state.portInfo` when connected
 - **`errors$`** — canonical fatal / non-fatal error event channel. Branch with `SerialError.is(SerialErrorCode.*)`
-- **Deprecated convenience** — `isConnected$`, `portInfo$`, `getPortInfo()` remain in v3.x; prefer `state$` narrowing in new code
+- **`dispose$()`** — sole session teardown API (subscribe to run it). Removed convenience APIs (`destroy$`, `isConnected$`, `portInfo$`, `getPortInfo()`, `getCurrentPort()`) are documented in [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals)

--- a/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md
+++ b/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md
@@ -2,7 +2,7 @@
 
 `SerialSession` intentionally exposes a small surface. Most "advanced" workflows are expressed by composing plain RxJS operators over `receive$` and `send$`. If you are new to the API, read [SerialSession overview](./overview.md#serialsession-at-a-glance) and [Quick Start](./quick-start.md) first; this page focuses on **recipes** (line framing, derived streams, and recovery) that the overview defers on purpose. For lifecycle and error patterns, prefer `state$` with `state.status` narrowing and `errors$` with `error.is()` — see [Migrating to v3](./migration-v3.md).
 
-This page maps directly to [issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228): built-in **`lines$`** and the imperative methods cover common cases. **`isConnected$`** is deprecated in v3.x — prefer `state$` narrowing. Patterns such as **`sendLine`**, **`readUntil`**, and **`waitForState`** are still things you build on the core API (no extra exports for those). For a real-world serial-console style app, see [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) (Web Serial over USB OTG); the same recipes apply when you reimplement its read/write loop with `SerialSession`.
+This page maps directly to [issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228): built-in **`lines$`** and the imperative methods cover common cases. Prefer **`state$`** narrowing for connection UI. Patterns such as **`sendLine`**, **`readUntil`**, and **`waitForState`** are still things you build on the core API (no extra exports for those). For a real-world serial-console style app, see [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) (Web Serial over USB OTG); the same recipes apply when you reimplement its read/write loop with `SerialSession`.
 
 ## Line Framing (built-in `lines$` vs custom framing on `receive$`)
 
@@ -57,7 +57,7 @@ isConnected$.subscribe((isOpen) => {
 });
 ```
 
-**`isConnected$`** is deprecated in v3.x. For full lifecycle UI, prefer driving from `state$` directly (see [State-driven UI](#state-driven-ui) below).
+The local `isConnected$` above is **derived from `state$`** — it is not a `SerialSession` member. For full lifecycle UI, prefer driving from `state$` directly (see [State-driven UI](#state-driven-ui) below).
 
 When you need connected-only fields such as `portInfo` inside an RxJS pipeline, use `isConnectedSessionState` with `filter()` — inline status comparisons do not narrow types in TypeScript:
 

--- a/packages/web-serial-rxjs/docs/guide/en/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/en/concepts.md
@@ -200,22 +200,13 @@ interface SerialSession {
   connect$(): Observable<void>;
   disconnect$(): Observable<void>;
   dispose$(): Observable<void>;
-  /** @deprecated Use {@link dispose$}. Scheduled for removal in the next major version. */
-  destroy$(): Observable<void>;
 
   readonly state$: Observable<SerialSessionState>;
-  /** @deprecated Prefer {@link state$} narrowing with {@link SerialSessionStatus.Connected}. Scheduled for removal in the next major version. */
-  readonly isConnected$: Observable<boolean>;
-  /** @deprecated Prefer {@link state$} narrowing with {@link SerialSessionStatus.Connected} and `state.portInfo`. Scheduled for removal in the next major version. */
-  readonly portInfo$: Observable<SerialPortInfo | null>;
   readonly errors$: Observable<SerialError>;
   readonly receive$: Observable<string>;
   readonly receiveReplay$: Observable<string>;
   readonly terminalText$: Observable<string>;
   readonly lines$: Observable<string>;
-
-  /** @deprecated Prefer {@link state$} narrowing with {@link SerialSessionStatus.Connected} and `state.portInfo`. Scheduled for removal in the next major version. */
-  getPortInfo(): SerialPortInfo | null;
 
   send$(data: string | Uint8Array): Observable<void>;
 }
@@ -227,37 +218,21 @@ Synchronous feature check. Returns `true` when `navigator.serial` is available.
 
 ### `connect$(): Observable<void>`
 
-Opens a user-selected serial port and starts the internal read pump. Completes on success; errors via `errors$` and the subscriber on failure. Transitions `idle → connecting → connected`.
+Opens a user-selected serial port and starts the internal read pump. Completes on success; errors via `errors$` and the subscriber on failure. Transitions `idle → connecting → connected`. **Runs when subscribed.**
 
 ### `disconnect$(): Observable<void>`
 
-Stops the read pump and closes the port. Safe to call when already idle or while a disconnect is already in progress. When called during `'connecting'`, cancels the in-flight `connect$()` (closes any opened port) and returns to `'idle'` without reaching `'connected'`. Transitions `connected → disconnecting → idle`. When called from `'error'` it still tears the port down and returns to `idle`. The session remains reusable after `disconnect$`; use `dispose$` for permanent teardown.
+Stops the read pump and closes the port. Safe to call when already idle or while a disconnect is already in progress. When called during `'connecting'`, cancels the in-flight `connect$()` (closes any opened port) and returns to `'idle'` without reaching `'connected'`. Transitions `connected → disconnecting → idle`. When called from `'error'` it still tears the port down and returns to `idle`. The session remains reusable after `disconnect$`; use `dispose$` for permanent teardown. **Runs when subscribed.**
 
 ### `dispose$(): Observable<void>`
 
-Permanently tears down the session. Closes any active connection (same port/pump cleanup as `disconnect$`), emits `'disposed'` on `state$`, and **completes every session observable** (`state$`, `errors$`, `receive$`, `lines$`, `terminalText$`, `receiveReplay$`, `portInfo$`, `isConnected$`). Safe to call multiple times; subsequent calls complete immediately.
+Permanently tears down the session. Closes any active connection (same port/pump cleanup as `disconnect$`), emits `'disposed'` on `state$`, and **completes every session observable** (`state$`, `errors$`, `receive$`, `lines$`, `terminalText$`, `receiveReplay$`). Safe to call multiple times; subsequent calls complete immediately. **Runs when subscribed.**
 
 After disposal, `connect$` and `send$` fail with `SerialErrorCode.SESSION_DISPOSED`. `disconnect$` completes immediately. Create a new `SerialSession` instead of reusing a disposed instance (for example when replacing a session after a baud-rate change).
 
-### `destroy$(): Observable<void>`
-
-**Deprecated** — alias for `dispose$()`. Retained for backward compatibility in v3.x; scheduled for removal in the next major version. See [Migrating to v3 – destroy$ deprecation](./migration-v3.md#4-destroy-deprecation).
-
 ### `state$: Observable<SerialSessionState>`
 
-Replays the current state on subscribe. Prefer driving your UI from this stream instead of rebuilding a `BehaviorSubject`.
-
-### `isConnected$: Observable<boolean>`
-
-**Deprecated** — `true` when `state$.status` is `SerialSessionStatus.Connected`; `false` otherwise. Retained in v3.x for backward compatibility but scheduled for removal in the next major version. Prefer narrowing `state$` with `SerialSessionStatus.Connected` or derive a boolean from `state$`. See [Migrating to v3 – isConnected$ deprecation](./migration-v3.md#6-isconnected-deprecation).
-
-### `portInfo$: Observable<SerialPortInfo | null>`
-
-**Deprecated** — convenience stream that emits the active port's `SerialPort.getInfo()` snapshot, or `null` when no port is open. Retained for backward compatibility in v3.x; scheduled for removal in the next major version. Prefer narrowing `state$` with `SerialSessionStatus.Connected` and reading `state.portInfo`. See [Migrating to v3 – portInfo$ / getPortInfo() deprecation](./migration-v3.md#5-portinfo--getportinfo-deprecation).
-
-### `getPortInfo(): SerialPortInfo | null`
-
-**Deprecated** — synchronous read of the last `portInfo$` value. Retained for backward compatibility in v3.x; scheduled for removal in the next major version. Prefer narrowing `state$` with `SerialSessionStatus.Connected` and reading `state.portInfo`. See [Migrating to v3 – portInfo$ / getPortInfo() deprecation](./migration-v3.md#5-portinfo--getportinfo-deprecation).
+Replays the current state on subscribe. Prefer driving your UI from this stream instead of rebuilding a `BehaviorSubject`. When `state.status` is `SerialSessionStatus.Connected`, read **`state.portInfo`** for device identification. There is no separate `portInfo$` / `getPortInfo()` / `isConnected$` / `destroy$()` / `getCurrentPort()` on the public API — see [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals).
 
 ### `errors$: Observable<SerialError>`
 
@@ -281,7 +256,7 @@ The same UTF-8 stream split into **complete lines** using `\n`, `\r\n`, and a lo
 
 ### `send$(data: string | Uint8Array): Observable<void>`
 
-Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a shared `TextEncoder`. Concurrent `send$` calls are serialised in call order by an internal FIFO queue. Write failures are normalised to `SerialError` with `SerialErrorCode.WRITE_FAILED`, multiplexed on `errors$`, and surfaced to the subscriber. Calling `send$` while not `'connected'` fails fast with `SerialErrorCode.PORT_NOT_OPEN`.
+Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a shared `TextEncoder`. Concurrent `send$` calls are serialised in call order by an internal FIFO queue. Write failures are normalised to `SerialError` with `SerialErrorCode.WRITE_FAILED`, multiplexed on `errors$`, and surfaced to the subscriber. Calling `send$` while not `'connected'` fails fast with `SerialErrorCode.PORT_NOT_OPEN`. **Runs when subscribed.**
 
 ## SerialError / SerialErrorCode
 

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v2.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v2.md
@@ -54,7 +54,7 @@ The following v1 exports are **deleted** and no compatibility shim is provided.
 | `createSerialClient(opts)`              | `createSerialSession(opts)`                                             |
 | `client.connect()`                      | `session.connect$()`                                                    |
 | `client.disconnect()`                   | `session.disconnect$()`                                                 |
-| `client.connected` / `client.connected$`| `session.isConnected$` (or `session.state$` with `map`)                  |
+| `client.connected` / `client.connected$`| `session.state$` (narrow on `SerialSessionStatus.Connected`, or derive a boolean with `map`) |
 | `client.state$` (discriminated object)  | `session.state$` (`SerialSessionState` string union)                  |
 | `client.text$` / `client.lines$`        | `session.lines$` (line-delimited) or `session.receive$` (raw UTF-8 chunks) |
 | `client.bytes$`                         | Not exposed in v2. Convert with `new TextEncoder().encode(chunk)` if you need bytes, or open an issue. |

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
@@ -49,7 +49,7 @@ Phase 1 of [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) removed 
 | `getPortInfo()` | `state.portInfo` when connected (same as above) |
 | `getCurrentPort()` | No direct replacement. Use `state.portInfo` for identification; raw `SerialPort` is not exposed |
 
-Details: [§4](#4-destroy-removal), [§5](#5-portinfo--getportinfo-removal), [§6](#6-isconnected-removal), [§7](#7-getcurrentport-removal).
+Details: [§4](#4-removal), [§5](#5-removal), [§6](#6-removal), [§7](#7-removal).
 
 ---
 
@@ -145,13 +145,13 @@ export type SerialSessionState =
 - [ ] Replace `import { SerialSessionState }` used as **constants** with `SerialSessionStatus`.
 - [ ] Replace `state === SerialSessionState.X` with `state.status === SerialSessionStatus.X`.
 - [ ] Replace `switch (state)` with `switch (state.status)` (or compare `state.status` in `if`).
-- [ ] Use `state.portInfo` when `state.status === SerialSessionStatus.Connected` (`portInfo$` and `getPortInfo()` were removed — see [§5](#5-portinfo--getportinfo-removal)).
+- [ ] Use `state.portInfo` when `state.status === SerialSessionStatus.Connected` (`portInfo$` and `getPortInfo()` were removed — see [§5](#5-removal)).
 - [ ] Use `state.error` when `state.status === 'error'` (same instance as `errors$` for fatal errors).
 
 ### Unchanged
 
 - `errors$` remains available as the independent error event channel.
-- Lifecycle convenience APIs (`portInfo$`, `getPortInfo()`, `isConnected$`, `destroy$()`) are **removed** — migrate with [§4](#4-destroy-removal)–[§6](#6-isconnected-removal).
+- Lifecycle convenience APIs (`portInfo$`, `getPortInfo()`, `isConnected$`, `destroy$()`) are **removed** — migrate with [§4](#4-removal)–[§6](#6-removal).
 
 ---
 
@@ -575,7 +575,6 @@ The `createSerialSession(options?)` signature and existing options object litera
 - [Migrating from v1 to v2](./migration-v2.md)
 - [API Reference – SerialSessionState / SerialSessionStatus](./concepts.md#serialsessionstate--serialsessionstatus)
 - [API Reference – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode)
-- [API Reference – dispose$](./concepts.md#dispose-observablevoid)
-- [API Reference – state$](./concepts.md#state-observableserialsessionstate)
+- [API Reference – dispose$ / state$](./concepts.md#serialsession)
 - [API Reference – Deprecated exports](./concepts.md#deprecated-exports)
 - [API Reference – SerialSessionOptions](./concepts.md#serialsessionoptions)

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
@@ -37,6 +37,22 @@ session.errors$.subscribe((error) => {
 
 ---
 
+## Phase 1 API removals
+
+Phase 1 of [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) removed duplicate / escape-hatch APIs so `state$` and `dispose$()` are the only public sources for lifecycle and teardown. See [#478](https://github.com/gurezo/web-serial-rxjs/issues/478) for the documentation pass.
+
+| Removed API | Replacement |
+| --- | --- |
+| `destroy$()` | `dispose$()` |
+| `isConnected$` | `state$` with `state.status` (or derive a boolean from `state$`) |
+| `portInfo$` | `state.portInfo` when `state.status === SerialSessionStatus.Connected` |
+| `getPortInfo()` | `state.portInfo` when connected (same as above) |
+| `getCurrentPort()` | No direct replacement. Use `state.portInfo` for identification; raw `SerialPort` is not exposed |
+
+Details: [§4](#4-destroy-removal), [§5](#5-portinfo--getportinfo-removal), [§6](#6-isconnected-removal), [§7](#7-getcurrentport-removal).
+
+---
+
 ## 1. `SerialErrorCode` const object
 
 ### What changed
@@ -129,14 +145,13 @@ export type SerialSessionState =
 - [ ] Replace `import { SerialSessionState }` used as **constants** with `SerialSessionStatus`.
 - [ ] Replace `state === SerialSessionState.X` with `state.status === SerialSessionStatus.X`.
 - [ ] Replace `switch (state)` with `switch (state.status)` (or compare `state.status` in `if`).
-- [ ] Use `state.portInfo` when `state.status === SerialSessionStatus.Connected` (recommended — `portInfo$` and `getPortInfo()` are deprecated).
+- [ ] Use `state.portInfo` when `state.status === SerialSessionStatus.Connected` (`portInfo$` and `getPortInfo()` were removed — see [§5](#5-portinfo--getportinfo-removal)).
 - [ ] Use `state.error` when `state.status === 'error'` (same instance as `errors$` for fatal errors).
 
 ### Unchanged
 
-- `errors$` remains available.
-- `portInfo$` and `getPortInfo()` remain available in v3.x but are **deprecated** (see [§5](#5-portinfo--getportinfo-deprecation)).
-- `isConnected$` remains available in v3.x but is **deprecated** (see [§6](#6-isconnected-deprecation)).
+- `errors$` remains available as the independent error event channel.
+- Lifecycle convenience APIs (`portInfo$`, `getPortInfo()`, `isConnected$`, `destroy$()`) are **removed** — migrate with [§4](#4-destroy-removal)–[§6](#6-isconnected-removal).
 
 ---
 
@@ -181,13 +196,11 @@ session.errors$.subscribe((error) => {
 
 ---
 
-## 4. `destroy$` deprecation
+## 4. `destroy$()` removal
 
-`SerialSession` exposes both `dispose$()` and `destroy$()`. They are the same function — `destroy$` is a legacy alias. Lifecycle terminology (`dispose`, `disposed`, `SESSION_DISPOSED`) already uses **`dispose$`** as the canonical API.
+`destroy$()` was a legacy alias of `dispose$()`. Lifecycle terminology (`dispose`, `disposed`, `SESSION_DISPOSED`) already used **`dispose$`** as the canonical API. Phase 1 ([#473](https://github.com/gurezo/web-serial-rxjs/issues/473) / [#479](https://github.com/gurezo/web-serial-rxjs/pull/479)) **removed** `destroy$()` from the public API so session teardown has a single entry point.
 
-`destroy$()` remains in v3.x for backward compatibility but is **deprecated** and scheduled for removal in the next major version.
-
-### v2 / legacy pattern (deprecated)
+### Old pattern (removed)
 
 ```typescript
 session.destroy$().subscribe({
@@ -195,7 +208,7 @@ session.destroy$().subscribe({
 });
 ```
 
-### v3 recommended pattern
+### Recommended pattern
 
 ```typescript
 session.dispose$().subscribe({
@@ -206,23 +219,21 @@ session.dispose$().subscribe({
 ### Migration checklist
 
 - [ ] Replace `session.destroy$()` with `session.dispose$()`.
-- [ ] Address TypeScript `@deprecated` warnings by migrating to `dispose$`.
 - [ ] Prefer `dispose$` in new code and documentation.
 
-### Compatibility in v3.x
+### Why there is no alias
 
-- `destroy$` remains available in v3.x and delegates to the same implementation as `dispose$`.
-- Runtime behavior is unchanged; only the alias is deprecated.
+Keeping both names forced callers to choose between equivalent APIs and kept docs / tests dual. `dispose$()` is the only teardown method.
 
 ---
 
-## 5. `portInfo$` / `getPortInfo()` deprecation
+## 5. `portInfo$` / `getPortInfo()` removal
 
 v3.0.0 made `state$` a discriminated union. When `state.status` is `SerialSessionStatus.Connected`, **`state.portInfo`** is the canonical source for the active port's `SerialPort.getInfo()` snapshot — TypeScript narrowing guarantees it is present.
 
-`portInfo$` and `getPortInfo()` remain in v3.x for backward compatibility but are **deprecated** and scheduled for removal in the next major version. They expose `SerialPortInfo | null`, which does not encode the relationship between connection state and port information.
+`portInfo$` and `getPortInfo()` exposed `SerialPortInfo | null`, which did not encode the relationship between connection state and port information. Phase 1 **removed** both APIs ([#473](https://github.com/gurezo/web-serial-rxjs/issues/473) / [#479](https://github.com/gurezo/web-serial-rxjs/pull/479)).
 
-### v2 / legacy pattern (deprecated)
+### Old pattern (removed)
 
 ```typescript
 session.portInfo$.subscribe((portInfo) => {
@@ -234,7 +245,7 @@ session.portInfo$.subscribe((portInfo) => {
 const snapshot = session.getPortInfo();
 ```
 
-### v3 recommended pattern
+### Recommended pattern
 
 ```typescript
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
@@ -250,24 +261,21 @@ session.state$.subscribe((state) => {
 
 - [ ] Replace `portInfo$` subscriptions with `state$` and read `state.portInfo` when `state.status === SerialSessionStatus.Connected`.
 - [ ] Replace `getPortInfo()` with `state$` narrowing and `state.portInfo`.
-- [ ] Address TypeScript `@deprecated` warnings by migrating to the pattern above.
 - [ ] Prefer `state.portInfo` in new code and documentation.
 
-### Compatibility in v3.x
+### Notes
 
-- `portInfo$` and `getPortInfo()` remain available in v3.x.
-- Runtime behavior is unchanged; values stay in sync with `state.portInfo` while connected.
-- `errors$` is not deprecated — it is an independent error event channel, not a duplicate of lifecycle state.
+- `errors$` is not a duplicate of lifecycle state — it remains the independent error event channel.
 
 ---
 
-## 6. `isConnected$` deprecation
+## 6. `isConnected$` removal
 
 v3.0.0 made `state$` a discriminated union. When `state.status` is `SerialSessionStatus.Connected`, TypeScript narrowing gives type-safe access to `state.portInfo` and other state-specific fields.
 
-`isConnected$` is an `Observable<boolean>` that only projects whether the session is connected, so it loses the type information carried by the discriminated union. It remains in v3.x for backward compatibility but is **deprecated** and scheduled for removal in the next major version.
+`isConnected$` was an `Observable<boolean>` that only projected whether the session was connected, so it lost the type information carried by the discriminated union and could not distinguish `idle` / `connecting` / `disconnecting` / `error` / `disposed`. Phase 1 **removed** it ([#473](https://github.com/gurezo/web-serial-rxjs/issues/473) / [#479](https://github.com/gurezo/web-serial-rxjs/pull/479)).
 
-### v2 / legacy pattern (deprecated)
+### Old pattern (removed)
 
 ```typescript
 session.isConnected$.subscribe((isConnected) => {
@@ -277,7 +285,7 @@ session.isConnected$.subscribe((isConnected) => {
 });
 ```
 
-### v3 recommended pattern (`state$` narrowing)
+### Recommended pattern (`state$` narrowing)
 
 ```typescript
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
@@ -300,6 +308,8 @@ const isConnected$ = session.state$.pipe(
   distinctUntilChanged(),
 );
 ```
+
+The local `isConnected$` above is **application-derived** from `state$`. It is not a `SerialSession` member.
 
 ### RxJS `filter` with connected-state narrowing
 
@@ -334,20 +344,13 @@ const isConnected = computed(
 
 - [ ] Replace `isConnected$` subscriptions with `state$` and narrow on `state.status === SerialSessionStatus.Connected`.
 - [ ] When you only need a boolean for UI, derive it from `state$` with `map` or `computed`.
-- [ ] Address TypeScript `@deprecated` warnings by migrating to the patterns above.
 - [ ] Prefer `state$` narrowing in new code and documentation.
-
-### Compatibility in v3.x
-
-- `isConnected$` remains available in v3.x.
-- Runtime behavior is unchanged; values stay in sync with `state.status === SerialSessionStatus.Connected`.
-- Framework-specific convenience state should be derived from `state$` in framework adapters and examples.
 
 ---
 
 ## 7. `getCurrentPort()` removal
 
-`SerialSession.getCurrentPort()` was a raw `SerialPort` escape hatch. Calling `port.close()` or `writable.getWriter()` on the returned port could conflict with the session lifecycle and break internal runtime invariants.
+`SerialSession.getCurrentPort()` was a raw `SerialPort` escape hatch. Calling `port.close()` or `writable.getWriter()` on the returned port could conflict with the session lifecycle and break internal runtime invariants. **There is no direct replacement** — the library does not expose the managed `SerialPort` so callers cannot bypass session I/O.
 
 A usage audit ([#437](https://github.com/gurezo/web-serial-rxjs/issues/437)) found no production callers in this repository. Device identification is covered by `state.portInfo`, so **`getCurrentPort()` has been removed** from the public API ([#448](https://github.com/gurezo/web-serial-rxjs/pull/448)). Phase 1 parent issue [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) / child issue [#474](https://github.com/gurezo/web-serial-rxjs/issues/474) also track this removal as a completion criterion.
 
@@ -572,8 +575,7 @@ The `createSerialSession(options?)` signature and existing options object litera
 - [Migrating from v1 to v2](./migration-v2.md)
 - [API Reference – SerialSessionState / SerialSessionStatus](./concepts.md#serialsessionstate--serialsessionstatus)
 - [API Reference – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode)
-- [API Reference – dispose$ / destroy$](./concepts.md#dispose-observablevoid)
-- [API Reference – portInfo$ / getPortInfo()](./concepts.md#portinfo-observableserialportinfo--null)
-- [API Reference – isConnected$](./concepts.md#isconnected-observableboolean)
+- [API Reference – dispose$](./concepts.md#dispose-observablevoid)
+- [API Reference – state$](./concepts.md#state-observableserialsessionstate)
 - [API Reference – Deprecated exports](./concepts.md#deprecated-exports)
 - [API Reference – SerialSessionOptions](./concepts.md#serialsessionoptions)

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -32,7 +32,7 @@ Standalone guides (HTML):
 
 ## Features
 
-- **Session-oriented reactive API**: a single `SerialSession` exposes `state$` (canonical lifecycle discriminated union), `errors$` (error event channel), `receive$`, `lines$`, and `connect$`, `disconnect$`, `dispose$`, and `send$` (`isConnected$` is a deprecated convenience stream in v3.x)
+- **Session-oriented reactive API**: a single `SerialSession` exposes `state$` (canonical lifecycle discriminated union), `errors$` (error event channel), `receive$`, `lines$`, and `connect$`, `disconnect$`, `dispose$`, and `send$`
 - **UTF-8 text stream**: `receive$` is already decoded with a streaming `TextDecoder`, so multi-byte characters split across chunks are joined correctly
 - **Ordered send queue**: concurrent `send$` calls are serialized internally in call order, without the caller having to manage a writer
 - **Unified error channel**: every I/O error is normalised into `SerialError` and multiplexed on `errors$`
@@ -58,7 +58,6 @@ This library is framework-agnostic and can be used with:
 | `state$` | **Canonical connection lifecycle** — discriminated union (`status` plus optional `portInfo` / `error`). Replays on subscribe. Compare **`state.status`** with **`SerialSessionStatus`**. |
 | `SerialSessionStatus` | **Status constants** — const object (e.g. `SerialSessionStatus.Connected` → `'connected'`). Compare with `state$.status`. |
 | `SerialSessionState` | **Payload type** for `state$` (discriminated union). |
-| `isConnected$` | **Deprecated (convenience)** — `true` only when `state$.status` is `SerialSessionStatus.Connected`. Prefer `state$` narrowing or derive. |
 | `receive$` | **Raw decoder chunks** — UTF-8 text as emitted by the pump (not line-aligned; multi-byte safe). Preserves `\r` and other control characters. Use for **terminal-like mirrors** and progress output that relies on carriage-return redraws. |
 | `terminalText$` | **Terminal-ready cumulative text** — display-oriented text derived from `receive$` that folds carriage-return redraws while keeping normal newline behavior. By default strips ANSI escape sequences for plain-text UIs; use `receive$` for raw output. Use when you want to bind one string directly to a terminal-like viewport. By default retains at most 10,000 lines and 1,048,576 characters (configure via `SerialSessionOptions.terminalBuffer`). |
 | `lines$` | **Line-delimited UTF-8 text** — one string per complete line via the built-in buffer (`\n`, `\r\n`, interior `\r`). Use for **logs** and **line-by-line parsing**, not for mirroring raw terminal streams where `\r` must stay intact. |
@@ -85,7 +84,7 @@ Each `state$` emission has a `status` field. Prefer the **const object** (e.g. `
 
 **`receive$` vs `lines$`:** use **`receive$`** when the UI must show **exactly** what the device sent (e.g. interactive shells, `ls` progress, any stream using `\r` to redraw a line). Use **`lines$`** for **newline-oriented** consumers—logs, one-line replies, parsers. Feeding **`lines$`** into a terminal widget can drop or split on `\r` and break redraw semantics. For custom delimiters beyond the built-in line buffer, compose on **`receive$`** ([Advanced Usage](./advanced-usage.md#line-framing)).
 
-**`isConnected$` (deprecated convenience)** — a read-only `Observable<boolean>`. Retained in v3.x for backward compatibility but scheduled for removal in the next major version. When you only need a boolean for UI toggles, derive it from `state$` or narrow on `state.status === SerialSessionStatus.Connected`. See [Migrating to v3](./migration-v3.md#6-isconnected-deprecation).
+**Connected boolean for UI** — when you only need a flag, derive it from `state$` (see [Advanced Usage](./advanced-usage.md#connected-boolean-ui-state-narrowing)) or narrow on `state.status === SerialSessionStatus.Connected`. Removed convenience APIs are documented in [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals).
 
 **`lines$` (newline framing)** — built-in line splitting; for non-line protocols or terminal mirrors, subscribe to **`receive$`** instead (recipes in [Advanced Usage](./advanced-usage.md#line-framing)).
 

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -84,7 +84,7 @@ Each `state$` emission has a `status` field. Prefer the **const object** (e.g. `
 
 **`receive$` vs `lines$`:** use **`receive$`** when the UI must show **exactly** what the device sent (e.g. interactive shells, `ls` progress, any stream using `\r` to redraw a line). Use **`lines$`** for **newline-oriented** consumers—logs, one-line replies, parsers. Feeding **`lines$`** into a terminal widget can drop or split on `\r` and break redraw semantics. For custom delimiters beyond the built-in line buffer, compose on **`receive$`** ([Advanced Usage](./advanced-usage.md#line-framing)).
 
-**Connected boolean for UI** — when you only need a flag, derive it from `state$` (see [Advanced Usage](./advanced-usage.md#connected-boolean-ui-state-narrowing)) or narrow on `state.status === SerialSessionStatus.Connected`. Removed convenience APIs are documented in [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals).
+**Connected boolean for UI** — when you only need a flag, derive it from `state$` (see [Advanced Usage](./advanced-usage.md#connected-boolean-ui-narrowing)) or narrow on `state.status === SerialSessionStatus.Connected`. Removed convenience APIs are documented in [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals).
 
 **`lines$` (newline framing)** — built-in line splitting; for non-line protocols or terminal mirrors, subscribe to **`receive$`** instead (recipes in [Advanced Usage](./advanced-usage.md#line-framing)).
 

--- a/packages/web-serial-rxjs/docs/guide/en/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/en/quick-start.md
@@ -2,7 +2,7 @@
 
 This is the **shortest path** to opening a serial port, receiving **newline-delimited lines**, sending data, and closing the port. For the full map of `state$`, `errors$`, `receive$`, `lines$`, and the imperative methods, read [SerialSession overview](./overview.md#serialsession-at-a-glance) first.
 
-Use **`lines$`** for standard newline-framed text (`\n`, `\r\n`). **`receive$`** is the raw UTF-8 decoder chunk stream when you need custom framing (see [Advanced Usage](./advanced-usage.md#line-framing)). Prefer **`state$`** with `state.status` narrowing for lifecycle UI. **`isConnected$`** is deprecated in v3.x — derive a boolean from `state$` instead.
+Use **`lines$`** for standard newline-framed text (`\n`, `\r\n`). **`receive$`** is the raw UTF-8 decoder chunk stream when you need custom framing (see [Advanced Usage](./advanced-usage.md#line-framing)). Prefer **`state$`** with `state.status` narrowing for lifecycle UI. Derive a connected boolean from `state$` when you only need a flag. **`connect$()`**, **`send$()`**, **`disconnect$()`**, and **`dispose$()`** run when you subscribe.
 
 ## Installation
 

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -40,4 +40,4 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 
 - **`state$`** — 接続ライフサイクルの canonical source。`state.status` と `SerialSessionStatus` で分岐し、connected 時は `state.portInfo` を利用する
 - **`errors$`** — fatal / non-fatal エラーの canonical event channel。`SerialError.is(SerialErrorCode.*)` で分岐する
-- **非推奨 convenience** — `isConnected$`、`portInfo$`、`getPortInfo()` は v3.x で残存するが、新規コードでは `state$` narrowing を優先する
+- **`dispose$()`** — セッション破棄の唯一の API（購読により実行）。削除された convenience API（`destroy$`、`isConnected$`、`portInfo$`、`getPortInfo()`、`getCurrentPort()`）は [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照

--- a/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md
@@ -2,7 +2,7 @@
 
 `SerialSession` は意図的に小さな公開面に絞られています。応用パターンの大半は、`receive$` と `send$` の上に普通の RxJS オペレータを組み合わせることで表現できます。API の全体像は先に[SerialSession の概要](./overview.md#serialsessionの全体像)と[クイックスタート](./quick-start.md)を読み、本ページは概要で省いた**行フレーミング・派生ストリーム・リカバリ**のレシピに絞ります。ライフサイクルとエラーは `state$` の `state.status` narrowing と `errors$` の `error.is()` を優先してください — [v3 への移行](./migration-v3.md) を参照。
 
-本ページは [Issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228) で列挙したパターンに対応します。**`lines$`** は `SerialSession` の組み込みとして用意されています。**`isConnected$`** は v3.x で非推奨です — `state$` narrowing を優先してください。**`sendLine`・`readUntil`・`waitForState`** などは、引き続きコア API の上に組み立てるパターンです（専用の追加 export はありません）。USB OTG シリアルコンソールの実例として [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) があります。同アプリの読み書きループを `SerialSession` で書き直すときも、ここでのレシピがそのまま使えます。
+本ページは [Issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228) で列挙したパターンに対応します。**`lines$`** は `SerialSession` の組み込みとして用意されています。接続 UI には **`state$`** narrowing を優先してください。**`sendLine`・`readUntil`・`waitForState`** などは、引き続きコア API の上に組み立てるパターンです（専用の追加 export はありません）。USB OTG シリアルコンソールの実例として [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) があります。同アプリの読み書きループを `SerialSession` で書き直すときも、ここでのレシピがそのまま使えます。
 
 ## 行単位のフレーミング（組み込み `lines$` と `receive$` 上のカスタム分割）
 
@@ -55,7 +55,7 @@ isConnected$.subscribe((isOpen) => {
 });
 ```
 
-**`isConnected$`** は v3.x で非推奨です。多段階の UI では下記の [state$ 駆動の UI](#state-駆動の-ui) のように `state$` 全体を使う方が分かりやすいです。
+上記のローカル `isConnected$` は **`state$` から derive したもの**であり、`SerialSession` のメンバーではありません。多段階の UI では下記の [state$ 駆動の UI](#state-駆動の-ui) のように `state$` 全体を使う方が分かりやすいです。
 
 RxJS pipeline 内で `portInfo` など connected 専用フィールドにアクセスする場合は、`filter()` と `isConnectedSessionState` を組み合わせてください。inline の status 比較では TypeScript の narrowing は行われません。
 

--- a/packages/web-serial-rxjs/docs/guide/ja/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/concepts.md
@@ -200,22 +200,13 @@ interface SerialSession {
   connect$(): Observable<void>;
   disconnect$(): Observable<void>;
   dispose$(): Observable<void>;
-  /** @deprecated {@link dispose$} を使用してください。次回 major version で削除予定です。 */
-  destroy$(): Observable<void>;
 
   readonly state$: Observable<SerialSessionState>;
-  /** @deprecated {@link state$} を {@link SerialSessionStatus.Connected} で narrowing してください。次回 major version で削除予定です。 */
-  readonly isConnected$: Observable<boolean>;
-  /** @deprecated {@link state$} を {@link SerialSessionStatus.Connected} で narrowing し `state.portInfo` を使用してください。次回 major version で削除予定です。 */
-  readonly portInfo$: Observable<SerialPortInfo | null>;
   readonly errors$: Observable<SerialError>;
   readonly receive$: Observable<string>;
   readonly receiveReplay$: Observable<string>;
   readonly terminalText$: Observable<string>;
   readonly lines$: Observable<string>;
-
-  /** @deprecated {@link state$} を {@link SerialSessionStatus.Connected} で narrowing し `state.portInfo` を使用してください。次回 major version で削除予定です。 */
-  getPortInfo(): SerialPortInfo | null;
 
   send$(data: string | Uint8Array): Observable<void>;
 }
@@ -227,37 +218,21 @@ interface SerialSession {
 
 ### `connect$(): Observable<void>`
 
-ユーザーが選択したシリアルポートをオープンし、内部の read pump を起動します。成功時は complete し、失敗時は subscriber と `errors$` の両方にエラーを流します。状態遷移は `idle → connecting → connected`。
+ユーザーが選択したシリアルポートをオープンし、内部の read pump を起動します。成功時は complete し、失敗時は subscriber と `errors$` の両方にエラーを流します。状態遷移は `idle → connecting → connected`。**購読により実行されます。**
 
 ### `disconnect$(): Observable<void>`
 
-read pump を停止してポートを閉じます。すでに idle の場合もそのまま complete します。状態遷移は `connected → disconnecting → idle`。`'error'` からも呼べて、ポートをテアダウンして `idle` に戻します。`disconnect$` 後もセッションは再利用可能です。永久破棄には `dispose$` を使います。
+read pump を停止してポートを閉じます。すでに idle の場合もそのまま complete します。状態遷移は `connected → disconnecting → idle`。`'error'` からも呼べて、ポートをテアダウンして `idle` に戻します。`disconnect$` 後もセッションは再利用可能です。永久破棄には `dispose$` を使います。**購読により実行されます。**
 
 ### `dispose$(): Observable<void>`
 
-セッションを永久破棄します。アクティブな接続があれば `disconnect$` と同様にポートと read pump を teardown し、`state$` に `'disposed'` を emit したうえで、すべてのセッション Observable（`state$`、`errors$`、`receive$`、`lines$`、`terminalText$`、`receiveReplay$`、`portInfo$`、`isConnected$`）を complete します。複数回呼んでも安全で、2 回目以降は即 complete します。
+セッションを永久破棄します。アクティブな接続があれば `disconnect$` と同様にポートと read pump を teardown し、`state$` に `'disposed'` を emit したうえで、すべてのセッション Observable（`state$`、`errors$`、`receive$`、`lines$`、`terminalText$`、`receiveReplay$`）を complete します。複数回呼んでも安全で、2 回目以降は即 complete します。**購読により実行されます。**
 
 dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で失敗します。`disconnect$` は即 complete します。baud rate 変更時の session 作り替えなどでは、破棄したインスタンスを再利用せず新しい `SerialSession` を作成してください。
 
-### `destroy$(): Observable<void>`
-
-**非推奨** — `dispose$()` のエイリアスです。v3.x では後方互換のため残っていますが、次回 major version で削除予定です。詳細は [v3 移行ガイド – destroy$ の非推奨化](./migration-v3.md#4-destroy-の非推奨化) を参照してください。
-
 ### `state$: Observable<SerialSessionState>`
 
-購読時に現在値をリプレイします。`BehaviorSubject` を自前で再構築する代わりに、このストリームを UI の駆動源として使ってください。
-
-### `isConnected$: Observable<boolean>`
-
-**非推奨** — `state$.status` が `SerialSessionStatus.Connected` のとき `true`、それ以外のとき `false` です。v3.x では後方互換のため残っていますが、次回 major version で削除予定です。`state$` を `SerialSessionStatus.Connected` で narrowing するか、`state$` から derive してください。詳細は [v3 移行ガイド – isConnected$ の非推奨化](./migration-v3.md#6-isconnected-の非推奨化) を参照してください。
-
-### `portInfo$: Observable<SerialPortInfo | null>`
-
-**非推奨** — アクティブポートの `SerialPort.getInfo()` スナップショットを emit する convenience stream です。ポートが開いていないときは `null` です。v3.x では後方互換のため残っていますが、次回 major version で削除予定です。`state$` を `SerialSessionStatus.Connected` で narrowing し `state.portInfo` を参照してください。詳細は [v3 移行ガイド – portInfo$ / getPortInfo() の非推奨化](./migration-v3.md#5-portinfo--getportinfo-の非推奨化) を参照してください。
-
-### `getPortInfo(): SerialPortInfo | null`
-
-**非推奨** — 最後の `portInfo$` 値の同期読み取りです。v3.x では後方互換のため残っていますが、次回 major version で削除予定です。`state$` を `SerialSessionStatus.Connected` で narrowing し `state.portInfo` を参照してください。詳細は [v3 移行ガイド – portInfo$ / getPortInfo() の非推奨化](./migration-v3.md#5-portinfo--getportinfo-の非推奨化) を参照してください。
+購読時に現在値をリプレイします。`BehaviorSubject` を自前で再構築する代わりに、このストリームを UI の駆動源として使ってください。`state.status` が `SerialSessionStatus.Connected` のときは **`state.portInfo`** でデバイス識別します。公開 API に `portInfo$` / `getPortInfo()` / `isConnected$` / `destroy$()` / `getCurrentPort()` はありません — [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照してください。
 
 ### `errors$: Observable<SerialError>`
 
@@ -281,7 +256,7 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 
 ### `send$(data: string | Uint8Array): Observable<void>`
 
-ペイロードを送信キューに投入します。文字列は共有 `TextEncoder` で UTF-8 エンコードされます。並行する `send$` 呼び出しは内部 FIFO キューで呼び出し順に直列化されます。書き込み失敗は `SerialErrorCode.WRITE_FAILED` の `SerialError` に正規化され、subscriber と `errors$` の両方に流れます。`'connected'` 以外の状態で呼ぶと、`SerialErrorCode.PORT_NOT_OPEN` で即失敗します。
+ペイロードを送信キューに投入します。文字列は共有 `TextEncoder` で UTF-8 エンコードされます。並行する `send$` 呼び出しは内部 FIFO キューで呼び出し順に直列化されます。書き込み失敗は `SerialErrorCode.WRITE_FAILED` の `SerialError` に正規化され、subscriber と `errors$` の両方に流れます。`'connected'` 以外の状態で呼ぶと、`SerialErrorCode.PORT_NOT_OPEN` で即失敗します。**購読により実行されます。**
 
 ## SerialError / SerialErrorCode
 

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md
@@ -54,7 +54,7 @@ session.send$('hi').subscribe();
 | `createSerialClient(opts)`              | `createSerialSession(opts)`                                              |
 | `client.connect()`                      | `session.connect$()`                                                     |
 | `client.disconnect()`                   | `session.disconnect$()`                                                  |
-| `client.connected` / `client.connected$`| `session.isConnected$`（または `session.state$` を `map`）               |
+| `client.connected` / `client.connected$`| `session.state$`（`SerialSessionStatus.Connected` で narrowing、または `map` で boolean を derive） |
 | `client.state$`（discriminated object） | `session.state$`（`SerialSessionState` 文字列ユニオン）                 |
 | `client.text$` / `client.lines$`        | `session.lines$`（行区切り）または `session.receive$`（生の UTF-8 チャンク） |
 | `client.bytes$`                         | v2 では非公開。バイトが必要なら `new TextEncoder().encode(chunk)` などで変換するか issue でリクエストしてください |

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
@@ -37,6 +37,22 @@ session.errors$.subscribe((error) => {
 
 ---
 
+## Phase 1 API 削除
+
+[#472](https://github.com/gurezo/web-serial-rxjs/issues/472) の Phase 1 では、重複・escape hatch な API を削除し、ライフサイクルと破棄の正規情報源を `state$` と `dispose$()` に統一しました。ドキュメント整備は [#478](https://github.com/gurezo/web-serial-rxjs/issues/478) です。
+
+| 削除 API | 移行先 |
+| --- | --- |
+| `destroy$()` | `dispose$()` |
+| `isConnected$` | `state$` の `state.status`（または `state$` から boolean を derive） |
+| `portInfo$` | `state.status === SerialSessionStatus.Connected` 時の `state.portInfo` |
+| `getPortInfo()` | 同上（Connected 時の `state.portInfo`） |
+| `getCurrentPort()` | 直接の代替なし。識別は `state.portInfo`。生の `SerialPort` は公開しない |
+
+詳細: [§4](#4-destroy-の削除)、[§5](#5-portinfo--getportinfo-の削除)、[§6](#6-isconnected-の削除)、[§7](#7-getcurrentport-の削除)。
+
+---
+
 ## 1. `SerialErrorCode` const object
 
 ### 変更内容
@@ -129,14 +145,13 @@ export type SerialSessionState =
 - [ ] **定数**として使っていた `SerialSessionState` を `SerialSessionStatus` に置き換える。
 - [ ] `state === SerialSessionState.X` を `state.status === SerialSessionStatus.X` に置き換える。
 - [ ] `switch (state)` を `switch (state.status)` に置き換える（または `if` で `state.status` を比較）。
-- [ ] `connected` 時は `state.portInfo` を利用する（推奨 — `portInfo$` と `getPortInfo()` は非推奨）。
+- [ ] `connected` 時は `state.portInfo` を利用する（`portInfo$` と `getPortInfo()` は削除済み — [§5](#5-portinfo--getportinfo-の削除) を参照）。
 - [ ] `error` 時は `state.error` を利用（fatal error は `errors$` と同一インスタンス）。
 
 ### 変更なし
 
-- `errors$` は引き続き利用可能です。
-- `portInfo$` と `getPortInfo()` は v3.x では引き続き利用可能ですが、**非推奨**です（[§5](#5-portinfo--getportinfo-の非推奨化) を参照）。
-- `isConnected$` は v3.x では引き続き利用可能ですが、**非推奨**です（[§6](#6-isconnected-の非推奨化) を参照）。
+- `errors$` は独立した error event channel として引き続き利用可能です。
+- ライフサイクル convenience API（`portInfo$`、`getPortInfo()`、`isConnected$`、`destroy$()`）は **削除済み** です — [§4](#4-destroy-の削除)–[§6](#6-isconnected-の削除) で移行してください。
 
 ---
 
@@ -181,13 +196,11 @@ session.errors$.subscribe((error) => {
 
 ---
 
-## 4. `destroy$` の非推奨化
+## 4. `destroy$()` の削除
 
-`SerialSession` は `dispose$()` と `destroy$()` の両方を公開しています。これらは同一関数であり、`destroy$` は legacy エイリアスです。lifecycle terminology（`dispose`、`disposed`、`SESSION_DISPOSED`）はすでに **`dispose$`** を canonical API として使用しています。
+`destroy$()` は `dispose$()` の legacy エイリアスでした。lifecycle terminology（`dispose`、`disposed`、`SESSION_DISPOSED`）はすでに **`dispose$`** を canonical API として使用していました。Phase 1（[#473](https://github.com/gurezo/web-serial-rxjs/issues/473) / [#479](https://github.com/gurezo/web-serial-rxjs/pull/479)）で公開 API から **削除**し、セッション破棄の入口を一本化しました。
 
-後方互換のため `destroy$()` は v3.x に残っていますが、**非推奨**です。次回 major version で削除予定です。
-
-### v2 / 旧パターン（非推奨）
+### 旧パターン（削除済み）
 
 ```typescript
 session.destroy$().subscribe({
@@ -195,7 +208,7 @@ session.destroy$().subscribe({
 });
 ```
 
-### v3 推奨パターン
+### 推奨パターン
 
 ```typescript
 session.dispose$().subscribe({
@@ -206,23 +219,21 @@ session.dispose$().subscribe({
 ### 移行チェックリスト
 
 - [ ] `session.destroy$()` を `session.dispose$()` に置き換える。
-- [ ] TypeScript の `@deprecated` 警告が出たら `dispose$` へ移行する。
 - [ ] 新規コードとドキュメントでは `dispose$` を使用する。
 
-### v3.x での互換性
+### エイリアスを残さない理由
 
-- `destroy$` は v3.x では引き続き利用可能で、`dispose$` と同じ実装に委譲します。
-- ランタイム挙動は変更されません。非推奨化されるのはエイリアスのみです。
+同じ処理に二つの名前があると、利用者がどちらを使うべきか判断を迫られ、ドキュメントとテストも二重になります。破棄 API は `dispose$()` のみです。
 
 ---
 
-## 5. `portInfo$` / `getPortInfo()` の非推奨化
+## 5. `portInfo$` / `getPortInfo()` の削除
 
 v3.0.0 では `state$` が discriminated union になりました。`state.status` が `SerialSessionStatus.Connected` のとき、**`state.portInfo`** がアクティブポートの `SerialPort.getInfo()` スナップショットの canonical source です。TypeScript の narrowing により、存在が型で保証されます。
 
-`portInfo$` と `getPortInfo()` は後方互換のため v3.x に残っていますが、**非推奨**で、次回 major version で削除予定です。これらは `SerialPortInfo | null` を返すため、接続状態とポート情報の関係を型で表現できません。
+`portInfo$` と `getPortInfo()` は `SerialPortInfo | null` を返すため、接続状態とポート情報の関係を型で表現できませんでした。Phase 1 で両方を **削除**しました（[#473](https://github.com/gurezo/web-serial-rxjs/issues/473) / [#479](https://github.com/gurezo/web-serial-rxjs/pull/479)）。
 
-### v2 / 旧パターン（非推奨）
+### 旧パターン（削除済み）
 
 ```typescript
 session.portInfo$.subscribe((portInfo) => {
@@ -234,7 +245,7 @@ session.portInfo$.subscribe((portInfo) => {
 const snapshot = session.getPortInfo();
 ```
 
-### v3 推奨パターン
+### 推奨パターン
 
 ```typescript
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
@@ -250,24 +261,21 @@ session.state$.subscribe((state) => {
 
 - [ ] `portInfo$` の購読を `state$` に置き換え、`state.status === SerialSessionStatus.Connected` のとき `state.portInfo` を参照する。
 - [ ] `getPortInfo()` を `state$` の narrowing と `state.portInfo` に置き換える。
-- [ ] TypeScript の `@deprecated` 警告が出たら、上記パターンへ移行する。
 - [ ] 新規コードとドキュメントでは `state.portInfo` を使用する。
 
-### v3.x での互換性
+### 補足
 
-- `portInfo$` と `getPortInfo()` は v3.x では引き続き利用可能です。
-- ランタイム挙動は変更されません。接続中は `state.portInfo` と値が同期します。
-- `errors$` は非推奨化の対象ではありません。lifecycle state ではなく、独立した error event channel です。
+- `errors$` は lifecycle state の重複ではありません。独立した error event channel として残ります。
 
 ---
 
-## 6. `isConnected$` の非推奨化
+## 6. `isConnected$` の削除
 
 v3.0.0 では `state$` が discriminated union になりました。`state.status` が `SerialSessionStatus.Connected` のとき、TypeScript の narrowing により接続状態と `state.portInfo` などの state-specific データへ型安全にアクセスできます。
 
-`isConnected$` は `Observable<boolean>` として接続の真偽値だけを返すため、discriminated union が持つ型情報を失います。後方互換のため v3.x に残っていますが、**非推奨**で、次回 major version で削除予定です。
+`isConnected$` は `Observable<boolean>` として接続の真偽値だけを返すため、discriminated union が持つ型情報を失い、`idle` / `connecting` / `disconnecting` / `error` / `disposed` を区別できませんでした。Phase 1 で **削除**しました（[#473](https://github.com/gurezo/web-serial-rxjs/issues/473) / [#479](https://github.com/gurezo/web-serial-rxjs/pull/479)）。
 
-### v2 / 旧パターン（非推奨）
+### 旧パターン（削除済み）
 
 ```typescript
 session.isConnected$.subscribe((isConnected) => {
@@ -277,7 +285,7 @@ session.isConnected$.subscribe((isConnected) => {
 });
 ```
 
-### v3 推奨パターン（`state$` narrowing）
+### 推奨パターン（`state$` narrowing）
 
 ```typescript
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
@@ -300,6 +308,8 @@ const isConnected$ = session.state$.pipe(
   distinctUntilChanged(),
 );
 ```
+
+上記のローカル `isConnected$` は **`state$` からアプリ側で derive したもの**であり、`SerialSession` のメンバーではありません。
 
 ### RxJS `filter` で connected state を narrowing する場合
 
@@ -334,20 +344,13 @@ const isConnected = computed(
 
 - [ ] `isConnected$` の購読を `state$` に置き換え、`state.status === SerialSessionStatus.Connected` で narrowing する。
 - [ ] boolean だけ必要な UI では `state$` から `map` / `computed` で derive する。
-- [ ] TypeScript の `@deprecated` 警告が出たら、上記パターンへ移行する。
 - [ ] 新規コードとドキュメントでは `state$` narrowing を使用する。
-
-### v3.x での互換性
-
-- `isConnected$` は v3.x では引き続き利用可能です。
-- ランタイム挙動は変更されません。接続中は `state.status === SerialSessionStatus.Connected` と値が同期します。
-- framework-specific convenience state は framework adapter / example 側で `state$` から derive してください。
 
 ---
 
 ## 7. `getCurrentPort()` の削除
 
-`SerialSession.getCurrentPort()` は raw `SerialPort` を返す escape hatch でした。利用者が `port.close()` や `writable.getWriter()` を直接呼び出すと、session が管理する lifecycle と競合し、internal runtime invariant を破壊する可能性がありました。
+`SerialSession.getCurrentPort()` は raw `SerialPort` を返す escape hatch でした。利用者が `port.close()` や `writable.getWriter()` を直接呼び出すと、session が管理する lifecycle と競合し、internal runtime invariant を破壊する可能性がありました。**直接の代替 API はありません** — ライブラリ管理下の `SerialPort` を公開せず、セッション I/O の迂回を防ぎます。
 
 利用状況監査（[#437](https://github.com/gurezo/web-serial-rxjs/issues/437)）の結果、本リポジトリ内のライブラリ・example コードに `getCurrentPort()` の実利用はなく、デバイス識別は `state.portInfo` で代替可能と判断し、**public API から削除**しました（[#448](https://github.com/gurezo/web-serial-rxjs/pull/448)）。Phase 1 の親 Issue [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) / 子 Issue [#474](https://github.com/gurezo/web-serial-rxjs/issues/474) でも、同じ削除方針を完了条件として追跡しています。
 
@@ -572,8 +575,7 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 - [v1 から v2 への移行](./migration-v2.md)
 - [概念と設計メモ – SerialSessionState / SerialSessionStatus](./concepts.md#serialsessionstate--serialsessionstatus)
 - [概念と設計メモ – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode)
-- [概念と設計メモ – dispose$ / destroy$](./concepts.md#dispose-observablevoid)
-- [概念と設計メモ – portInfo$ / getPortInfo()](./concepts.md#portinfo-observableserialportinfo--null)
-- [概念と設計メモ – isConnected$](./concepts.md#isconnected-observableboolean)
+- [概念と設計メモ – dispose$](./concepts.md#dispose-observablevoid)
+- [概念と設計メモ – state$](./concepts.md#state-observableserialsessionstate)
 - [概念と設計メモ – Deprecated exports](./concepts.md#deprecated-exports)
 - [概念と設計メモ – SerialSessionOptions](./concepts.md#serialsessionoptions)

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
@@ -49,7 +49,7 @@ session.errors$.subscribe((error) => {
 | `getPortInfo()` | 同上（Connected 時の `state.portInfo`） |
 | `getCurrentPort()` | 直接の代替なし。識別は `state.portInfo`。生の `SerialPort` は公開しない |
 
-詳細: [§4](#4-destroy-の削除)、[§5](#5-portinfo--getportinfo-の削除)、[§6](#6-isconnected-の削除)、[§7](#7-getcurrentport-の削除)。
+詳細: [§4](#4-の削除)、[§5](#5-の削除)、[§6](#6-の削除)、[§7](#7-の削除)。
 
 ---
 
@@ -145,13 +145,13 @@ export type SerialSessionState =
 - [ ] **定数**として使っていた `SerialSessionState` を `SerialSessionStatus` に置き換える。
 - [ ] `state === SerialSessionState.X` を `state.status === SerialSessionStatus.X` に置き換える。
 - [ ] `switch (state)` を `switch (state.status)` に置き換える（または `if` で `state.status` を比較）。
-- [ ] `connected` 時は `state.portInfo` を利用する（`portInfo$` と `getPortInfo()` は削除済み — [§5](#5-portinfo--getportinfo-の削除) を参照）。
+- [ ] `connected` 時は `state.portInfo` を利用する（`portInfo$` と `getPortInfo()` は削除済み — [§5](#5-の削除) を参照）。
 - [ ] `error` 時は `state.error` を利用（fatal error は `errors$` と同一インスタンス）。
 
 ### 変更なし
 
 - `errors$` は独立した error event channel として引き続き利用可能です。
-- ライフサイクル convenience API（`portInfo$`、`getPortInfo()`、`isConnected$`、`destroy$()`）は **削除済み** です — [§4](#4-destroy-の削除)–[§6](#6-isconnected-の削除) で移行してください。
+- ライフサイクル convenience API（`portInfo$`、`getPortInfo()`、`isConnected$`、`destroy$()`）は **削除済み** です — [§4](#4-の削除)–[§6](#6-の削除) で移行してください。
 
 ---
 
@@ -575,7 +575,6 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 - [v1 から v2 への移行](./migration-v2.md)
 - [概念と設計メモ – SerialSessionState / SerialSessionStatus](./concepts.md#serialsessionstate--serialsessionstatus)
 - [概念と設計メモ – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode)
-- [概念と設計メモ – dispose$](./concepts.md#dispose-observablevoid)
-- [概念と設計メモ – state$](./concepts.md#state-observableserialsessionstate)
+- [概念と設計メモ – dispose$ / state$](./concepts.md#serialsession)
 - [概念と設計メモ – Deprecated exports](./concepts.md#deprecated-exports)
 - [概念と設計メモ – SerialSessionOptions](./concepts.md#serialsessionoptions)

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -78,7 +78,7 @@
 
 **`receive$` と `lines$`:** 機器から来たバイト列を**そのまま**画面に反映する（シェル、`ls` のプログレス、`\r` で行を描き直す出力など）ときは **`receive$`** を使います。**改行区切りのログ**や**1 行ずつ処理するプロトコル**では **`lines$`** が適しています。ターミナル表示に **`lines$`** を繋ぐと、内部で `\r` を行境界として扱うため **上書き表示が壊れる**ことがあります。独自区切りは **`receive$` 上で RxJS を合成**します（[高度な使用方法 — 行単位のフレーミング](./advanced-usage.md)）。
 
-**UI 用の接続 boolean** — フラグだけ必要な場合は `state$` から derive するか（[高度な使用方法](./advanced-usage.md#connected-boolean-ui-state-の-narrowing)）、`state.status === SerialSessionStatus.Connected` で narrowing してください。削除された convenience API は [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照してください。
+**UI 用の接続 boolean** — フラグだけ必要な場合は `state$` から derive するか（[高度な使用方法](./advanced-usage.md#接続中フラグ（-narrowing）)）、`state.status === SerialSessionStatus.Connected` で narrowing してください。削除された convenience API は [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照してください。
 
 **`lines$`（行区切り）** — 組み込みの行分割。ターミナルのミラーや `\r` を保持したいときは **`receive$`** を購読します（[高度な使用方法 — 行単位のフレーミング](./advanced-usage.md)）。
 

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -26,7 +26,7 @@
 
 ## 機能
 
-- **Session 指向のリアクティブ API**: 1 つの `SerialSession` が `state$`（canonical lifecycle discriminated union）/ `errors$`（error event channel）/ `receive$` / `lines$` と `connect$` / `disconnect$` / `dispose$` / `send$` を公開（`isConnected$` は v3.x で非推奨の convenience stream）
+- **Session 指向のリアクティブ API**: 1 つの `SerialSession` が `state$`（canonical lifecycle discriminated union）/ `errors$`（error event channel）/ `receive$` / `lines$` と `connect$` / `disconnect$` / `dispose$` / `send$` を公開
 - **UTF-8 テキストストリーム**: `receive$` は内部でストリーミング `TextDecoder` を用いてデコード済み。マルチバイト文字がチャンクにまたがっても正しく結合されます
 - **順序保証された送信キュー**: 並行する `send$` 呼び出しも内部キューで FIFO 処理され、呼び出し順に書き込まれます
 - **統一エラーチャネル**: すべての I/O エラーは `SerialError` に正規化され `errors$` に多重化されます
@@ -52,7 +52,6 @@
 | `state$` | **Canonical 接続ライフサイクル** — discriminated union（`status` + 必要に応じ `portInfo` / `error`）。購読時に現在値をリプレイ。分岐は **`SerialSessionStatus`** との比較を推奨。 |
 | `SerialSessionStatus` | **状態定数** — エクスポートされる const object（例: `SerialSessionStatus.Connected` → `'connected'`）。`state$.status` と比較する。 |
 | `SerialSessionState` | **`state$` の payload 型** — discriminated union。 |
-| `isConnected$` | **非推奨（convenience）** — `state$.status` が `SerialSessionStatus.Connected` のときだけ `true`。`state$` narrowing または derive を優先。 |
 | `receive$` | **生のデコードチャンク** — UTF-8 テキストを read pump が返すとおりに受け取る（行揃えではない。マルチバイト安全）。`\r` 等も保持。**ターミナル風の表示**や `\r` による上書き表示向け。 |
 | `terminalText$` | **ターミナル表示向けの累積テキスト** — `receive$` 由来の表示用テキスト。`\r` による上書きを折りたたみつつ通常の改行挙動は維持します。既定ではプレーンテキスト UI 向けに ANSI エスケープを除去します（生データは `receive$`）。ターミナル風ビューへ 1 つの文字列をそのままバインドしたい場合に使います。既定では完了行 10,000 行・文字数 1,048,576 文字まで保持します（`SerialSessionOptions.terminalBuffer` で変更可能）。 |
 | `lines$` | **行単位の受信** — `\n` / `\r\n` / 内部の `\r` など実装に従い 1 行ずつ emit。**ログ・1 行ごとの解析**向け。`\r` をそのまま残す必要がある raw ターミナル表示には向かない。 |
@@ -79,7 +78,7 @@
 
 **`receive$` と `lines$`:** 機器から来たバイト列を**そのまま**画面に反映する（シェル、`ls` のプログレス、`\r` で行を描き直す出力など）ときは **`receive$`** を使います。**改行区切りのログ**や**1 行ずつ処理するプロトコル**では **`lines$`** が適しています。ターミナル表示に **`lines$`** を繋ぐと、内部で `\r` を行境界として扱うため **上書き表示が壊れる**ことがあります。独自区切りは **`receive$` 上で RxJS を合成**します（[高度な使用方法 — 行単位のフレーミング](./advanced-usage.md)）。
 
-**`isConnected$`（非推奨 convenience）** — 読み取り専用の `Observable<boolean>` です。v3.x では後方互換のため残っていますが、次回 major version で削除予定です。boolean だけ欲しい UI 分岐では `state$` から derive するか、`state.status === SerialSessionStatus.Connected` で narrowing してください。詳細は [v3 移行ガイド](./migration-v3.md#6-isconnected-の非推奨化) を参照してください。
+**UI 用の接続 boolean** — フラグだけ必要な場合は `state$` から derive するか（[高度な使用方法](./advanced-usage.md#connected-boolean-ui-state-の-narrowing)）、`state.status === SerialSessionStatus.Connected` で narrowing してください。削除された convenience API は [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照してください。
 
 **`lines$`（行区切り）** — 組み込みの行分割。ターミナルのミラーや `\r` を保持したいときは **`receive$`** を購読します（[高度な使用方法 — 行単位のフレーミング](./advanced-usage.md)）。
 

--- a/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
@@ -2,7 +2,7 @@
 
 **最短で**シリアルポートを開き、行単位で受信し、送信・切断するところまで進む手順です。`state$` / `errors$` / `receive$` / `lines$` と各メソッドの一覧は、先に [SerialSession の概要](./overview.md#serialsessionの全体像)を参照してください。
 
-標準的な改行区切り（`\n` / `\r\n`）には **`lines$`** を使います。**`receive$`** はデコーダが返す生のチャンク列のままです。ライフサイクル UI には **`state$`** の `state.status` narrowing を優先してください。**`isConnected$`** は v3.x で非推奨です — `state$` から derive してください。
+標準的な改行区切り（`\n` / `\r\n`）には **`lines$`** を使います。**`receive$`** はデコーダが返す生のチャンク列のままです。ライフサイクル UI には **`state$`** の `state.status` narrowing を優先してください。boolean だけ必要な場合は `state$` から derive してください。**`connect$()`**、**`send$()`**、**`disconnect$()`**、**`dispose$()`** は購読により実行されます。
 
 ## インストール
 


### PR DESCRIPTION
## PR Title (Conventional Commits)
`docs(web-serial-rxjs): update docs for phase 1 removed apis`

## Summary
Phase 1 で削除済みの公開 API（`destroy$` / `isConnected$` / `portInfo$` / `getPortInfo()` / `getCurrentPort()`）を、README・ガイド・移行ガイドから「v3.x で利用可能」と誤認させる記載を取り除き、`state$` / `dispose$()` を正規 API として統一しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [x] Breaking change

## Related issues
- Fixes #478
- Related to #472

## What changed?
- ルート / package README（EN/JA）を正規 API（`state$` / `dispose$()` / `state.portInfo`）に合わせて更新
- guide EN/JA（overview / quick-start / advanced-usage / concepts / README）から削除 API を除去し、購読駆動を明記
- migration-v3 EN/JA の §4–§6 を「非推奨」から「削除」に書き換え、Phase 1 移行表を追加。§7 で `getCurrentPort()` に直接代替がない理由を補強
- migration-v2 の置換先を `session.isConnected$` から `state$` へ変更
- example-react / example-svelte README の「v2 SerialSession」表記を整理
- TypeDoc 向けの壊れたアンカーを修正し、`pnpm run docs` を確認

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: 本 PR では公開 API の追加・削除は行いません（#479 等で実施済み）。ドキュメントのみ更新です。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes:

    | 削除 API | 移行先 |
    | --- | --- |
    | `destroy$()` | `dispose$()` |
    | `isConnected$` | `state$` の `status`（または `state$` から derive） |
    | `portInfo$` | Connected 時の `state.portInfo` |
    | `getPortInfo()` | Connected 時の `state.portInfo` |
    | `getCurrentPort()` | 直接の代替なし。識別は `state.portInfo`。生の `SerialPort` は公開しない |

## How to test
1. リポジトリ検索で、削除 API の現行利用例が migration の before 例以外に残っていないことを確認
2. `pnpm run docs` が成功すること（link check 含む）
3. Quick Start / overview / package README が `state$` / `dispose$()` のみで構成されていることを目視確認
4. migration-v3 の Phase 1 節と §4–§7 の置換例を目視確認

## Environment (if relevant)
- Browser: N/A（ドキュメント更新）
- OS: macOS
- web-serial-rxjs version (for verification): branch `docs/web-serial-rxjs-phase1-removed-api-docs`
- RxJS version: workspace 依存どおり

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)