### PR TITLE
refactor(web-serial-rxjs): reorganize SerialSessionOptions responsibilities

### DIFF
--- a/packages/web-serial-rxjs/docs/guide/en/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/en/concepts.md
@@ -61,7 +61,14 @@ function createSerialSession(options?: SerialSessionOptions): SerialSession;
 SerialSessionOptions = Partial<SerialConnectionOptions> & SerialSessionFeatureOptions
 ```
 
+Minimal callers typically only set `baudRate`; other fields keep safe defaults.
+
+```typescript
+const session = createSerialSession({ baudRate: 115200 });
+```
+
 See [Migrating to v3 – §10 Session options type responsibility audit](./migration-v3.md#10-session-options-type-responsibility-audit) for the audit rationale.
+See also [Issue #488](https://github.com/gurezo/web-serial-rxjs/issues/488) for the Phase 2 options responsibility cleanup.
 
 ### Connection options (`SerialConnectionOptions`)
 
@@ -69,11 +76,11 @@ Derived from W3C `SerialOptions` and passed to `port.open`. All fields are optio
 
 | Field         | Type                                | Default  | Description                                                       |
 | ------------- | ----------------------------------- | -------- | ----------------------------------------------------------------- |
-| `baudRate`    | `number`                            | `9600`   | Bits per second.                                                  |
+| `baudRate`    | `number`                            | `9600`   | Bits per second. Must be a safe integer `> 0`.                    |
 | `dataBits`    | `7 \| 8`                            | `8`      | Data bits per frame.                                              |
 | `stopBits`    | `1 \| 2`                            | `1`      | Stop bits per frame.                                              |
 | `parity`      | `'none' \| 'even' \| 'odd'`         | `'none'` | Parity checking mode.                                             |
-| `bufferSize`  | `number`                            | `255`    | Read-stream buffer size in bytes.                                 |
+| `bufferSize`  | `number`                            | `255`    | Read-stream buffer size in bytes. Must be a safe integer `> 0`.   |
 | `flowControl` | `'none' \| 'hardware'`              | `'none'` | Flow control mode.                                                |
 
 ### Session feature options (`SerialSessionFeatureOptions`)
@@ -91,13 +98,24 @@ At `createSerialSession` time (factory), `resolveSerialSessionOptions` validates
 | Target | Validation | Error code |
 | --- | --- | --- |
 | `baudRate` | safe integer and `> 0` | `INVALID_CONNECTION_OPTIONS` |
+| `bufferSize` | safe integer and `> 0` | `INVALID_CONNECTION_OPTIONS` |
 | `filters` | USB vendor/product ID ranges | `INVALID_FILTER_OPTIONS` |
 | `terminalBuffer` | `maxLines` / `maxChars` are safe integers and `>= 0` | `INVALID_TERMINAL_BUFFER_OPTIONS` |
 | `lineBuffer` | `maxChars` is a safe integer and `>= 0` | `INVALID_LINE_BUFFER_OPTIONS` |
 
+#### Numeric boundary semantics
+
+| Value | Connection (`baudRate` / `bufferSize`) | Buffer limits (`terminalBuffer` / `lineBuffer`) |
+| --- | --- | --- |
+| `undefined` | Apply default | Apply nested default |
+| `0` | **Rejected** | **Unlimited** (disable that limit) |
+| negative / non-integer / `NaN` / `Infinity` | Rejected | Rejected |
+
+Do not mix meanings: `0` is never “unlimited” for connection fields.
+
 ### `TerminalBufferOptions`
 
-Used by `createTerminalBuffer` and `SerialSessionOptions.terminalBuffer`. When a limit is exceeded, the **oldest** completed lines or leading characters are dropped so long-running terminal views do not grow without bound. Pass `0` for either field to disable that constraint.
+Used by `createTerminalBuffer` and `SerialSessionOptions.terminalBuffer`. When a limit is exceeded, the **oldest** completed lines or leading characters are dropped so long-running terminal views do not grow without bound. Pass `0` for either field to disable that constraint. Character counts use UTF-16 string length (JavaScript `.length`).
 
 | Field      | Type     | Default    | Description |
 | ---------- | -------- | ---------- | ----------- |
@@ -105,11 +123,11 @@ Used by `createTerminalBuffer` and `SerialSessionOptions.terminalBuffer`. When a
 | `maxChars` | `number` | `1048576`  | Max total characters in the display text (`completed` + current line). |
 | `stripAnsi` | `boolean` | `true` | When `true`, removes ANSI escape sequences before folding `\r` redraws. Set `false` to preserve raw escape codes in `terminalText$`. `receive$` is always unchanged. |
 
-Invalid `maxLines` or `maxChars` values cause `createSerialSession` to throw `SerialError` with `INVALID_TERMINAL_BUFFER_OPTIONS`.
+Invalid `maxLines` or `maxChars` values cause `createSerialSession` and standalone `createTerminalBuffer` to throw `SerialError` with `INVALID_TERMINAL_BUFFER_OPTIONS`.
 
 ### `LineBufferOptions`
 
-Used by `SerialSessionOptions.lineBuffer` for the **incomplete line tail** held while framing `lines$`. When `maxChars` is exceeded, **leading** characters of the tail are discarded and a non-fatal `SerialError` with `SerialErrorCode.LINE_BUFFER_OVERFLOW` is emitted on `errors$`. Completed lines are emitted in full before the tail is trimmed. Pass `0` to disable the limit.
+Used by `SerialSessionOptions.lineBuffer` for the **incomplete line tail** held while framing `lines$`. When `maxChars` is exceeded, **leading** characters of the tail are discarded and a non-fatal `SerialError` with `SerialErrorCode.LINE_BUFFER_OVERFLOW` is emitted on `errors$`. Completed lines are emitted in full before the tail is trimmed. Pass `0` to disable the limit. Character counts use UTF-16 string length.
 
 | Field      | Type     | Default    | Description |
 | ---------- | -------- | ---------- | ----------- |
@@ -119,7 +137,7 @@ Invalid `maxChars` values cause `createSerialSession` to throw `SerialError` wit
 
 ## createTerminalBuffer(receive$, options?)
 
-Builds a terminal-oriented cumulative text stream from any `Observable<string>` of decoded chunks (typically `SerialSession.receive$`). Folds `\r` redraws while preserving normal newline behavior. Defaults match `DEFAULT_TERMINAL_BUFFER_OPTIONS`.
+Builds a terminal-oriented cumulative text stream from any `Observable<string>` of decoded chunks (typically `SerialSession.receive$`). Folds `\r` redraws while preserving normal newline behavior. Defaults match `DEFAULT_TERMINAL_BUFFER_OPTIONS`. Invalid `maxLines` / `maxChars` throw the same `INVALID_TERMINAL_BUFFER_OPTIONS` error as session factory validation.
 
 ```typescript
 function createTerminalBuffer(

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v2.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v2.md
@@ -144,7 +144,7 @@ async function query(
 
 `SerialSessionOptions` mirrors the fields of `SerialClientOptions` (`baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`, `filters`) and uses the same defaults (`9600`, `8`, `1`, `'none'`, `255`, `'none'`).
 
-At `createSerialSession` factory time, `resolveSerialSessionOptions` validates `filters`, `baudRate`, `receiveReplay`, `terminalBuffer`, and `lineBuffer`. Invalid values throw `SerialError` (for example `SerialErrorCode.INVALID_FILTER_OPTIONS`).
+At `createSerialSession` factory time, `resolveSerialSessionOptions` validates `filters`, `baudRate`, `bufferSize`, `terminalBuffer`, and `lineBuffer`. Invalid values throw `SerialError` (for example `SerialErrorCode.INVALID_FILTER_OPTIONS`).
 
 ## Framework examples
 

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
@@ -559,10 +559,10 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 ```
 
 - `SerialConnectionOptions` — `baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl` (passed to `port.open`)
-- `SerialSessionFeatureOptions` — `filters`, `receiveReplay`, `terminalBuffer`, `lineBuffer` (library-specific)
+- `SerialSessionFeatureOptions` — `filters`, `terminalBuffer`, `lineBuffer` (library-specific; `receiveReplay` was removed in v4 Phase 2)
 - `SerialSessionOptions` — composition of the two (factory argument)
 
-See [API Reference – SerialSessionOptions](./concepts.md#serialsessionoptions) for details.
+See [API Reference – SerialSessionOptions](./concepts.md#serialsessionoptions) for details. Boundary semantics (`0` = unlimited for buffer limits only; connection fields require `> 0`) are documented there ([#488](https://github.com/gurezo/web-serial-rxjs/issues/488)).
 
 ### v3.x compatibility
 

--- a/packages/web-serial-rxjs/docs/guide/ja/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/concepts.md
@@ -61,7 +61,14 @@ function createSerialSession(options?: SerialSessionOptions): SerialSession;
 SerialSessionOptions = Partial<SerialConnectionOptions> & SerialSessionFeatureOptions
 ```
 
+最小構成では通常 `baudRate` だけで十分です。他のフィールドは安全な既定値が適用されます。
+
+```typescript
+const session = createSerialSession({ baudRate: 115200 });
+```
+
 詳細は [v3 への移行 – §10 Session options 型責務監査](./migration-v3.md#10-session-options-型責務監査) を参照してください。
+Phase 2 のオプション責務整理は [Issue #488](https://github.com/gurezo/web-serial-rxjs/issues/488) も参照してください。
 
 ### Connection options（`SerialConnectionOptions`）
 
@@ -69,11 +76,11 @@ W3C `SerialOptions` から派生し、`port.open` に渡されます。factory �
 
 | フィールド    | 型                                  | 既定値    | 説明                                                                         |
 | ------------- | ----------------------------------- | --------- | ---------------------------------------------------------------------------- |
-| `baudRate`    | `number`                            | `9600`    | ボーレート（bps）                                                            |
+| `baudRate`    | `number`                            | `9600`    | ボーレート（bps）。safe integer かつ `> 0`                                   |
 | `dataBits`    | `7 \| 8`                            | `8`       | データビット                                                                 |
 | `stopBits`    | `1 \| 2`                            | `1`       | ストップビット                                                               |
 | `parity`      | `'none' \| 'even' \| 'odd'`         | `'none'`  | パリティ                                                                     |
-| `bufferSize`  | `number`                            | `255`     | リードストリームのバッファサイズ（バイト）                                   |
+| `bufferSize`  | `number`                            | `255`     | リードストリームのバッファサイズ（バイト）。safe integer かつ `> 0`          |
 | `flowControl` | `'none' \| 'hardware'`              | `'none'`  | フロー制御                                                                   |
 
 ### Session feature options（`SerialSessionFeatureOptions`）
@@ -91,13 +98,24 @@ W3C `SerialOptions` から派生し、`port.open` に渡されます。factory �
 | 対象 | 検証内容 | エラーコード |
 | --- | --- | --- |
 | `baudRate` | safe integer かつ `> 0` | `INVALID_CONNECTION_OPTIONS` |
+| `bufferSize` | safe integer かつ `> 0` | `INVALID_CONNECTION_OPTIONS` |
 | `filters` | USB vendor/product ID の範囲 | `INVALID_FILTER_OPTIONS` |
 | `terminalBuffer` | `maxLines` / `maxChars` が safe integer かつ `>= 0` | `INVALID_TERMINAL_BUFFER_OPTIONS` |
 | `lineBuffer` | `maxChars` が safe integer かつ `>= 0` | `INVALID_LINE_BUFFER_OPTIONS` |
 
+#### 数値境界値の意味
+
+| 値 | 接続（`baudRate` / `bufferSize`） | バッファ上限（`terminalBuffer` / `lineBuffer`） |
+| --- | --- | --- |
+| `undefined` | 既定値を適用 | ネスト側の既定値を適用 |
+| `0` | **拒否** | **無制限**（その制限を無効化） |
+| 負数 / 非整数 / `NaN` / `Infinity` | 拒否 | 拒否 |
+
+接続フィールドで `0` を無制限と解釈しないでください。
+
 ### `TerminalBufferOptions`
 
-`createTerminalBuffer` と `SerialSessionOptions.terminalBuffer` で使います。上限を超えたときは、**古い**完了行や先頭の文字から破棄し、長時間のターミナル表示でメモリが際限なく増えないようにします。`0` を指定するとその制限を無効化します。
+`createTerminalBuffer` と `SerialSessionOptions.terminalBuffer` で使います。上限を超えたときは、**古い**完了行や先頭の文字から破棄し、長時間のターミナル表示でメモリが際限なく増えないようにします。`0` を指定するとその制限を無効化します。文字数は UTF-16 の文字列長（JavaScript の `.length`）です。
 
 | フィールド   | 型        | 既定値     | 説明 |
 | ------------ | --------- | ---------- | ---- |
@@ -105,11 +123,11 @@ W3C `SerialOptions` から派生し、`port.open` に渡されます。factory �
 | `maxChars`   | `number`  | `1048576`  | 表示テキスト全体（完了部分 + 編集中行）の文字数上限。 |
 | `stripAnsi`  | `boolean` | `true`     | `true` のとき、`\r` 折りたたみ前に ANSI エスケープシーケンスを除去します。`false` にすると `terminalText$` に生のエスケープが残ります。`receive$` は常に変更されません。 |
 
-無効な `maxLines` / `maxChars` は `createSerialSession` 時に `INVALID_TERMINAL_BUFFER_OPTIONS` で throw します。
+無効な `maxLines` / `maxChars` は `createSerialSession` および単独の `createTerminalBuffer` 時に `INVALID_TERMINAL_BUFFER_OPTIONS` で throw します。
 
 ### `LineBufferOptions`
 
-`SerialSessionOptions.lineBuffer` で `lines$` の**未完成行 tail**（改行未到達の保持データ）の上限を指定します。`maxChars` を超えたときは tail の**先頭**文字から破棄し、non-fatal の `SerialErrorCode.LINE_BUFFER_OVERFLOW` を `errors$` に emit します（セッションは切断されません）。完了した行は trim 前にそのまま emit されます。`0` で制限を無効化します。
+`SerialSessionOptions.lineBuffer` で `lines$` の**未完成行 tail**（改行未到達の保持データ）の上限を指定します。`maxChars` を超えたときは tail の**先頭**文字から破棄し、non-fatal の `SerialErrorCode.LINE_BUFFER_OVERFLOW` を `errors$` に emit します（セッションは切断されません）。完了した行は trim 前にそのまま emit されます。`0` で制限を無効化します。文字数は UTF-16 の文字列長です。
 
 | フィールド   | 型        | 既定値     | 説明 |
 | ------------ | --------- | ---------- | ---- |
@@ -119,7 +137,7 @@ W3C `SerialOptions` から派生し、`port.open` に渡されます。factory �
 
 ## createTerminalBuffer(receive$, options?)
 
-デコード済みチャンクの `Observable<string>`（通常は `SerialSession.receive$`）から、ターミナル向けの累積テキストストリームを構築します。`\r` による再描画を畳み込みつつ、通常の改行挙動は維持します。既定値は `DEFAULT_TERMINAL_BUFFER_OPTIONS` と同じです。
+デコード済みチャンクの `Observable<string>`（通常は `SerialSession.receive$`）から、ターミナル向けの累積テキストストリームを構築します。`\r` による再描画を畳み込みつつ、通常の改行挙動は維持します。既定値は `DEFAULT_TERMINAL_BUFFER_OPTIONS` と同じです。無効な `maxLines` / `maxChars` はセッション生成時と同じ `INVALID_TERMINAL_BUFFER_OPTIONS` を throw します。
 
 ```typescript
 function createTerminalBuffer(

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md
@@ -146,7 +146,7 @@ async function query(
 
 `SerialSessionOptions` は `SerialClientOptions` と同じフィールド（`baudRate` / `dataBits` / `stopBits` / `parity` / `bufferSize` / `flowControl` / `filters`）を持ち、デフォルト値（`9600` / `8` / `1` / `'none'` / `255` / `'none'`）も同一です。
 
-`createSerialSession` factory 時に `resolveSerialSessionOptions` が `filters`・`baudRate`・`receiveReplay`・`terminalBuffer`・`lineBuffer` を検証します。不正な値は `SerialError` として throw されます（例: `SerialErrorCode.INVALID_FILTER_OPTIONS`）。
+`createSerialSession` factory 時に `resolveSerialSessionOptions` が `filters`・`baudRate`・`bufferSize`・`terminalBuffer`・`lineBuffer` を検証します。不正な値は `SerialError` として throw されます（例: `SerialErrorCode.INVALID_FILTER_OPTIONS`）。
 
 ## フレームワーク別の例
 

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
@@ -559,10 +559,10 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 ```
 
 - `SerialConnectionOptions` — `baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`（`port.open` に渡される）
-- `SerialSessionFeatureOptions` — `filters`, `receiveReplay`, `terminalBuffer`, `lineBuffer`（library-specific）
+- `SerialSessionFeatureOptions` — `filters`, `terminalBuffer`, `lineBuffer`（library-specific。`receiveReplay` は v4 Phase 2 で削除）
 - `SerialSessionOptions` — 上記 2 つの composition（factory 引数）
 
-詳細は [概念と設計メモ – SerialSessionOptions](./concepts.md#serialsessionoptions) を参照してください。
+詳細は [概念と設計メモ – SerialSessionOptions](./concepts.md#serialsessionoptions) を参照してください。境界値の意味（バッファ上限のみ `0` = 無制限、接続フィールドは `> 0` 必須）も同ページに記載しています（[#488](https://github.com/gurezo/web-serial-rxjs/issues/488)）。
 
 ### v3.x での互換性
 

--- a/packages/web-serial-rxjs/src/internal/branded-numbers.ts
+++ b/packages/web-serial-rxjs/src/internal/branded-numbers.ts
@@ -3,7 +3,7 @@ declare const baudRateBrand: unique symbol;
 export type BaudRate = number & { readonly [baudRateBrand]: true };
 
 declare const serialPortBufferSizeBrand: unique symbol;
-/** Validated W3C {@link SerialOptions} `bufferSize`. */
+/** Validated W3C {@link SerialOptions} `bufferSize` (safe integer > 0). */
 export type SerialPortBufferSize = number & {
   readonly [serialPortBufferSizeBrand]: true;
 };

--- a/packages/web-serial-rxjs/src/session/create-serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/create-serial-session.ts
@@ -55,9 +55,12 @@ import {
  *   do not mutate `state$` because a real connection loss will be
  *   observed by the read pump on the next tick anyway.
  *
- * @param options - Session options. Only `filters` is consulted by
- *   `connect$` today (forwarded to `navigator.serial.requestPort`); the
- *   remaining fields are passed to `port.open` using defaults when omitted.
+ * @param options - Session options. W3C connection fields (`baudRate`,
+ *   `dataBits`, …) are passed to `port.open`. `filters` is forwarded to
+ *   `navigator.serial.requestPort`. `lineBuffer` / `terminalBuffer` configure
+ *   {@link SerialSession.lines$} and {@link SerialSession.terminalText$}.
+ *   Omitted fields use {@link resolveSerialSessionOptions} defaults; minimal
+ *   callers typically only set `baudRate`.
  * @returns A {@link SerialSession} instance.
  *
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/199 | Issue #199}

--- a/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
+++ b/packages/web-serial-rxjs/src/session/internal/line-buffer.ts
@@ -1,9 +1,13 @@
 import { createNewlineTokenizer } from '../../internal/newline-tokenizer';
 import type { MaxChars } from '../../internal/branded-numbers';
 import { brandMaxChars } from '../../internal/branded-numbers';
+import { SerialError } from '../../errors/serial-error';
+import { SerialErrorCode } from '../../errors/serial-error-code';
 
 /**
  * Options for {@link createLineBuffer}.
+ *
+ * Character counts use UTF-16 string length (JavaScript `.length`).
  *
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/371 | Issue #371}
  */
@@ -11,6 +15,7 @@ export interface LineBufferOptions {
   /**
    * Maximum characters retained in the incomplete line tail (no line terminator yet).
    * When exceeded, leading characters are discarded. `0` means unlimited.
+   * Must be a safe integer `>= 0` when validated.
    *
    * @default 1048576
    */
@@ -21,6 +26,48 @@ export interface LineBufferOptions {
 export const DEFAULT_LINE_BUFFER_OPTIONS: Required<LineBufferOptions> = {
   maxChars: 1_048_576,
 };
+
+/** Resolved line buffer options with validated branded numeric fields. */
+export type ResolvedLineBufferOptions = {
+  maxChars: MaxChars;
+};
+
+/**
+ * Merge and validate {@link LineBufferOptions}.
+ *
+ * This is the single normalization path for line buffer defaults and boundary
+ * checks used by {@link resolveSerialSessionOptions}.
+ *
+ * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS}
+ *         when `maxChars` is out of range.
+ */
+export function resolveLineBufferOptions(
+  options?: LineBufferOptions,
+): ResolvedLineBufferOptions {
+  const merged: Required<LineBufferOptions> = {
+    ...DEFAULT_LINE_BUFFER_OPTIONS,
+    ...options,
+  };
+
+  const { maxChars } = merged;
+
+  if (!Number.isSafeInteger(maxChars) || maxChars < 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS,
+      `Invalid lineBuffer.maxChars: ${maxChars}. Must be a safe integer >= 0.`,
+      undefined,
+      {
+        field: 'lineBuffer.maxChars',
+        value: maxChars,
+        constraint: 'non-negative-safe-integer',
+      },
+    );
+  }
+
+  return {
+    maxChars: brandMaxChars(maxChars),
+  };
+}
 
 /** Result of {@link createLineBuffer.feed}. */
 export interface LineBufferFeedResult {
@@ -56,11 +103,7 @@ export interface LineBufferLimits {
 export function createLineBuffer(
   options?: LineBufferOptions | LineBufferLimits,
 ): LineBuffer {
-  const limits: LineBufferLimits = {
-    maxChars: brandMaxChars(
-      options?.maxChars ?? DEFAULT_LINE_BUFFER_OPTIONS.maxChars,
-    ),
-  };
+  const limits: LineBufferLimits = resolveLineBufferOptions(options);
 
   const tokenizer = createNewlineTokenizer('line');
 

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -1,30 +1,50 @@
 import {
   brandBaudRate,
-  brandMaxChars,
-  brandMaxLines,
   brandSerialPortBufferSize,
   type BaudRate,
-  type MaxChars,
-  type MaxLines,
   type SerialPortBufferSize,
 } from '../internal/branded-numbers';
 import type { SerialConnectionOptions } from '../types';
-import type { TerminalBufferOptions } from '../terminal/create-terminal-buffer';
-import { DEFAULT_TERMINAL_BUFFER_OPTIONS } from '../terminal/create-terminal-buffer';
+import {
+  resolveTerminalBufferOptions,
+  type ResolvedTerminalBufferOptions,
+  type TerminalBufferOptions,
+} from '../terminal/create-terminal-buffer';
 import { SerialError } from '../errors/serial-error';
 import { SerialErrorCode } from '../errors/serial-error-code';
 import {
-  DEFAULT_LINE_BUFFER_OPTIONS,
+  resolveLineBufferOptions,
   type LineBufferOptions,
+  type ResolvedLineBufferOptions,
 } from './internal/line-buffer';
 import { validateSerialPortFilters } from './internal/validate-serial-port-filters';
+
+export type {
+  ResolvedLineBufferOptions,
+  ResolvedTerminalBufferOptions,
+};
 
 /**
  * Library-specific options for {@link createSerialSession} that are not passed
  * to W3C `port.open`.
  *
+ * Responsibility split (Issue #488):
+ *
+ * - {@link SerialSessionFeatureOptions.filters} — port selection only
+ *   (`navigator.serial.requestPort`)
+ * - {@link SerialSessionFeatureOptions.lineBuffer} — incomplete-line tail for
+ *   {@link SerialSession.lines$}
+ * - {@link SerialSessionFeatureOptions.terminalBuffer} — display memory for
+ *   {@link SerialSession.terminalText$}
+ *
+ * Connection parameters (`baudRate`, `dataBits`, …) live on
+ * {@link SerialConnectionOptions} and are composed into
+ * {@link SerialSessionOptions}. Minimal callers typically only set
+ * `baudRate`; other fields keep safe defaults.
+ *
  * @see {@link SerialConnectionOptions} for W3C connection parameters
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/441 | Issue #441}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/488 | Issue #488}
  */
 export interface SerialSessionFeatureOptions {
   /**
@@ -32,15 +52,21 @@ export interface SerialSessionFeatureOptions {
    *
    * When specified, the port selection dialog will only show devices
    * matching these filters. Each filter can specify `usbVendorId` and/or
-   * `usbProductId`.
+   * `usbProductId`. Not passed to `port.open`.
    */
   filters?: SerialPortFilter[];
 
   /**
    * Limits for {@link SerialSession.terminalText$} display memory. Oldest
    * completed lines and leading characters are dropped when exceeded.
+   * Character counts use UTF-16 string length (JavaScript `.length`).
    *
-   * @default `{ maxLines: 10000, maxChars: 1048576 }` (see {@link DEFAULT_SERIAL_SESSION_OPTIONS})
+   * Pass `0` for `maxLines` or `maxChars` to disable that limit (unlimited).
+   * Negative values, non-integers, `NaN`, and `Infinity` are rejected at
+   * factory time.
+   *
+   * @default `{ maxLines: 10000, maxChars: 1048576, stripAnsi: true }`
+   *   (see {@link DEFAULT_SERIAL_SESSION_OPTIONS})
    * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/370 | Issue #370}
    */
   terminalBuffer?: TerminalBufferOptions;
@@ -48,7 +74,11 @@ export interface SerialSessionFeatureOptions {
   /**
    * Limits for the incomplete line tail held by {@link SerialSession.lines$}
    * framing. When exceeded, leading characters are discarded and a non-fatal
-   * {@link SerialErrorCode.LINE_BUFFER_OVERFLOW} is emitted on {@link SerialSession.errors$}.
+   * {@link SerialErrorCode.LINE_BUFFER_OVERFLOW} is emitted on
+   * {@link SerialSession.errors$}. Character counts use UTF-16 string length.
+   *
+   * Pass `0` for `maxChars` to disable the limit (unlimited). Negative values,
+   * non-integers, `NaN`, and `Infinity` are rejected at factory time.
    *
    * @default `{ maxChars: 1048576 }` (see {@link DEFAULT_SERIAL_SESSION_OPTIONS})
    * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/371 | Issue #371}
@@ -61,10 +91,17 @@ export interface SerialSessionFeatureOptions {
  *
  * Composes {@link Partial}<{@link SerialConnectionOptions}> (W3C connection
  * parameters passed to `port.open`) with {@link SerialSessionFeatureOptions}
- * (library-specific session features). All connection fields are optional;
- * omitted values fall back to {@link DEFAULT_SERIAL_SESSION_OPTIONS}
- * (`baudRate` 9600, `dataBits` 8, `stopBits` 1, `parity` `'none'`,
- * `bufferSize` 255, `flowControl` `'none'`).
+ * (library-specific session features). All fields are optional; omitted values
+ * fall back to {@link DEFAULT_SERIAL_SESSION_OPTIONS}.
+ *
+ * Minimal usage typically only needs `baudRate`:
+ *
+ * @example
+ * ```typescript
+ * const session = createSerialSession({ baudRate: 115200 });
+ * ```
+ *
+ * Full example:
  *
  * @example
  * ```typescript
@@ -78,6 +115,12 @@ export interface SerialSessionFeatureOptions {
  * });
  * ```
  *
+ * Boundary semantics for numeric limits:
+ *
+ * - `undefined` — apply the default from {@link DEFAULT_SERIAL_SESSION_OPTIONS}
+ * - `baudRate` / `bufferSize` — must be safe integers `> 0` (rejected otherwise)
+ * - `terminalBuffer` / `lineBuffer` limits — safe integers `>= 0`; `0` means unlimited
+ *
  * @see {@link SerialConnectionOptions}
  * @see {@link SerialSessionFeatureOptions}
  * @see {@link SerialOptions}
@@ -85,104 +128,10 @@ export interface SerialSessionFeatureOptions {
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/200 | Issue #200}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/402 | Issue #402}
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/441 | Issue #441}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/488 | Issue #488}
  */
 export interface SerialSessionOptions
   extends Partial<SerialConnectionOptions>, SerialSessionFeatureOptions {}
-
-/**
- * Merge and validate {@link TerminalBufferOptions}.
- *
- * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS}
- *         when `maxLines` or `maxChars` are out of range.
- */
-/** Resolved terminal buffer options with validated branded numeric fields. */
-export type ResolvedTerminalBufferOptions = {
-  maxLines: MaxLines;
-  maxChars: MaxChars;
-  stripAnsi: boolean;
-};
-
-export function resolveTerminalBufferOptions(
-  options?: TerminalBufferOptions,
-): ResolvedTerminalBufferOptions {
-  const merged: Required<TerminalBufferOptions> = {
-    ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
-    ...options,
-  };
-
-  const { maxLines, maxChars } = merged;
-
-  if (!Number.isSafeInteger(maxLines) || maxLines < 0) {
-    throw new SerialError(
-      SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
-      `Invalid terminalBuffer.maxLines: ${maxLines}. Must be a safe integer >= 0.`,
-      undefined,
-      {
-        field: 'terminalBuffer.maxLines',
-        value: maxLines,
-        constraint: 'non-negative-safe-integer',
-      },
-    );
-  }
-
-  if (!Number.isSafeInteger(maxChars) || maxChars < 0) {
-    throw new SerialError(
-      SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
-      `Invalid terminalBuffer.maxChars: ${maxChars}. Must be a safe integer >= 0.`,
-      undefined,
-      {
-        field: 'terminalBuffer.maxChars',
-        value: maxChars,
-        constraint: 'non-negative-safe-integer',
-      },
-    );
-  }
-
-  return {
-    maxLines: brandMaxLines(maxLines),
-    maxChars: brandMaxChars(maxChars),
-    stripAnsi: merged.stripAnsi,
-  };
-}
-
-/**
- * Merge and validate {@link LineBufferOptions}.
- *
- * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS}
- *         when `maxChars` is out of range.
- */
-/** Resolved line buffer options with validated branded numeric fields. */
-export type ResolvedLineBufferOptions = {
-  maxChars: MaxChars;
-};
-
-export function resolveLineBufferOptions(
-  options?: LineBufferOptions,
-): ResolvedLineBufferOptions {
-  const merged: Required<LineBufferOptions> = {
-    ...DEFAULT_LINE_BUFFER_OPTIONS,
-    ...options,
-  };
-
-  const { maxChars } = merged;
-
-  if (!Number.isSafeInteger(maxChars) || maxChars < 0) {
-    throw new SerialError(
-      SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS,
-      `Invalid lineBuffer.maxChars: ${maxChars}. Must be a safe integer >= 0.`,
-      undefined,
-      {
-        field: 'lineBuffer.maxChars',
-        value: maxChars,
-        constraint: 'non-negative-safe-integer',
-      },
-    );
-  }
-
-  return {
-    maxChars: brandMaxChars(maxChars),
-  };
-}
 
 /**
  * Fully resolved session options after merging {@link SerialSessionOptions}
@@ -209,6 +158,10 @@ export type ResolvedSerialSessionOptions = Required<
 /**
  * Default values applied to omitted {@link SerialSessionOptions} fields.
  *
+ * Nested buffer defaults are owned by {@link resolveTerminalBufferOptions} and
+ * {@link resolveLineBufferOptions}; this object is the single session-level
+ * snapshot used by {@link resolveSerialSessionOptions}.
+ *
  * @internal
  */
 export const DEFAULT_SERIAL_SESSION_OPTIONS = {
@@ -234,7 +187,7 @@ export type ResolvedSerialSessionConnectionOptions = Required<
  * Merge and validate W3C connection fields from {@link SerialSessionOptions}.
  *
  * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_CONNECTION_OPTIONS}
- *         when `baudRate` is out of range.
+ *         when `baudRate` or `bufferSize` are out of range.
  */
 export function resolveConnectionOptions(
   options?: Partial<SerialConnectionOptions>,
@@ -264,16 +217,26 @@ export function resolveConnectionOptions(
     );
   }
 
+  if (!Number.isSafeInteger(bufferSize) || bufferSize <= 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_CONNECTION_OPTIONS,
+      `Invalid bufferSize: ${bufferSize}. Must be a safe integer > 0.`,
+      undefined,
+      {
+        field: 'bufferSize',
+        value: bufferSize,
+        constraint: 'positive-safe-integer',
+      },
+    );
+  }
+
   return {
-    dataBits: merged.dataBits ?? DEFAULT_SERIAL_SESSION_OPTIONS.dataBits,
-    stopBits: merged.stopBits ?? DEFAULT_SERIAL_SESSION_OPTIONS.stopBits,
-    parity: merged.parity ?? DEFAULT_SERIAL_SESSION_OPTIONS.parity,
-    flowControl:
-      merged.flowControl ?? DEFAULT_SERIAL_SESSION_OPTIONS.flowControl,
+    dataBits: merged.dataBits,
+    stopBits: merged.stopBits,
+    parity: merged.parity,
+    flowControl: merged.flowControl,
     baudRate: brandBaudRate(baudRate),
-    bufferSize: brandSerialPortBufferSize(
-      bufferSize ?? DEFAULT_SERIAL_SESSION_OPTIONS.bufferSize,
-    ),
+    bufferSize: brandSerialPortBufferSize(bufferSize),
   };
 }
 
@@ -281,12 +244,18 @@ export function resolveConnectionOptions(
  * Merge and validate {@link SerialSessionOptions} into a fully resolved
  * options object for internal session use.
  *
+ * Defaults and validation for nested buffers live next to their option types
+ * ({@link resolveTerminalBufferOptions}, {@link resolveLineBufferOptions}).
+ * This function is the single entry point that assembles connection + feature
+ * options for a session.
+ *
  * @throws {@link SerialError} when option values are out of range:
  *         {@link SerialErrorCode.INVALID_CONNECTION_OPTIONS},
  *         {@link SerialErrorCode.INVALID_FILTER_OPTIONS},
  *         {@link SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS}, or
  *         {@link SerialErrorCode.INVALID_LINE_BUFFER_OPTIONS}.
  * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/403 | Issue #403}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/488 | Issue #488}
  */
 export function resolveSerialSessionOptions(
   options?: SerialSessionOptions,

--- a/packages/web-serial-rxjs/src/session/serial-session-options.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session-options.ts
@@ -202,7 +202,10 @@ export function resolveConnectionOptions(
     ...options,
   };
 
-  const { baudRate, bufferSize } = merged;
+  const baudRate =
+    merged.baudRate ?? DEFAULT_SERIAL_SESSION_OPTIONS.baudRate;
+  const bufferSize =
+    merged.bufferSize ?? DEFAULT_SERIAL_SESSION_OPTIONS.bufferSize;
 
   if (!Number.isSafeInteger(baudRate) || baudRate <= 0) {
     throw new SerialError(
@@ -231,10 +234,11 @@ export function resolveConnectionOptions(
   }
 
   return {
-    dataBits: merged.dataBits,
-    stopBits: merged.stopBits,
-    parity: merged.parity,
-    flowControl: merged.flowControl,
+    dataBits: merged.dataBits ?? DEFAULT_SERIAL_SESSION_OPTIONS.dataBits,
+    stopBits: merged.stopBits ?? DEFAULT_SERIAL_SESSION_OPTIONS.stopBits,
+    parity: merged.parity ?? DEFAULT_SERIAL_SESSION_OPTIONS.parity,
+    flowControl:
+      merged.flowControl ?? DEFAULT_SERIAL_SESSION_OPTIONS.flowControl,
     baudRate: brandBaudRate(baudRate),
     bufferSize: brandSerialPortBufferSize(bufferSize),
   };

--- a/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
+++ b/packages/web-serial-rxjs/src/terminal/create-terminal-buffer.ts
@@ -1,4 +1,6 @@
 import { type Observable, map, scan, shareReplay } from 'rxjs';
+import { SerialError } from '../errors/serial-error';
+import { SerialErrorCode } from '../errors/serial-error-code';
 import {
   brandMaxChars,
   brandMaxLines,
@@ -136,10 +138,16 @@ export interface TerminalBuffer {
   readonly text$: Observable<string>;
 }
 
-/** Options for {@link createTerminalBuffer} memory limits. `0` means unlimited. */
+/**
+ * Options for {@link createTerminalBuffer} memory limits.
+ *
+ * Character counts use UTF-16 string length (JavaScript `.length`).
+ * Pass `0` for `maxLines` or `maxChars` to disable that limit (unlimited).
+ */
 export interface TerminalBufferOptions {
   /**
    * Maximum number of completed lines to retain in the display buffer.
+   * `0` means unlimited. Must be a safe integer `>= 0` when validated.
    *
    * @default 10000
    */
@@ -148,6 +156,7 @@ export interface TerminalBufferOptions {
   /**
    * Maximum total characters in the cumulative display text
    * (`completed` + `currentLine`). Oldest content is dropped first.
+   * `0` means unlimited. Must be a safe integer `>= 0` when validated.
    *
    * @default 1048576
    */
@@ -172,14 +181,62 @@ export const DEFAULT_TERMINAL_BUFFER_OPTIONS: Required<TerminalBufferOptions> =
     stripAnsi: true,
   };
 
-function resolveTerminalBufferLimits(
+/** Resolved terminal buffer options with validated branded numeric fields. */
+export type ResolvedTerminalBufferOptions = {
+  maxLines: MaxLines;
+  maxChars: MaxChars;
+  stripAnsi: boolean;
+};
+
+/**
+ * Merge and validate {@link TerminalBufferOptions}.
+ *
+ * This is the single normalization path for terminal buffer defaults and
+ * boundary checks (session factory and standalone {@link createTerminalBuffer}).
+ *
+ * @throws {@link SerialError} with {@link SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS}
+ *         when `maxLines` or `maxChars` are out of range.
+ */
+export function resolveTerminalBufferOptions(
   options?: TerminalBufferOptions,
-): TerminalBufferLimits {
-  const maxLines = options?.maxLines ?? DEFAULT_TERMINAL_BUFFER_OPTIONS.maxLines;
-  const maxChars = options?.maxChars ?? DEFAULT_TERMINAL_BUFFER_OPTIONS.maxChars;
+): ResolvedTerminalBufferOptions {
+  const merged: Required<TerminalBufferOptions> = {
+    ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
+    ...options,
+  };
+
+  const { maxLines, maxChars } = merged;
+
+  if (!Number.isSafeInteger(maxLines) || maxLines < 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
+      `Invalid terminalBuffer.maxLines: ${maxLines}. Must be a safe integer >= 0.`,
+      undefined,
+      {
+        field: 'terminalBuffer.maxLines',
+        value: maxLines,
+        constraint: 'non-negative-safe-integer',
+      },
+    );
+  }
+
+  if (!Number.isSafeInteger(maxChars) || maxChars < 0) {
+    throw new SerialError(
+      SerialErrorCode.INVALID_TERMINAL_BUFFER_OPTIONS,
+      `Invalid terminalBuffer.maxChars: ${maxChars}. Must be a safe integer >= 0.`,
+      undefined,
+      {
+        field: 'terminalBuffer.maxChars',
+        value: maxChars,
+        constraint: 'non-negative-safe-integer',
+      },
+    );
+  }
+
   return {
     maxLines: brandMaxLines(maxLines),
     maxChars: brandMaxChars(maxChars),
+    stripAnsi: merged.stripAnsi,
   };
 }
 
@@ -204,10 +261,12 @@ export function createTerminalBuffer(
   receive$: Observable<string>,
   options?: TerminalBufferOptions,
 ): TerminalBuffer {
-  const limits = resolveTerminalBufferLimits(options);
-  const stripAnsi =
-    options?.stripAnsi ?? DEFAULT_TERMINAL_BUFFER_OPTIONS.stripAnsi;
-  const ansiStripper = stripAnsi ? createAnsiStripper() : null;
+  const resolved = resolveTerminalBufferOptions(options);
+  const limits: TerminalBufferLimits = {
+    maxLines: resolved.maxLines,
+    maxChars: resolved.maxChars,
+  };
+  const ansiStripper = resolved.stripAnsi ? createAnsiStripper() : null;
 
   const text$ = receive$.pipe(
     scan((state, chunk: string) => {

--- a/packages/web-serial-rxjs/src/types.ts
+++ b/packages/web-serial-rxjs/src/types.ts
@@ -13,7 +13,12 @@ export type SerialPayload = string | Uint8Array;
  * {@link SerialSessionOptions.filters}, which apply only to
  * `navigator.serial.requestPort`.
  *
+ * At session factory time, `baudRate` and `bufferSize` must be safe integers
+ * `> 0` (or omitted to use defaults). `0`, negatives, non-integers, `NaN`, and
+ * `Infinity` are rejected.
+ *
  * @see {@link SerialOptions}
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/488 | Issue #488}
  */
 export type SerialConnectionOptions = Pick<
   SerialOptions,

--- a/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
+++ b/packages/web-serial-rxjs/tests/session/resolve-serial-session-options.test.ts
@@ -55,6 +55,17 @@ describe('resolveSerialSessionOptions', () => {
     expect(resolveSerialSessionOptions().terminalBuffer.stripAnsi).toBe(true);
   });
 
+  it('merges terminalBuffer.stripAnsi false', () => {
+    expect(
+      resolveSerialSessionOptions({
+        terminalBuffer: { stripAnsi: false },
+      }).terminalBuffer,
+    ).toEqual({
+      ...DEFAULT_TERMINAL_BUFFER_OPTIONS,
+      stripAnsi: false,
+    });
+  });
+
   it('merges nested lineBuffer options', () => {
     expect(
       resolveSerialSessionOptions({
@@ -81,9 +92,19 @@ describe('resolveSerialSessionOptions', () => {
     ['terminalBuffer.maxLines', { terminalBuffer: { maxLines: -1 } }, -1],
     ['terminalBuffer.maxLines', { terminalBuffer: { maxLines: 1.5 } }, 1.5],
     ['terminalBuffer.maxLines', { terminalBuffer: { maxLines: NaN } }, NaN],
+    [
+      'terminalBuffer.maxLines',
+      { terminalBuffer: { maxLines: Infinity } },
+      Infinity,
+    ],
     ['terminalBuffer.maxChars', { terminalBuffer: { maxChars: -1 } }, -1],
     ['terminalBuffer.maxChars', { terminalBuffer: { maxChars: 1.5 } }, 1.5],
     ['terminalBuffer.maxChars', { terminalBuffer: { maxChars: NaN } }, NaN],
+    [
+      'terminalBuffer.maxChars',
+      { terminalBuffer: { maxChars: Infinity } },
+      Infinity,
+    ],
   ])('rejects invalid %s', (field, options, value) => {
     expect(() => resolveSerialSessionOptions(options)).toThrow(SerialError);
     try {
@@ -113,6 +134,7 @@ describe('resolveSerialSessionOptions', () => {
     ['lineBuffer.maxChars', { lineBuffer: { maxChars: -1 } }, -1],
     ['lineBuffer.maxChars', { lineBuffer: { maxChars: 1.5 } }, 1.5],
     ['lineBuffer.maxChars', { lineBuffer: { maxChars: NaN } }, NaN],
+    ['lineBuffer.maxChars', { lineBuffer: { maxChars: Infinity } }, Infinity],
   ])('rejects invalid %s', (field, options, value) => {
     expect(() => resolveSerialSessionOptions(options)).toThrow(SerialError);
     try {
@@ -160,6 +182,12 @@ describe('resolveSerialSessionOptions', () => {
     ['baudRate', { baudRate: -1 }, -1],
     ['baudRate', { baudRate: 1.5 }, 1.5],
     ['baudRate', { baudRate: NaN }, NaN],
+    ['baudRate', { baudRate: Infinity }, Infinity],
+    ['bufferSize', { bufferSize: 0 }, 0],
+    ['bufferSize', { bufferSize: -1 }, -1],
+    ['bufferSize', { bufferSize: 1.5 }, 1.5],
+    ['bufferSize', { bufferSize: NaN }, NaN],
+    ['bufferSize', { bufferSize: Infinity }, Infinity],
   ])('rejects invalid %s', (field, options, value) => {
     expect(() => resolveSerialSessionOptions(options)).toThrow(SerialError);
     try {
@@ -180,6 +208,21 @@ describe('resolveSerialSessionOptions', () => {
   it('accepts valid baudRate values', () => {
     expect(resolveSerialSessionOptions({ baudRate: 115200 }).baudRate).toBe(
       115200,
+    );
+  });
+
+  it('accepts valid bufferSize values', () => {
+    expect(resolveSerialSessionOptions({ bufferSize: 512 }).bufferSize).toBe(
+      512,
+    );
+  });
+
+  it('does not treat connection zero as unlimited', () => {
+    expect(() => resolveSerialSessionOptions({ baudRate: 0 })).toThrow(
+      SerialError,
+    );
+    expect(() => resolveSerialSessionOptions({ bufferSize: 0 })).toThrow(
+      SerialError,
     );
   });
 

--- a/packages/web-serial-rxjs/tests/session/serial-session-options-type-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/serial-session-options-type-audit.test.ts
@@ -11,13 +11,19 @@ import {
 } from '../../src/index';
 
 /**
- * Regression guard for the session options type responsibility audit (Issue #441).
- * Keep in sync with MIGRATION_V3 §10 and API_REFERENCE.
+ * Regression guard for the session options type responsibility audit
+ * (Issues #441 / #488). Keep in sync with concepts.md and migration guides.
  */
 const CANONICAL_OPTIONS_TYPE_EXPORTS = [
   'SerialConnectionOptions',
   'SerialSessionFeatureOptions',
   'SerialSessionOptions',
+] as const;
+
+const CANONICAL_FEATURE_OPTION_KEYS = [
+  'filters',
+  'terminalBuffer',
+  'lineBuffer',
 ] as const;
 
 const __filename = fileURLToPath(import.meta.url);
@@ -26,11 +32,38 @@ const publicIndexSource = readFileSync(
   join(__dirname, '../../src/index.ts'),
   'utf8',
 );
+const featureOptionsSource = readFileSync(
+  join(__dirname, '../../src/session/serial-session-options.ts'),
+  'utf8',
+);
+const packageSrcRoot = join(__dirname, '../../src');
 
-describe('session options type audit (#441)', () => {
+describe('session options type audit (#441 / #488)', () => {
   it('exports connection and feature option types from the public barrel', () => {
     for (const name of CANONICAL_OPTIONS_TYPE_EXPORTS) {
       expect(publicIndexSource).toContain(name);
+    }
+  });
+
+  it('keeps SerialSessionFeatureOptions keys aligned with session responsibilities', () => {
+    for (const key of CANONICAL_FEATURE_OPTION_KEYS) {
+      expect(featureOptionsSource).toContain(`${key}?:`);
+    }
+    expect(featureOptionsSource).not.toContain('receiveReplay');
+  });
+
+  it('does not leave receiveReplay in package source', () => {
+    const sources = [
+      'index.ts',
+      'session/serial-session-options.ts',
+      'session/serial-session.ts',
+      'session/create-serial-session.ts',
+    ].map((relativePath) =>
+      readFileSync(join(packageSrcRoot, relativePath), 'utf8'),
+    );
+
+    for (const source of sources) {
+      expect(source).not.toMatch(/receiveReplay/);
     }
   });
 
@@ -65,5 +98,9 @@ describe('session options type audit (#441)', () => {
     } as const satisfies Partial<SerialSessionOptions>;
 
     expect(() => createSerialSession(options)).not.toThrow();
+  });
+
+  it('accepts baudRate-only minimal session creation', () => {
+    expect(() => createSerialSession({ baudRate: 115200 })).not.toThrow();
   });
 });

--- a/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
+++ b/packages/web-serial-rxjs/tests/terminal/create-terminal-buffer.test.ts
@@ -202,4 +202,10 @@ describe('createTerminalBuffer', () => {
     receive$.next('prompt\u001b[?2004h');
     expect(last).toContain('[?2004h');
   });
+
+  it('issue #488: rejects invalid terminal buffer limits at creation', () => {
+    const receive$ = new Subject<string>();
+    expect(() => createTerminalBuffer(receive$, { maxLines: -1 })).toThrow();
+    expect(() => createTerminalBuffer(receive$, { maxChars: Infinity })).toThrow();
+  });
 });


### PR DESCRIPTION
## PR Title (Conventional Commits)
`refactor(web-serial-rxjs): reorganize SerialSessionOptions responsibilities`

## Summary
`SerialSessionOptions` の責務とデフォルト値・境界値の意味を整理し、正規化処理をオプション型の定義元へ一元化しました。最小構成では `baudRate` だけで利用できることを型・JSDoc・ドキュメントで明確化しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [x] Breaking change

## Related issues
- Fixes #488
- Parent: #485

## What changed?
- 接続オプションと派生機能（`filters` / `lineBuffer` / `terminalBuffer`）の責務を JSDoc と型コメントで明確化
- `resolveTerminalBufferOptions` / `resolveLineBufferOptions` を各オプション定義元へ移動し、`createTerminalBuffer` からも同じ検証経路を利用
- `bufferSize` を `baudRate` と同様に safe integer `> 0` で検証
- `0` の意味を統一（バッファ上限のみ無制限、接続フィールドは拒否）
- option normalization / 境界値 / `receiveReplay` 残骸除去の回帰テストを追加
- concepts / migration ガイドを現行 API に合わせて更新

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `createSerialSession({ bufferSize: 0 })` や不正な `bufferSize` は `INVALID_CONNECTION_OPTIONS` で throw するようになりました。単独の `createTerminalBuffer` でも不正な `maxLines` / `maxChars` は `INVALID_TERMINAL_BUFFER_OPTIONS` で throw します。
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes:
    - `bufferSize` に `0` / 負数 / 非整数 / `NaN` / `Infinity` を渡している場合は、正の safe integer へ変更してください（省略時の既定値は `255`）。
    - `createTerminalBuffer` に不正な上限を渡している場合は、従来黙って通過していた値がエラーになります。`0`（無制限）は従来どおり有効です。
    - `receiveReplay` オプションは既に削除済みです。残っている場合は呼び出し側から除去してください。

## How to test
1. `pnpm exec nx run web-serial-rxjs:lint`
2. `pnpm exec nx run web-serial-rxjs:test`
3. `pnpm exec nx run web-serial-rxjs:build`
4. `pnpm run docs`
5. 境界値確認例:
   - `resolveSerialSessionOptions({ bufferSize: 0 })` が throw すること
   - `resolveSerialSessionOptions({ terminalBuffer: { maxLines: 0 } })` が unlimited として通ること

## Environment (if relevant)
- Browser: N/A（オプション正規化のユニットテスト中心）
- OS: macOS
- web-serial-rxjs version (for verification): branch `refactor/web-serial-rxjs-488-session-options`
- RxJS version: workspace 依存どおり

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)