### PR TITLE
test(web-serial-rxjs): lock v4 public API boundary

### DIFF
--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -21,7 +21,7 @@
     "web-serial-rxjs-icon.png"
   ],
   "scripts": {
-    "build": "pnpm run build:types && pnpm run build:bundle && pnpm run build:copy-files && pnpm run build:cleanup",
+    "build": "pnpm run clean && pnpm run build:types && pnpm run build:bundle && pnpm run build:copy-files && pnpm run build:cleanup",
     "build:types": "../../node_modules/.bin/tsc --project tsconfig.lib.json",
     "build:bundle": "node esbuild.config.mjs",
     "build:copy-files": "cp ../../LICENSE . 2>/dev/null || true",

--- a/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -102,23 +102,41 @@ const CANONICAL_TYPE_EXPORTS = [
   'ValidationErrorContext',
 ] as const;
 
-function parseExportedTypeNames(source: string): string[] {
+function parseExportedNamesFromBlocks(
+  source: string,
+  kind: 'value' | 'type',
+): string[] {
   const names: string[] = [];
-  const typeExportBlocks =
-    source.matchAll(/export\s+type\s*\{([^}]+)\}/gs);
-  for (const match of typeExportBlocks) {
+  const pattern =
+    kind === 'type'
+      ? /export\s+type\s*\{([^}]+)\}/gs
+      : /export\s*\{([^}]+)\}/gs;
+  for (const match of source.matchAll(pattern)) {
     const block = match[1] ?? '';
     for (const part of block.split(',')) {
       const trimmed = part.trim();
       if (!trimmed) continue;
-      // Support `Foo as Bar` / trailing comments are unlikely; take the local name.
       const localName = trimmed.split(/\s+as\s+/)[0]?.trim();
       if (localName && /^[A-Za-z_][A-Za-z0-9_]*$/.test(localName)) {
         names.push(localName);
       }
     }
   }
-  return names.sort();
+  return [...new Set(names)].sort();
+}
+
+function parseExportedTypeNames(source: string): string[] {
+  return parseExportedNamesFromBlocks(source, 'type');
+}
+
+function parseExportedValueNames(source: string): string[] {
+  return parseExportedNamesFromBlocks(source, 'value');
+}
+
+function listDeclarationFiles(distRoot: string): readonly string[] {
+  return readdirSync(distRoot, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith('.d.ts'))
+    .sort();
 }
 
 describe('v4 public API boundary audit (#489) — export allowlist', () => {
@@ -233,5 +251,59 @@ describe('v4 public API boundary audit (#489) — removed APIs', () => {
     expect('isBrowserSupported' in publicApi).toBe(false);
     expect(publicIndexSource).not.toMatch(/\bisBrowserSupported\b/);
     expect('isWebSerialSupported' in publicApi).toBe(true);
+  });
+});
+
+describe('v4 public API boundary audit (#489) — package exports and declarations', () => {
+  it('restricts package.json exports to the root entry and package.json', () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(packageRoot, 'package.json'), 'utf8'),
+    ) as { exports?: Record<string, unknown> };
+
+    expect(Object.keys(packageJson.exports ?? {}).sort()).toEqual([
+      '.',
+      './package.json',
+    ]);
+  });
+
+  it('keeps dist/index.d.ts runtime exports aligned with the allowlist', () => {
+    const dtsPath = join(packageRoot, 'dist/index.d.ts');
+    expect(
+      existsSync(dtsPath),
+      'dist/index.d.ts is missing; run `pnpm exec nx build web-serial-rxjs` (CI builds before test)',
+    ).toBe(true);
+
+    const dtsSource = readFileSync(dtsPath, 'utf8');
+    const actual = parseExportedValueNames(dtsSource);
+    const expected = [...CANONICAL_RUNTIME_EXPORTS].sort();
+    expect(actual).toEqual(expected);
+  });
+
+  it('keeps dist/index.d.ts type exports aligned with the allowlist', () => {
+    const dtsPath = join(packageRoot, 'dist/index.d.ts');
+    expect(existsSync(dtsPath)).toBe(true);
+
+    const dtsSource = readFileSync(dtsPath, 'utf8');
+    const actual = parseExportedTypeNames(dtsSource);
+    const expected = [...CANONICAL_TYPE_EXPORTS].sort();
+    expect(actual).toEqual(expected);
+  });
+
+  it('does not reintroduce removed APIs in declaration build output', () => {
+    const distRoot = join(packageRoot, 'dist');
+    expect(
+      existsSync(distRoot),
+      'dist/ is missing; run `pnpm exec nx build web-serial-rxjs` (CI builds before test)',
+    ).toBe(true);
+
+    for (const relativePath of listDeclarationFiles(distRoot)) {
+      const source = readFileSync(join(distRoot, relativePath), 'utf8');
+      for (const name of REMOVED_SESSION_APIS) {
+        expect(source, `${relativePath} / ${name}`).not.toContain(name);
+      }
+      expect(source, `${relativePath} / receiveReplay`).not.toMatch(
+        /receiveReplay/,
+      );
+    }
   });
 });

