### PR TITLE
refactor(web-serial-rxjs): SerialSession からブラウザー対応判定を分離する

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -53,7 +53,7 @@ Web Serial API は**デスクトップ**ブラウザでのみサポートされ�
 
 **Safari** は現時点で Web Serial API をサポートしていません。
 
-`connect$` を呼ぶ前の feature detection には `SerialSession.isBrowserSupported()` が使えます（同期的に `boolean` を返します）。
+`connect$` を呼ぶ前の feature detection には `isWebSerialSupported()` が使えます（同期的に `boolean` を返します）。
 
 ## インストール
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Supported desktop browsers:
 
 **Safari** does not currently support the Web Serial API.
 
-`SerialSession.isBrowserSupported()` returns a synchronous boolean for feature detection before calling `connect$`.
+`isWebSerialSupported()` returns a synchronous boolean for feature detection before calling `connect$`.
 
 ## Installation
 

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -4,6 +4,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import {
+  isWebSerialSupported,
   SerialSessionStatus,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
@@ -24,7 +25,7 @@ export class App {
 
   private readonly serialService = inject(SerialClientService);
 
-  readonly browserSupported = this.serialService.isBrowserSupported();
+  readonly browserSupported = isWebSerialSupported();
   readonly state = toSignal(this.serialService.state$, {
     initialValue: {
       status: SerialSessionStatus.Idle,

--- a/apps/example-angular/src/app/services/serial-client.service.spec.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.spec.ts
@@ -21,7 +21,6 @@ interface MockCore {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
 const createMockCore = (): MockCore => {
@@ -34,10 +33,8 @@ const createMockCore = (): MockCore => {
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => true);
 
   const session: webSerialRxjs.SerialSession = {
-    isBrowserSupported,
     connect$,
     disconnect$,
     dispose$,
@@ -58,7 +55,6 @@ const createMockCore = (): MockCore => {
     disconnect$,
     dispose$,
     send$,
-    isBrowserSupported,
   };
 };
 
@@ -105,11 +101,6 @@ describe('SerialClientService', () => {
       vi.mocked(webSerialRxjs.createSerialSession),
     ).toHaveBeenCalledTimes(1);
     expect(service).toBeTruthy();
-  });
-
-  it('should expose browser support via the session', () => {
-    expect(service.isBrowserSupported()).toBe(true);
-    expect(latestMock().isBrowserSupported).toHaveBeenCalled();
   });
 
   it('should emit the initial idle state on state$', async () => {

--- a/apps/example-angular/src/app/services/serial-client.service.ts
+++ b/apps/example-angular/src/app/services/serial-client.service.ts
@@ -24,10 +24,6 @@ export class SerialClientService implements OnDestroy {
     this.controller.dispose();
   }
 
-  isBrowserSupported(): boolean {
-    return this.controller.isBrowserSupported();
-  }
-
   connect$(baudRate?: number): Observable<void> {
     return this.controller.connect$(baudRate);
   }

--- a/apps/example-react/README.md
+++ b/apps/example-react/README.md
@@ -26,7 +26,7 @@ This is a minimal React example for the `SerialSession` API (Web Serial). The `u
 
 ## Features
 
-- Browser support detection (`session.isBrowserSupported()`)
+- Browser support detection (`isWebSerialSupported()`)
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
@@ -78,7 +78,7 @@ pnpm exec nx lint example-react
 
 The example uses `createSerialSession` directly through `useSerialSession`:
 
-1. **Browser support check**: `useSerialSession` calls `session.isBrowserSupported()` once on mount and exposes the result as `browserSupported`.
+1. **Browser support check**: `useSerialSession` calls `isWebSerialSupported()` once on mount and exposes the result as `browserSupported`.
 2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`; when baud rate changes, the hook creates a new `SerialSession` with the selected baud rate and connects it.
 3. **State UI**: The hook subscribes to `session.state$` and derives `isConnected` from `state.status`. `App.tsx` branches on `state.status` with `SerialSessionStatus` for status text and uses `isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -22,7 +22,6 @@ interface MockSession {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
 const createMockSession = (): MockSession => {
@@ -34,10 +33,8 @@ const createMockSession = (): MockSession => {
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => true);
 
   const session: SerialSession = {
-    isBrowserSupported,
     connect$,
     disconnect$,
     dispose$,
@@ -59,7 +56,6 @@ const createMockSession = (): MockSession => {
     disconnect$,
     dispose$,
     send$,
-    isBrowserSupported,
   };
 };
 
@@ -72,6 +68,7 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     );
   return {
     ...actual,
+    isWebSerialSupported: vi.fn(() => true),
     createSerialSession: vi.fn(() => {
       const mock = createMockSession();
       mockSessions.push(mock);

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -26,10 +26,9 @@ interface MockCore {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockCore = (supported = true): MockCore => {
+const createMockCore = (): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
@@ -37,10 +36,8 @@ const createMockCore = (supported = true): MockCore => {
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => supported);
 
   const session: SerialSession = {
-    isBrowserSupported,
     connect$,
     disconnect$,
     dispose$,
@@ -61,7 +58,6 @@ const createMockCore = (supported = true): MockCore => {
     disconnect$,
     dispose$,
     send$,
-    isBrowserSupported,
   };
 };
 
@@ -75,8 +71,9 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     );
   return {
     ...actual,
+    isWebSerialSupported: vi.fn(() => nextSupported),
     createSerialSession: vi.fn(() => {
-      const mock = createMockCore(nextSupported);
+      const mock = createMockCore();
       mockCores.push(mock);
       return mock.session;
     }),
@@ -115,7 +112,7 @@ describe('useSerialSession', () => {
     ).toHaveBeenCalledWith({ baudRate: 9600 });
   });
 
-  it('browserSupported は session.isBrowserSupported() の結果を反映する', () => {
+  it('browserSupported は isWebSerialSupported() の結果を反映する', () => {
     nextSupported = false;
     const { result } = renderHook(() => useSerialSession());
     expect(result.current.browserSupported).toBe(false);

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,4 +1,5 @@
 import {
+  isWebSerialSupported,
   SerialSessionStatus,
   type SerialError,
   type SerialSessionState,
@@ -40,9 +41,7 @@ export function useSerialSession(
 
   ensureController(initialBaudRate);
 
-  const [browserSupported] = useState(() =>
-    (controllerRef.current as SerialSessionController).isBrowserSupported(),
-  );
+  const [browserSupported] = useState(() => isWebSerialSupported());
   const [state, setState] = useState<SerialSessionState>({
     status: SerialSessionStatus.Idle,
   });

--- a/apps/example-svelte/README.md
+++ b/apps/example-svelte/README.md
@@ -26,7 +26,7 @@ This is a minimal Svelte example for the `SerialSession` API. `useSerialSession`
 
 ## Features
 
-- Browser support detection (`session.isBrowserSupported()`)
+- Browser support detection (`isWebSerialSupported()`)
 - Reactive session lifecycle driven by `state$` (`idle | connecting | connected | disconnecting | unsupported | error`)
 - Configuration option (baud rate)
 - Send data to the serial port through the library-owned FIFO send queue
@@ -78,7 +78,7 @@ pnpm exec nx lint example-svelte
 
 The example uses `createSerialSession` directly through `useSerialSession`:
 
-1. **Browser support check**: `useSerialSession` calls `session.isBrowserSupported()` once at creation time and exposes the result as the `browserSupported` store.
+1. **Browser support check**: `useSerialSession` calls `isWebSerialSupported()` once at creation time and exposes the result as the `browserSupported` store.
 2. **Connection**: Clicking "接続" invokes `connect$(baudRate)`; when baud rate changes, the helper creates a new `SerialSession` with the selected baud rate and connects it.
 3. **State UI**: The helper subscribes to `session.state$` and derives `$isConnected` from `state.status`. `App.svelte` branches on `state.status` with `SerialSessionStatus` for status and uses `$isConnected` for button enablement.
 4. **Sending**: Calling `send$(data)` enqueues the payload through the library's internal FIFO send queue, preserving call order regardless of how many concurrent subscribers run.

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -25,10 +25,9 @@ interface MockCore {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockCore = (supported = true): MockCore => {
+const createMockCore = (): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
@@ -36,10 +35,8 @@ const createMockCore = (supported = true): MockCore => {
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => supported);
 
   const session: SerialSession = {
-    isBrowserSupported,
     connect$,
     disconnect$,
     dispose$,
@@ -60,7 +57,6 @@ const createMockCore = (supported = true): MockCore => {
     disconnect$,
     dispose$,
     send$,
-    isBrowserSupported,
   };
 };
 
@@ -85,8 +81,9 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     );
   return {
     ...actual,
+    isWebSerialSupported: vi.fn(() => nextSupported),
     createSerialSession: vi.fn(() => {
-      const mock = createMockCore(nextSupported);
+      const mock = createMockCore();
       mockCores.push(mock);
       return mock.session;
     }),
@@ -133,7 +130,7 @@ describe('useSerialSession', () => {
     ).toHaveBeenCalledWith({ baudRate: 9600 });
   });
 
-  it('browserSupported は session.isBrowserSupported() の結果を反映する', () => {
+  it('browserSupported は isWebSerialSupported() の結果を反映する', () => {
     nextSupported = false;
     const s = useSerialSession();
     expect(get(s.browserSupported)).toBe(false);

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,4 +1,5 @@
 import {
+  isWebSerialSupported,
   SerialSessionStatus,
   type SerialError,
   type SerialSessionState,
@@ -28,7 +29,7 @@ export function useSerialSession(
     initialBaudRate,
   });
 
-  const browserSupported = readable(controller.isBrowserSupported());
+  const browserSupported = readable(isWebSerialSupported());
 
   const state = readable<SerialSessionState>(
     { status: SerialSessionStatus.Idle },

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,4 +1,4 @@
-import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { isWebSerialSupported, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { createSerialSessionController } from '@gurezo/examples-shared';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
@@ -36,7 +36,7 @@ export class App {
     const receiveOutput = $('receive-output');
     this.controller = createSerialSessionController({ initialBaudRate: 9600 });
 
-    const supported = this.controller.isBrowserSupported();
+    const supported = isWebSerialSupported();
     setStatus(
       $('browser-support-status'),
       supported ? 'success' : 'error',

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -8,7 +8,6 @@ const createMockSession = () => {
   const receive$ = new Subject();
   const errors$ = new Subject();
   return {
-    isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
     disconnect$: vi.fn(() => of(undefined)),
     dispose$: vi.fn(() => of(undefined)),
@@ -26,6 +25,7 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
   const actual = await vi.importActual('@gurezo/web-serial-rxjs');
   return {
     ...actual,
+    isWebSerialSupported: vi.fn(() => true),
     createSerialSession: vi.fn(() => {
       const mock = createMockSession();
       mockSessions.push(mock);
@@ -79,7 +79,7 @@ describe('App', () => {
     });
   });
 
-  it('should render browser support status based on session.isBrowserSupported', () => {
+  it('should render browser support status based on isWebSerialSupported', () => {
     app = new App();
     const el = document.getElementById('browser-support-status');
     expect(el.textContent).toContain('Web Serial API');

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -4,7 +4,6 @@ import * as webSerialRxjs from '@gurezo/web-serial-rxjs';
 import { App } from './app.js';
 
 interface MockSession {
-  isBrowserSupported: ReturnType<typeof vi.fn>;
   connect$: ReturnType<typeof vi.fn>;
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
@@ -20,7 +19,6 @@ const createMockSession = (): MockSession => {
   const receive$ = new Subject<string>();
   const errors$ = new Subject<{ message: string }>();
   return {
-    isBrowserSupported: vi.fn(() => true),
     connect$: vi.fn(() => of(undefined)),
     disconnect$: vi.fn(() => of(undefined)),
     dispose$: vi.fn(() => of(undefined)),
@@ -40,6 +38,7 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
   );
   return {
     ...actual,
+    isWebSerialSupported: vi.fn(() => true),
     createSerialSession: vi.fn(() => {
       const mock = createMockSession();
       mockSessions.push(mock);
@@ -93,7 +92,7 @@ describe('App', () => {
     });
   });
 
-  it('should render browser support status based on session.isBrowserSupported', () => {
+  it('should render browser support status based on isWebSerialSupported', () => {
     app = new App();
     const el = document.getElementById('browser-support-status');
     expect(el?.textContent).toContain('Web Serial API');

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,4 +1,5 @@
 import {
+  isWebSerialSupported,
   SerialSessionStatus,
   type SerialSessionStatus as SerialSessionStatusType,
 } from '@gurezo/web-serial-rxjs';
@@ -46,7 +47,7 @@ export class App {
     const sendBtn = $<HTMLButtonElement>('send-btn');
     const receiveOutput = $<HTMLTextAreaElement>('receive-output');
 
-    const supported = this.controller.isBrowserSupported();
+    const supported = isWebSerialSupported();
     setStatus(
       $<HTMLElement>('browser-support-status'),
       supported ? 'success' : 'error',

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -22,7 +22,6 @@ interface MockSession {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
 const createMockSession = (): MockSession => {
@@ -42,10 +41,8 @@ const createMockSession = (): MockSession => {
   });
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => true);
 
   const session: SerialSession = {
-    isBrowserSupported,
     connect$,
     disconnect$,
     dispose$,
@@ -67,7 +64,6 @@ const createMockSession = (): MockSession => {
     disconnect$,
     dispose$,
     send$,
-    isBrowserSupported,
   };
 };
 
@@ -80,6 +76,7 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     );
   return {
     ...actual,
+    isWebSerialSupported: vi.fn(() => true),
     createSerialSession: vi.fn(() => {
       const mock = createMockSession();
       mockSessions.push(mock);

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -25,10 +25,9 @@ interface MockCore {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockCore = (supported = true): MockCore => {
+const createMockCore = (): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
@@ -36,10 +35,8 @@ const createMockCore = (supported = true): MockCore => {
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => supported);
 
   const session: SerialSession = {
-    isBrowserSupported,
     connect$,
     disconnect$,
     dispose$,
@@ -60,7 +57,6 @@ const createMockCore = (supported = true): MockCore => {
     disconnect$,
     dispose$,
     send$,
-    isBrowserSupported,
   };
 };
 
@@ -74,8 +70,9 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
     );
   return {
     ...actual,
+    isWebSerialSupported: vi.fn(() => nextSupported),
     createSerialSession: vi.fn(() => {
-      const mock = createMockCore(nextSupported);
+      const mock = createMockCore();
       mockCores.push(mock);
       return mock.session;
     }),
@@ -137,7 +134,7 @@ describe('useSerialClient', () => {
     expect(api.errorMessage.value).toBe(null);
   });
 
-  it('browserSupported reflects isBrowserSupported when unsupported', () => {
+  it('browserSupported reflects isWebSerialSupported when unsupported', () => {
     nextSupported = false;
     const { api } = mountHarness();
     expect(api.browserSupported.value).toBe(false);

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,4 +1,5 @@
 import {
+  isWebSerialSupported,
   SerialSessionStatus,
   type SerialError,
   type SerialSessionState,
@@ -25,7 +26,7 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     initialBaudRate,
   });
 
-  const browserSupported = ref(controller.isBrowserSupported());
+  const browserSupported = ref(isWebSerialSupported());
   const state = ref<SerialSessionState>({ status: SerialSessionStatus.Idle });
   const isConnected = ref(false);
   const receivedData = ref('');

--- a/libs/examples-shared/src/create-serial-session-controller.spec.ts
+++ b/libs/examples-shared/src/create-serial-session-controller.spec.ts
@@ -24,10 +24,9 @@ interface MockCore {
   disconnect$: ReturnType<typeof vi.fn>;
   dispose$: ReturnType<typeof vi.fn>;
   send$: ReturnType<typeof vi.fn>;
-  isBrowserSupported: ReturnType<typeof vi.fn>;
 }
 
-const createMockCore = (supported = true): MockCore => {
+const createMockCore = (): MockCore => {
   const stateSubject = new BehaviorSubject<SerialSessionState>({ status: SS.Idle });
   const receiveSubject = new Subject<string>();
   const errorsSubject = new Subject<SerialError>();
@@ -35,10 +34,8 @@ const createMockCore = (supported = true): MockCore => {
   const disconnect$ = vi.fn(() => of(undefined));
   const dispose$ = vi.fn(() => of(undefined));
   const send$ = vi.fn(() => of(undefined));
-  const isBrowserSupported = vi.fn(() => supported);
 
   const session: SerialSession = {
-    isBrowserSupported,
     connect$,
     disconnect$,
     dispose$,
@@ -60,12 +57,10 @@ const createMockCore = (supported = true): MockCore => {
     disconnect$,
     dispose$,
     send$,
-    isBrowserSupported,
   };
 };
 
 let mockCores: MockCore[] = [];
-let nextSupported = true;
 
 vi.mock('@gurezo/web-serial-rxjs', async () => {
   const actual =
@@ -75,7 +70,7 @@ vi.mock('@gurezo/web-serial-rxjs', async () => {
   return {
     ...actual,
     createSerialSession: vi.fn(() => {
-      const mock = createMockCore(nextSupported);
+      const mock = createMockCore();
       mockCores.push(mock);
       return mock.session;
     }),
@@ -91,7 +86,6 @@ const latestMock = (): MockCore => {
 describe('createSerialSessionController', () => {
   beforeEach(() => {
     mockCores = [];
-    nextSupported = true;
   });
 
   afterEach(() => {
@@ -103,12 +97,6 @@ describe('createSerialSessionController', () => {
     expect(
       vi.mocked(webSerialRxjs.createSerialSession),
     ).toHaveBeenCalledWith({ baudRate: 9600 });
-  });
-
-  it('isBrowserSupported は session の結果を返す', () => {
-    nextSupported = false;
-    const controller = createSerialSessionController();
-    expect(controller.isBrowserSupported()).toBe(false);
   });
 
   it('state$ / terminalText$ / errors$ を配信する', () => {

--- a/libs/examples-shared/src/create-serial-session-controller.ts
+++ b/libs/examples-shared/src/create-serial-session-controller.ts
@@ -28,7 +28,6 @@ export interface SerialSessionController {
   readonly terminalText$: Observable<string>;
   readonly errors$: Observable<SerialError>;
   readonly receive$: Observable<string>;
-  isBrowserSupported(): boolean;
   connect$(baudRate?: SerialConnectionOptions['baudRate']): Observable<void>;
   disconnect$(): Observable<void>;
   send$(data: SerialPayload): Observable<void>;
@@ -109,7 +108,6 @@ export function createSerialSessionController(
     terminalText$,
     errors$,
     receive$,
-    isBrowserSupported: () => currentSession.isBrowserSupported(),
     connect$,
     disconnect$,
     send$,

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -19,7 +19,7 @@ Web Serial API は**デスクトップ**ブラウザでのみサポートされ�
 
 **Safari** は現時点で Web Serial API をサポートしていません。
 
-`connect$` の前の feature detection には `SerialSession.isBrowserSupported()`（同期的に `boolean`）を使います。
+`connect$` の前の feature detection には `isWebSerialSupported()`（同期的に `boolean`）を使います。
 
 ## 接続状態（ライフサイクル UI）
 

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -19,7 +19,7 @@ Supported desktop browsers:
 
 **Safari** does not currently support the Web Serial API.
 
-`SerialSession.isBrowserSupported()` returns a synchronous `boolean` for feature detection before `connect$`.
+`isWebSerialSupported()` returns a synchronous `boolean` for feature detection before `connect$`.
 
 ## Connection state (lifecycle UI)
 

--- a/packages/web-serial-rxjs/docs/guide/en/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/en/concepts.md
@@ -10,6 +10,7 @@ The public surface consists of a single factory (`createSerialSession`), the run
 ```typescript
 import {
   createSerialSession,
+  isWebSerialSupported,
   createTerminalBuffer,
   DEFAULT_TERMINAL_BUFFER_OPTIONS,
   SerialError,
@@ -182,8 +183,6 @@ See [Migrating to v3](./migration-v3.md) for the v2 string migration.
 
 ```typescript
 interface SerialSession {
-  isBrowserSupported(): boolean;
-
   connect$(): Observable<void>;
   disconnect$(): Observable<void>;
   dispose$(): Observable<void>;
@@ -198,7 +197,7 @@ interface SerialSession {
 }
 ```
 
-### `isBrowserSupported(): boolean`
+### `isWebSerialSupported(): boolean`
 
 Synchronous feature check. Returns `true` when `navigator.serial` is available.
 

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -66,7 +66,7 @@ This library is framework-agnostic and can be used with:
 | `disconnect$()` | **Close** the port and stop the pump. The session stays reusable (`idle`). |
 | `dispose$()` | **Permanently tear down** the session: close any active connection, complete all observables, and prevent reuse. |
 | `send$(string \| Uint8Array)` | **Enqueue** outgoing data; writes are **FIFO-ordered** when multiple `send$` run concurrently. |
-| `isBrowserSupported()` | Synchronous `boolean` for Web Serial availability before `connect$`. |
+| `isWebSerialSupported()` | Synchronous `boolean` for Web Serial availability before `connect$`. |
 
 ### SerialSessionStatus (quick reference)
 
@@ -91,12 +91,16 @@ Each `state$` emission has a `status` field. Prefer the **const object** (e.g. `
 ### Minimal example
 
 ```typescript
-import { createSerialSession, isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+import {
+  createSerialSession,
+  isConnectedSessionState,
+  isWebSerialSupported,
+} from '@gurezo/web-serial-rxjs';
 import { filter } from 'rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
 
-if (!session.isBrowserSupported()) {
+if (!isWebSerialSupported()) {
   throw new Error('Web Serial is not available in this browser');
 }
 

--- a/packages/web-serial-rxjs/docs/guide/en/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/en/quick-start.md
@@ -43,11 +43,11 @@ For monorepo-wide browser support and example app index, see the [repository REA
 Details: [API concepts and design notes](./concepts.md#serialsessionstate--serialsessionstatus) and [Migrating to v3](./migration-v3.md).
 
 ```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
+import { createSerialSession, isWebSerialSupported } from '@gurezo/web-serial-rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
 
-if (!session.isBrowserSupported()) {
+if (!isWebSerialSupported()) {
   console.error('Web Serial API is not supported in this browser');
 }
 

--- a/packages/web-serial-rxjs/docs/guide/ja/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/concepts.md
@@ -10,6 +10,7 @@
 ```typescript
 import {
   createSerialSession,
+  isWebSerialSupported,
   createTerminalBuffer,
   DEFAULT_TERMINAL_BUFFER_OPTIONS,
   SerialError,
@@ -182,8 +183,6 @@ v2 からの移行は [v3 移行ガイド](./migration-v3.md) を参照してく
 
 ```typescript
 interface SerialSession {
-  isBrowserSupported(): boolean;
-
   connect$(): Observable<void>;
   disconnect$(): Observable<void>;
   dispose$(): Observable<void>;
@@ -198,7 +197,7 @@ interface SerialSession {
 }
 ```
 
-### `isBrowserSupported(): boolean`
+### `isWebSerialSupported(): boolean`
 
 同期的な feature detection。`navigator.serial` が存在すれば `true` を返します。
 

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -60,7 +60,7 @@
 | `disconnect$()` | ポートを閉じ、pump を停止。セッションは `idle` に戻り再利用可能。 |
 | `dispose$()` | セッションを**永久破棄**。接続を閉じ、すべての Observable を complete し、再利用不可にする。 |
 | `send$(string \| Uint8Array)` | 送信を **FIFO** で直列化（並行 `send$` も呼び出し順）。 |
-| `isBrowserSupported()` | `connect$` の前に使う、Web Serial 利用可否の同期的な `boolean`。 |
+| `isWebSerialSupported()` | `connect$` の前に使う、Web Serial 利用可否の同期的な `boolean`。 |
 
 ### SerialSessionStatus（早見表）
 
@@ -85,12 +85,16 @@
 ### 最小サンプル
 
 ```typescript
-import { createSerialSession, isConnectedSessionState } from '@gurezo/web-serial-rxjs';
+import {
+  createSerialSession,
+  isConnectedSessionState,
+  isWebSerialSupported,
+} from '@gurezo/web-serial-rxjs';
 import { filter } from 'rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
 
-if (!session.isBrowserSupported()) {
+if (!isWebSerialSupported()) {
   throw new Error('このブラウザでは Web Serial を利用できません');
 }
 

--- a/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
@@ -43,11 +43,11 @@ pnpm add rxjs
 詳細は [概念と設計メモ](./concepts.md#serialsessionstate--serialsessionstatus) と [v3 移行ガイド](./migration-v3.md) を参照してください。
 
 ```typescript
-import { createSerialSession } from '@gurezo/web-serial-rxjs';
+import { createSerialSession, isWebSerialSupported } from '@gurezo/web-serial-rxjs';
 
 const session = createSerialSession({ baudRate: 115200 });
 
-if (!session.isBrowserSupported()) {
+if (!isWebSerialSupported()) {
   console.error('このブラウザは Web Serial API をサポートしていません');
 }
 

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -45,7 +45,7 @@
  *
  * **Safari** does not currently support the Web Serial API.
  *
- * Use {@link SerialSession.isBrowserSupported} for a synchronous feature
+ * Use {@link isWebSerialSupported} for a synchronous feature
  * check before calling {@link SerialSession.connect$}.
  *
  * @example
@@ -53,6 +53,7 @@
  * import { filter } from 'rxjs';
  * import {
  *   createSerialSession,
+ *   isWebSerialSupported,
  *   isConnectedSessionState,
  *   SerialSessionStatus,
  *   SerialErrorCode,
@@ -60,7 +61,7 @@
  *
  * const session = createSerialSession({ baudRate: 115200 });
  *
- * if (!session.isBrowserSupported()) {
+ * if (!isWebSerialSupported()) {
  *   console.error('Web Serial API is not supported in this browser');
  * } else {
  *   session.state$.subscribe((state) => {
@@ -88,7 +89,7 @@
 
 export { assertNever } from './internal/assert-never';
 
-export { createSerialSession, SerialSessionStatus, isConnectedSessionState, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions } from './session';
+export { createSerialSession, isWebSerialSupported, SerialSessionStatus, isConnectedSessionState, DEFAULT_LINE_BUFFER_OPTIONS, resolveSerialSessionOptions } from './session';
 export type {
   SerialSession,
   SerialSessionState,

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -3,7 +3,7 @@ import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import { createTerminalBuffer } from '../terminal/create-terminal-buffer';
 import type { SerialPayload } from '../types';
-import { hasWebSerialSupport } from './internal/has-web-serial-support';
+import { isWebSerialSupported } from './internal/has-web-serial-support';
 import { createPortTeardown } from './internal/port-teardown';
 import { createReceivePipeline } from './internal/receive-pipeline';
 import { createSessionErrorReporter } from './internal/session-error-reporter';
@@ -32,7 +32,6 @@ import {
  *
  * Key behaviors:
  *
- * - `isBrowserSupported()` returns whether `navigator.serial` is available.
  * - `state$` replays the current lifecycle state driven by the internal
  *   {@link SessionRuntime} controller.
  * - `connect$()` opens a user-selected port, starts the internal read pump,
@@ -75,7 +74,7 @@ export function createSerialSession(
   const resolvedOptions = resolveSerialSessionOptions(options);
 
   const controller = createSessionRuntimeController(
-    createInitialRuntime(hasWebSerialSupport()),
+    createInitialRuntime(isWebSerialSupported()),
   );
   const errorsSubject = new Subject<SerialError>();
   const sendQueue = createSendQueue();
@@ -126,9 +125,6 @@ export function createSerialSession(
   ).text$;
 
   return {
-    isBrowserSupported(): boolean {
-      return hasWebSerialSupport();
-    },
     connect$: lifecycle.connect$,
     disconnect$: lifecycle.disconnect$,
     dispose$: lifecycle.dispose$,

--- a/packages/web-serial-rxjs/src/session/index.ts
+++ b/packages/web-serial-rxjs/src/session/index.ts
@@ -1,4 +1,5 @@
 export { createSerialSession } from './create-serial-session';
+export { isWebSerialSupported } from './internal/has-web-serial-support';
 export type { SerialSession } from './serial-session';
 export type {
   SerialSessionOptions,

--- a/packages/web-serial-rxjs/src/session/internal/has-web-serial-support.ts
+++ b/packages/web-serial-rxjs/src/session/internal/has-web-serial-support.ts
@@ -1,14 +1,11 @@
 /**
- * Internal feature detection for the Web Serial API.
+ * Synchronous feature detection for the Web Serial API.
  *
- * This helper is intentionally kept package-private: the v2 public API
- * exposes browser support only through {@link SerialSession.isBrowserSupported}.
+ * This helper is SSR-safe: it returns `false` when `navigator` is not available.
  *
  * @returns `true` when `navigator.serial` is available.
- *
- * @internal
  */
-export function hasWebSerialSupport(): boolean {
+export function isWebSerialSupported(): boolean {
   return (
     typeof navigator !== 'undefined' &&
     'serial' in navigator &&

--- a/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
+++ b/packages/web-serial-rxjs/src/session/internal/session-lifecycle.ts
@@ -2,7 +2,7 @@ import { Observable, type Subject } from 'rxjs';
 import { SerialError } from '../../errors/serial-error';
 import { SerialErrorCode } from '../../errors/serial-error-code';
 import { buildRequestOptions } from './build-request-options';
-import { hasWebSerialSupport } from './has-web-serial-support';
+import { isWebSerialSupported } from './has-web-serial-support';
 import type { ReceivePipeline } from './receive-pipeline';
 import {
   normalizeSerialError,
@@ -167,7 +167,7 @@ export function createSessionLifecycle(
         return;
       }
 
-      if (!hasWebSerialSupport()) {
+      if (!isWebSerialSupported()) {
         const error = reportError(
           new SerialError(
             SerialErrorCode.BROWSER_NOT_SUPPORTED,

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -45,15 +45,6 @@ import type { SerialSessionState } from './serial-session-state';
  */
 export interface SerialSession {
   /**
-   * Synchronous feature detection for the Web Serial API.
-   *
-   * Never throws; intended for UI branching before calling `connect$`.
-   *
-   * @returns `true` when `navigator.serial` is available.
-   */
-  isBrowserSupported(): boolean;
-
-  /**
    * Open a serial port and start the internal read pump.
    *
    * Returns an Observable that completes when the port is fully opened and

--- a/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
+++ b/packages/web-serial-rxjs/tests/session/create-serial-session.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { SerialError } from '../../src/errors/serial-error';
 import { SerialErrorCode } from '../../src/errors/serial-error-code';
 import { createSerialSession } from '../../src/session/create-serial-session';
+import { isWebSerialSupported } from '../../src/session';
 import type { SerialSession } from '../../src/session/serial-session';
 import {
   SerialSessionStatus,
@@ -134,7 +135,6 @@ describe('createSerialSession', () => {
     it('returns an object that satisfies the SerialSession contract', () => {
       const session: SerialSession = createSerialSession();
 
-      expect(typeof session.isBrowserSupported).toBe('function');
       expect(typeof session.connect$).toBe('function');
       expect(typeof session.disconnect$).toBe('function');
       expect(typeof session.dispose$).toBe('function');
@@ -153,28 +153,22 @@ describe('createSerialSession', () => {
     });
   });
 
-  describe('isBrowserSupported', () => {
+  describe('isWebSerialSupported', () => {
     it('returns true when navigator.serial is present', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Testing: Mock navigator
       (globalThis as any).navigator = { serial: {} };
 
-      const session = createSerialSession();
-
-      expect(session.isBrowserSupported()).toBe(true);
+      expect(isWebSerialSupported()).toBe(true);
     });
 
     it('returns false when navigator.serial is missing', () => {
       installUnsupportedNavigator();
 
-      const session = createSerialSession();
-
-      expect(session.isBrowserSupported()).toBe(false);
+      expect(isWebSerialSupported()).toBe(false);
     });
 
     it('returns false when navigator is undefined', () => {
-      const session = createSerialSession();
-
-      expect(session.isBrowserSupported()).toBe(false);
+      expect(isWebSerialSupported()).toBe(false);
     });
   });
 


### PR DESCRIPTION
## PR Title (Conventional Commits)
refactor(web-serial-rxjs): SerialSession からブラウザー対応判定を分離する

## Summary
`SerialSession.isBrowserSupported()` を削除し、トップレベル関数 `isWebSerialSupported()` にブラウザー対応判定を統一しました。これにより、セッション生成前の判定とセッション初期状態 (`unsupported`) が同一ロジックで扱えるようになり、API の責務を明確化しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [x] Breaking change

## Related issues
- Fixes #487
- Related to #485

## What changed?
- `SerialSession` から `isBrowserSupported()` を削除し、`isWebSerialSupported()` を公開 export に追加
- セッション初期状態判定と `connect$` の未対応判定を `isWebSerialSupported()` へ統一
- `examples-shared` の controller から `isBrowserSupported` 委譲を削除
- React / Vue / Svelte / Angular / Vanilla の各 example と関連テストを `isWebSerialSupported()` 利用へ移行
- README / guide（en/ja）を新 API に更新（`migration-v2` は履歴として維持）

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details:
    - 追加: `isWebSerialSupported(): boolean`
    - 削除: `SerialSession.isBrowserSupported(): boolean`
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes:
    - `session.isBrowserSupported()` は `isWebSerialSupported()` に置き換えてください
    - セッション利用画面では `state$` の `SerialSessionStatus.Unsupported` 判定も継続して利用できます

BREAKING CHANGE: SerialSession.isBrowserSupported() is removed.
Use isWebSerialSupported() for synchronous browser support detection.

## How to test
1. `pnpm nx run-many -t test --projects=examples-shared,example-react,example-vue,example-svelte,example-angular,example-vanilla-ts,example-vanilla-js`
2. `pnpm nx run web-serial-rxjs:lint`
3. `pnpm nx run web-serial-rxjs:test`
4. `pnpm nx run web-serial-rxjs:build`

## Environment (if relevant)
- Browser: N/A（unit/integration tests）
- OS: macOS
- web-serial-rxjs version (for verification): branch `refactor/web-serial-rxjs-extract-is-web-serial-supported`
- RxJS version: workspace 既定

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)