--- a/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
@@ -3,6 +3,10 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import * as publicApi from '../../src/index';
+import {
+  createSerialSession,
+  type SerialSession,
+} from '../../src/index';
 
 /**
  * Regression guard for the v4 public API boundary (Issue #489 / Parent #485).
@@ -14,10 +18,43 @@ import * as publicApi from '../../src/index';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageRoot = join(__dirname, '../..');
+const packageSrcRoot = join(packageRoot, 'src');
 const publicIndexSource = readFileSync(
-  join(packageRoot, 'src/index.ts'),
+  join(packageSrcRoot, 'index.ts'),
   'utf8',
 );
+
+const PUBLIC_SURFACE_SOURCES = [
+  'index.ts',
+  'session/serial-session.ts',
+  'session/create-serial-session.ts',
+  'session/index.ts',
+  'session/serial-session-options.ts',
+] as const;
+
+/** Exact `SerialSession` public members for v4 (Issue #485 target shape). */
+const CANONICAL_SESSION_KEYS = [
+  'connect$',
+  'disconnect$',
+  'dispose$',
+  'errors$',
+  'lines$',
+  'receive$',
+  'send$',
+  'state$',
+  'terminalText$',
+] as const;
+
+/** APIs removed in Phase 1 / Phase 2 that must not return on `SerialSession`. */
+const REMOVED_SESSION_APIS = [
+  'destroy$',
+  'getCurrentPort',
+  'getPortInfo',
+  'isBrowserSupported',
+  'isConnected$',
+  'portInfo$',
+  'receiveReplay$',
+] as const;
 
 /**
  * Runtime values exported from the package root barrel.
@@ -101,5 +138,100 @@ describe('v4 public API boundary audit (#489) — export allowlist', () => {
     const actual = parseExportedTypeNames(publicIndexSource);
     const expected = [...CANONICAL_TYPE_EXPORTS].sort();
     expect(actual).toEqual(expected);
+  });
+});
+
+describe('v4 public API boundary audit (#489) — SerialSession shape', () => {
+  it('keeps keyof SerialSession aligned with the canonical member set', () => {
+    type ExpectedKeys = (typeof CANONICAL_SESSION_KEYS)[number];
+    type ActualKeys = keyof SerialSession;
+    type ExtraKeys = Exclude<ActualKeys, ExpectedKeys>;
+    type MissingKeys = Exclude<ExpectedKeys, ActualKeys>;
+    type ExactShape = [ExtraKeys] extends [never]
+      ? [MissingKeys] extends [never]
+        ? true
+        : false
+      : false;
+
+    const exact: ExactShape = true;
+    expect(exact).toBe(true);
+  });
+
+  it('exposes only canonical members on createSerialSession() at runtime', () => {
+    const session = createSerialSession({ baudRate: 115200 });
+    const actual = Object.getOwnPropertyNames(session).sort();
+    const expected = [...CANONICAL_SESSION_KEYS].sort();
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('v4 public API boundary audit (#489) — removed APIs', () => {
+  it('excludes removed APIs from keyof SerialSession', () => {
+    type HasDestroy = 'destroy$' extends keyof SerialSession ? true : false;
+    type HasGetCurrentPort = 'getCurrentPort' extends keyof SerialSession
+      ? true
+      : false;
+    type HasGetPortInfo = 'getPortInfo' extends keyof SerialSession
+      ? true
+      : false;
+    type HasIsBrowserSupported =
+      'isBrowserSupported' extends keyof SerialSession ? true : false;
+    type HasIsConnected = 'isConnected$' extends keyof SerialSession
+      ? true
+      : false;
+    type HasPortInfo = 'portInfo$' extends keyof SerialSession ? true : false;
+    type HasReceiveReplay = 'receiveReplay$' extends keyof SerialSession
+      ? true
+      : false;
+
+    const removed: [
+      HasDestroy,
+      HasGetCurrentPort,
+      HasGetPortInfo,
+      HasIsBrowserSupported,
+      HasIsConnected,
+      HasPortInfo,
+      HasReceiveReplay,
+    ] = [false, false, false, false, false, false, false];
+
+    expect(removed).toEqual([
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it('keeps removed APIs out of public session surface sources', () => {
+    for (const relativePath of PUBLIC_SURFACE_SOURCES) {
+      const source = readFileSync(join(packageSrcRoot, relativePath), 'utf8');
+      for (const name of REMOVED_SESSION_APIS) {
+        expect(source, `${relativePath} / ${name}`).not.toContain(name);
+      }
+      expect(source, `${relativePath} / receiveReplay`).not.toMatch(
+        /receiveReplay/,
+      );
+    }
+  });
+
+  it('does not expose removed APIs on createSerialSession() return value', () => {
+    const session = createSerialSession({ baudRate: 115200 });
+    const ownProperties = Object.getOwnPropertyNames(session);
+
+    for (const name of REMOVED_SESSION_APIS) {
+      expect(ownProperties, name).not.toContain(name);
+      expect(Object.prototype.hasOwnProperty.call(session, name), name).toBe(
+        false,
+      );
+    }
+  });
+
+  it('does not re-export isBrowserSupported from the package root barrel', () => {
+    expect('isBrowserSupported' in publicApi).toBe(false);
+    expect(publicIndexSource).not.toMatch(/\bisBrowserSupported\b/);
+    expect('isWebSerialSupported' in publicApi).toBe(true);
   });
 });

--- a/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import * as publicApi from '../../src/index';
+
+/**
+ * Regression guard for the v4 public API boundary (Issue #489 / Parent #485).
+ *
+ * Keep the allowlists in sync with:
+ * - `src/index.ts` (public barrel / TypeDoc entry)
+ * - package README / concepts docs when the surface changes intentionally
+ */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '../..');
+const publicIndexSource = readFileSync(
+  join(packageRoot, 'src/index.ts'),
+  'utf8',
+);
+
+/**
+ * Runtime values exported from the package root barrel.
+ * Intentional API additions must update this list explicitly.
+ */
+const CANONICAL_RUNTIME_EXPORTS = [
+  'assertNever',
+  'createSerialSession',
+  'createTerminalBuffer',
+  'DEFAULT_LINE_BUFFER_OPTIONS',
+  'DEFAULT_TERMINAL_BUFFER_OPTIONS',
+  'isConnectedSessionState',
+  'isWebSerialSupported',
+  'resolveSerialSessionOptions',
+  'SerialError',
+  'SerialErrorCode',
+  'SerialSessionStatus',
+] as const;
+
+/**
+ * Type-only exports from `src/index.ts` (`export type { ... }`).
+ * Parsed from source because they do not appear on `import * as publicApi`.
+ */
+const CANONICAL_TYPE_EXPORTS = [
+  'ConnectedSessionState',
+  'ConnectingSessionState',
+  'DisconnectingSessionState',
+  'DisposedSessionState',
+  'ErrorSessionState',
+  'IdleSessionState',
+  'LineBufferOptions',
+  'ResolvedSerialSessionOptions',
+  'SerialConnectionOptions',
+  'SerialErrorCauseContext',
+  'SerialErrorContextMap',
+  'SerialPayload',
+  'SerialSession',
+  'SerialSessionFeatureOptions',
+  'SerialSessionOptions',
+  'SerialSessionState',
+  'TerminalBuffer',
+  'TerminalBufferOptions',
+  'UnsupportedSessionState',
+  'ValidationErrorConstraint',
+  'ValidationErrorContext',
+] as const;
+
+function parseExportedTypeNames(source: string): string[] {
+  const names: string[] = [];
+  const typeExportBlocks =
+    source.matchAll(/export\s+type\s*\{([^}]+)\}/gs);
+  for (const match of typeExportBlocks) {
+    const block = match[1] ?? '';
+    for (const part of block.split(',')) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      // Support `Foo as Bar` / trailing comments are unlikely; take the local name.
+      const localName = trimmed.split(/\s+as\s+/)[0]?.trim();
+      if (localName && /^[A-Za-z_][A-Za-z0-9_]*$/.test(localName)) {
+        names.push(localName);
+      }
+    }
+  }
+  return names.sort();
+}
+
+describe('v4 public API boundary audit (#489) — export allowlist', () => {
+  it('keeps package-root runtime exports aligned with the allowlist', () => {
+    const actual = Object.keys(publicApi).sort();
+    const expected = [...CANONICAL_RUNTIME_EXPORTS].sort();
+    expect(actual).toEqual(expected);
+  });
+
+  it('exposes every allowlisted runtime export', () => {
+    for (const name of CANONICAL_RUNTIME_EXPORTS) {
+      expect(name in publicApi, name).toBe(true);
+    }
+  });
+
+  it('keeps package-root type exports aligned with the allowlist', () => {
+    const actual = parseExportedTypeNames(publicIndexSource);
+    const expected = [...CANONICAL_TYPE_EXPORTS].sort();
+    expect(actual).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## PR Title (Conventional Commits)
test(web-serial-rxjs): lock v4 public API boundary

## Summary
v4 Phase 2 の公開 API 境界を Vitest allowlist / 削除 API audit で機械的に固定します。あわせて、削除済み宣言が dist に残り得る問題を防ぐため、型生成前に dist をクリーンするようにしました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #489
- Parent: #485

## What changed?
- パッケージルートの runtime / type export の完全 allowlist を追加
- `SerialSession` のメンバー集合を厳密一致で固定
- Phase 1 / Phase 2 で削除した API（`receiveReplay$`、`isBrowserSupported` 等）の negative / ソース / runtime 検証を追加
- `package.json` の `exports` がルートエントリのみであることを検証
- `dist/**/*.d.ts` に削除 API が再出現しないことを検証
- ビルド時に `clean` を先実行し、削除済みソース由来の古い `.d.ts` が残らないように変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx build web-serial-rxjs`
2. `pnpm exec nx test web-serial-rxjs -- tests/session/public-api-boundary-audit.test.ts`
3. `pnpm exec nx run web-serial-rxjs:lint`
4. `pnpm exec nx run web-serial-rxjs:verify-dist`

## Environment (if relevant)
- Browser: N/A（公開 API 境界の静的 / 単体テスト）
- OS: macOS
- web-serial-rxjs version (for verification): workspace main + this branch
- RxJS version: peer `^7.8.0`

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)