### PR TITLE
docs(web-serial-rxjs): add v4 phase 2 migration guide

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -104,6 +104,7 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 | **[クイックスタート](packages/web-serial-rxjs/docs/guide/ja/quick-start.md)** | 最短でポートを開いて購読するところまで。 |
 | **[高度な使用方法](packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
 | **[API の概念と設計メモ](packages/web-serial-rxjs/docs/guide/ja/concepts.md)** | オプション、`SerialSessionState`、`SerialError` の表形式補足。 |
+| **[v3 → v4 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v4.md)** | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理）。 |
 | **[v2 → v3 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v3.md)** | `state$` discriminated union、`SerialSessionStatus`、`context.cause`。 |
 | **[v1 → v2 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v2.md)** | 削除された v1 API からの対応表。 |
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Documentation is split into **Guide** (how to use; Japanese and English hand-wri
 | **[Quick Start](packages/web-serial-rxjs/docs/guide/en/quick-start.md)** | Shortest path to a working open port and subscriptions. |
 | **[Advanced Usage](packages/web-serial-rxjs/docs/guide/en/advanced-usage.md)** | Line framing, request/response-style flows, and recovery. |
 | **[API concepts and design notes](packages/web-serial-rxjs/docs/guide/en/concepts.md)** | Options, `SerialSessionState`, and `SerialError` details. |
+| **[v3 → v4 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v4.md)** | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup). |
 | **[v2 → v3 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v3.md)** | `state$` discriminated union, `SerialSessionStatus`, and `context.cause`. |
 | **[v1 → v2 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v2.md)** | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
 

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -23,11 +23,11 @@ Web Serial API は**デスクトップ**ブラウザでのみサポートされ�
 
 ## 接続状態（ライフサイクル UI）
 
-ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。セッション破棄には **`dispose$()`** を使用します（購読により実行されます）。詳細は [v3 移行ガイド – Phase 1 API 削除](./docs/guide/ja/migration-v3.md#phase-1-api-削除) を参照してください。
+ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。セッション破棄には **`dispose$()`** を使用します（購読により実行されます）。詳細は [v4 への移行](./docs/guide/ja/migration-v4.md) を参照してください。
 
 ## 接続中のポート情報（デバイス識別）
 
-`connect$` 成功後、`state$` を `state.status === SerialSessionStatus.Connected` で handling する場合は **`state.portInfo`** を canonical API として使用してください。生の `SerialPort` は公開しません。削除された convenience API（`isConnected$`、`portInfo$`、`getPortInfo()`、`destroy$()`、`getCurrentPort()`）と置換先は [v3 移行ガイド](./docs/guide/ja/migration-v3.md#phase-1-api-削除) を参照してください。
+`connect$` 成功後、`state$` を `state.status === SerialSessionStatus.Connected` で handling する場合は **`state.portInfo`** を canonical API として使用してください。生の `SerialPort` は公開しません。削除された convenience API（`isConnected$`、`portInfo$`、`getPortInfo()`、`destroy$()`、`getCurrentPort()`、`receiveReplay$`、`isBrowserSupported()`）と置換先は [v4 への移行](./docs/guide/ja/migration-v4.md) を参照してください。
 
 ## `receive$` と `lines$`
 
@@ -96,6 +96,7 @@ pnpm add rxjs
 | [クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/quick-start.md) | ポートを開いて購読までを最短で |
 | [高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md) | 行フレーミング、擬似リクエスト/レス、リカバリ |
 | [API の概念と設計メモ](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/concepts.md) | オプション、`SerialError`、型の表形式補足 |
+| [v3 → v4 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md) | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理） |
 | [v2 → v3 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md) | `state$` discriminated union、`SerialSessionStatus`、`context.cause` |
 | [v1 → v2 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md) | 廃止された v1 API の置き換え |
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ構成、**`apps/` のサンプル**、貢献、MCP、プロジェクトアイコン |

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -23,11 +23,11 @@ Supported desktop browsers:
 
 ## Connection state (lifecycle UI)
 
-Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. Session teardown uses **`dispose$()`** (subscribe to run it). See [Migrating to v3 – Phase 1 removals](./docs/guide/en/migration-v3.md#phase-1-api-removals).
+Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. Session teardown uses **`dispose$()`** (subscribe to run it). See [Migrating to v4](./docs/guide/en/migration-v4.md).
 
 ## Port info (device identification)
 
-After a successful `connect$`, use `state.portInfo` when handling `state$` with `state.status === SerialSessionStatus.Connected` — this is the canonical API. Raw `SerialPort` is not exposed. Removed convenience APIs (`isConnected$`, `portInfo$`, `getPortInfo()`, `destroy$()`, `getCurrentPort()`) and their replacements are documented in [Migrating to v3](./docs/guide/en/migration-v3.md#phase-1-api-removals).
+After a successful `connect$`, use `state.portInfo` when handling `state$` with `state.status === SerialSessionStatus.Connected` — this is the canonical API. Raw `SerialPort` is not exposed. Removed convenience APIs (`isConnected$`, `portInfo$`, `getPortInfo()`, `destroy$()`, `getCurrentPort()`, `receiveReplay$`, `isBrowserSupported()`) and their replacements are documented in [Migrating to v4](./docs/guide/en/migration-v4.md).
 
 ## `receive$` vs `lines$`
 
@@ -100,6 +100,7 @@ pnpm add rxjs
 | [Quick Start](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/quick-start.md) | Open a port and wire subscriptions end-to-end |
 | [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md) | Line framing, request/response-style flows, recovery |
 | [API concepts and design notes](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/concepts.md) | `SerialSessionOptions`, `SerialError`, and formal details |
+| [v3 → v4 migration](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v4.md) | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup) |
 | [v2 → v3 migration](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v3.md) | `state$` discriminated union, `SerialSessionStatus`, `context.cause` |
 | [v1 → v2 migration](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v2.md) | Replacing the removed v1 `SerialClient` / `ShellClient` API |
 | [Repository README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md) | Monorepo layout, **examples** under `apps/`, contributing, MCP, and project icon |

--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -13,6 +13,7 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 
 When migrating existing code:
 
+- **[v3 → v4 Migration](./migration-v4.md)** — Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup)
 - **[v2 → v3 Migration](./migration-v3.md)** — `state$` discriminated union, `SerialSessionStatus`, `context.cause`
 - **[v1 → v2 Migration](./migration-v2.md)** — mapping for removed v1 APIs
 
@@ -24,6 +25,7 @@ When migrating existing code:
 | **[Quick Start](./quick-start.md)** | Basic flow from installation through disconnect |
 | **[Advanced Usage](./advanced-usage.md)** | Application patterns and RxJS recipes |
 | **[API concepts and design notes](./concepts.md)** | Options, error codes, and type tables |
+| **[v3 → v4 Migration](./migration-v4.md)** | Unified Phase 1+2 public API cleanup |
 | **[v2 → v3 Migration](./migration-v3.md)** | Steps to adopt v3 canonical API |
 | **[v1 → v2 Migration](./migration-v2.md)** | Replacements for removed v1 APIs |
 | **[Phase 5 (archive)](./archive/migration-phase5.md)** | Legacy v1 documentation reference |
@@ -36,8 +38,10 @@ When migrating existing code:
 - **English TypeDoc API Reference** — [modules.html](modules.html)
 - **Parent issue** — [#453](https://github.com/gurezo/web-serial-rxjs/issues/453) (documentation structure)
 
-## v3 canonical API highlights
+## Canonical API highlights
 
 - **`state$`** — canonical lifecycle source. Branch on `state.status` with `SerialSessionStatus`; use `state.portInfo` when connected
 - **`errors$`** — canonical fatal / non-fatal error event channel. Branch with `SerialError.is(SerialErrorCode.*)`
-- **`dispose$()`** — sole session teardown API (subscribe to run it). Removed convenience APIs (`destroy$`, `isConnected$`, `portInfo$`, `getPortInfo()`, `getCurrentPort()`) are documented in [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals)
+- **`dispose$()`** — sole session teardown API (subscribe to run it)
+- **`isWebSerialSupported()`** — top-level sync feature detection (not a session method)
+- Phase 1+2 removals (`destroy$`, `isConnected$`, `portInfo$`, `getPortInfo()`, `getCurrentPort()`, `receiveReplay$`, `isBrowserSupported()`) are documented in [Migrating to v4](./migration-v4.md)

--- a/packages/web-serial-rxjs/docs/guide/en/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/en/concepts.md
@@ -217,7 +217,7 @@ interface SerialSession {
 
 ### `isWebSerialSupported(): boolean`
 
-Synchronous feature check. Returns `true` when `navigator.serial` is available.
+Synchronous feature check. Returns `true` when `navigator.serial` is available. Prefer this **before** creating a session. After the session exists, drive unsupported UI from `state$` with `SerialSessionStatus.Unsupported`. See [Migrating to v4 – browser support](./migration-v4.md#browser-support-detection).
 
 ### `connect$(): Observable<void>`
 
@@ -235,7 +235,7 @@ After disposal, `connect$` and `send$` fail with `SerialErrorCode.SESSION_DISPOS
 
 ### `state$: Observable<SerialSessionState>`
 
-Replays the current state on subscribe. Prefer driving your UI from this stream instead of rebuilding a `BehaviorSubject`. When `state.status` is `SerialSessionStatus.Connected`, read **`state.portInfo`** for device identification. There is no separate `portInfo$` / `getPortInfo()` / `isConnected$` / `destroy$()` / `getCurrentPort()` on the public API — see [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals).
+Replays the current state on subscribe. Prefer driving your UI from this stream instead of rebuilding a `BehaviorSubject`. When `state.status` is `SerialSessionStatus.Connected`, read **`state.portInfo`** for device identification. There is no separate `portInfo$` / `getPortInfo()` / `isConnected$` / `destroy$()` / `getCurrentPort()` / `receiveReplay$` / `isBrowserSupported()` on the public API — see [Migrating to v4](./migration-v4.md).
 
 ### `errors$: Observable<SerialError>`
 
@@ -281,7 +281,7 @@ try {
 
 The same union is available as a **const object** `SerialErrorCode` (e.g. `SerialErrorCode.READ_FAILED` is `'READ_FAILED'`) for IDE completion and to avoid string typos. String literals stay valid for types and runtime comparisons. See [Migrating to v3](./migration-v3.md) for the enum-to-const declaration change.
 
-Runtime emission coverage for all 17 codes is audited in [Migrating to v3 §8](./migration-v3.md#8-serialerrorcode-runtime-emission-audit).
+Runtime emission coverage for the implemented codes is audited in [Migrating to v3 §8](./migration-v3.md#8-serialerrorcode-runtime-emission-audit). Receive-replay codes were removed in [Migrating to v4 – Phase 2](./migration-v4.md#phase-2-api-removals).
 
 | Code                     | `context` shape | When it is emitted                                                  |
 | ------------------------ | --------------- | ------------------------------------------------------------------- |

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v2.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v2.md
@@ -4,6 +4,8 @@ v2 replaces the multi-surface `SerialClient` / `ShellClient` / browser-util API 
 
 This guide maps every removed symbol to its v2 replacement.
 
+> **Note (v4):** In v2/v3, browser support lived on `session.isBrowserSupported()`. **v4 moves it back to a top-level** `isWebSerialSupported()` (and `state$` with `Unsupported` for post-creation UI). See [Migrating to v4](./migration-v4.md). The v2 mappings below remain historically accurate for a v1 → v2 upgrade.
+
 ## TL;DR
 
 ```typescript
@@ -24,6 +26,10 @@ if (!session.isBrowserSupported()) return;
 session.connect$().subscribe();
 session.receive$.subscribe(console.log);
 session.send$('hi').subscribe();
+
+// v4 (current): use the top-level helper instead of the session method
+// import { createSerialSession, isWebSerialSupported } from '@gurezo/web-serial-rxjs';
+// if (!isWebSerialSupported()) return;
 ```
 
 ## Removed public exports

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
@@ -404,8 +404,9 @@ Some members of the public `SerialErrorCode` contract were not emitted by the v3
 
 | Category | Count | Description |
 | --- | --- | --- |
-| **Implemented** | 17 | Emitted at runtime in v3.x (or thrown at factory time) |
-| **Reserved** | 2 | Present in the public API but not emitted in v3.x; scheduled for removal in the next major version |
+| **Implemented** | 15 | Emitted at runtime in v3.x / v4 (or thrown at factory time) |
+| **Reserved** | 2 | Present in the public API but not emitted; scheduled for removal in the next major version |
+| **Removed in v4 Phase 2** | 2 | Receive-replay codes deleted with `receiveReplay$` / `receiveReplay` |
 
 ### Reserved codes (not emitted in v3.x)
 
@@ -430,13 +431,20 @@ v3.x adds `@deprecated` annotations only; runtime values and exports are unchang
 | `INVALID_FILTER_OPTIONS` | `createSerialSession` factory | throw | `ValidationErrorContext` | unit + integration |
 | `OPERATION_CANCELLED` | `requestPort` dialog cancelled | fatal | `{ cause }` | integration |
 | `LINE_BUFFER_OVERFLOW` | `lines$` tail overflow | non-fatal | `{ maxChars }` | integration |
-| `INVALID_RECEIVE_REPLAY_OPTIONS` | factory | throw | `ValidationErrorContext` | unit + integration |
 | `INVALID_TERMINAL_BUFFER_OPTIONS` | factory | throw | `ValidationErrorContext` | unit |
 | `INVALID_LINE_BUFFER_OPTIONS` | factory | throw | `ValidationErrorContext` | unit |
 | `INVALID_CONNECTION_OPTIONS` | factory | throw | `ValidationErrorContext` | unit + integration |
-| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` overflow | non-fatal | `{ maxChars, bufferSize }` | integration |
 | `SESSION_DISPOSED` | `connect$` / `send$` after `dispose$` | fatal | `undefined` | integration |
 | `UNKNOWN` | unclassified dispose / disconnect fallback | fatal | `{ cause }` | unit |
+
+### Removed in v4 Phase 2
+
+| Code | Former emit location | Notes |
+| --- | --- | --- |
+| `INVALID_RECEIVE_REPLAY_OPTIONS` | factory | Removed with `options.receiveReplay` |
+| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` overflow | Removed with `receiveReplay$` |
+
+See [Migrating to v4 – Phase 2](./migration-v4.md#phase-2-api-removals).
 
 Fatal vs non-fatal follows `ERROR_SEVERITY` inside `reportError`. Factory-thrown `INVALID_*` codes bypass `reportError` and throw directly to the caller.
 
@@ -559,19 +567,20 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 ```
 
 - `SerialConnectionOptions` — `baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl` (passed to `port.open`)
-- `SerialSessionFeatureOptions` — `filters`, `terminalBuffer`, `lineBuffer` (library-specific; `receiveReplay` was removed in v4 Phase 2)
+- `SerialSessionFeatureOptions` — `filters`, `terminalBuffer`, `lineBuffer` (library-specific; `receiveReplay` was removed in v4 Phase 2 — see [Migrating to v4](./migration-v4.md))
 - `SerialSessionOptions` — composition of the two (factory argument)
 
 See [API Reference – SerialSessionOptions](./concepts.md#serialsessionoptions) for details. Boundary semantics (`0` = unlimited for buffer limits only; connection fields require `> 0`) are documented there ([#488](https://github.com/gurezo/web-serial-rxjs/issues/488)).
 
 ### v3.x compatibility
 
-The `createSerialSession(options?)` signature and existing options object literals remain **unchanged**. `SerialSessionFeatureOptions` is added as a new public export.
+The `createSerialSession(options?)` signature and existing options object literals remain **unchanged** for connection / buffer fields. `SerialSessionFeatureOptions` is added as a new public export. `receiveReplay` is removed in v4 — migrate via [Migrating to v4](./migration-v4.md).
 
 ---
 
 ## See also
 
+- [Migrating to v4](./migration-v4.md)
 - [Migrating from v1 to v2](./migration-v2.md)
 - [API Reference – SerialSessionState / SerialSessionStatus](./concepts.md#serialsessionstate--serialsessionstatus)
 - [API Reference – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode)

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v4.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v4.md
@@ -1,0 +1,223 @@
+# Migrating to v4
+
+v4 consolidates public API cleanup from Phase 1 ([#472](https://github.com/gurezo/web-serial-rxjs/issues/472)) and Phase 2 ([#485](https://github.com/gurezo/web-serial-rxjs/issues/485)) into one major upgrade. This guide covers both phases so you can migrate once.
+
+TypeScript-facing changes introduced in v3 (`SerialErrorCode` const object, discriminated-union `state$`) remain as documented in [Migrating to v3](./migration-v3.md).
+
+## TL;DR
+
+```typescript
+import {
+  createSerialSession,
+  isWebSerialSupported,
+  SerialSessionStatus,
+} from '@gurezo/web-serial-rxjs';
+import { shareReplay } from 'rxjs';
+
+if (!isWebSerialSupported()) {
+  // fallback UI before creating a session
+}
+
+const session = createSerialSession({ baudRate: 9600 });
+
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Unsupported) {
+    // unsupported UI after session creation
+  }
+});
+
+// Prefer the stream that matches your use case:
+session.receive$.subscribe(/* decoded chunks */);
+session.lines$.subscribe(/* complete lines */);
+session.terminalText$.subscribe(/* terminal display text */);
+
+// If you previously used receiveReplay$, compose operators yourself.
+// This is NOT a drop-in replacement for the removed API.
+const replayedReceive$ = session.receive$.pipe(
+  shareReplay({
+    bufferSize: 1,
+    refCount: true,
+  }),
+);
+```
+
+---
+
+## Phase 1 API removals
+
+Phase 1 of [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) removed duplicate / escape-hatch APIs so `state$` and `dispose$()` are the only public sources for lifecycle and teardown. Documentation pass: [#478](https://github.com/gurezo/web-serial-rxjs/issues/478).
+
+| Removed API | Replacement |
+| --- | --- |
+| `destroy$()` | `dispose$()` |
+| `isConnected$` | `state$` with `state.status` (or derive a boolean from `state$`) |
+| `portInfo$` | `state.portInfo` when `state.status === SerialSessionStatus.Connected` |
+| `getPortInfo()` | `state.portInfo` when connected (same as above) |
+| `getCurrentPort()` | No direct replacement. Use `state.portInfo` for identification; raw `SerialPort` is not exposed |
+
+Longer examples and checklists: [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals).
+
+---
+
+## Phase 2 API removals
+
+Phase 2 of [#485](https://github.com/gurezo/web-serial-rxjs/issues/485) removes session-attached derived APIs and options that did not match their names or session responsibilities. Implementation: [#486](https://github.com/gurezo/web-serial-rxjs/issues/486), [#487](https://github.com/gurezo/web-serial-rxjs/issues/487), [#488](https://github.com/gurezo/web-serial-rxjs/issues/488). Docs: [#490](https://github.com/gurezo/web-serial-rxjs/issues/490).
+
+| Before (v3 and earlier) | After (v4) |
+| --- | --- |
+| `session.receiveReplay$` | `session.receive$` composed with the RxJS operators you need |
+| `options.receiveReplay` | Removed |
+| `session.isBrowserSupported()` | Top-level `isWebSerialSupported()`, or `state$` with `Unsupported` |
+| Mixed / opaque session options | `SerialConnectionOptions` + `SerialSessionFeatureOptions` composition |
+
+### `receiveReplay$` and `receiveReplay` option
+
+`receiveReplay$` only replayed past chunks when `receiveReplay.enabled` was set at session creation. When disabled it behaved like `receive$`, so the name and behavior did not match. Replay applied to decoded receive chunks only—not to `lines$` or `terminalText$`—and required separate `bufferSize` / `maxChars` limits.
+
+**v4 removes both the stream and the option.** If your app needs replay-like caching, compose operators on `receive$` yourself.
+
+```typescript
+import { shareReplay } from 'rxjs';
+
+const replayedReceive$ = session.receive$.pipe(
+  shareReplay({
+    bufferSize: 1,
+    refCount: true,
+  }),
+);
+```
+
+#### Not a drop-in replacement
+
+This pattern is **not** guaranteed to be fully compatible with the removed `receiveReplay$` API:
+
+- `shareReplay` `bufferSize` counts **events**, not characters. The old option also supported `maxChars`.
+- There is **no** built-in `maxChars` / character-budget limit in this recipe.
+- Cache lifetime across connect / disconnect / dispose must be designed in application code.
+- Decide how errors and completion are re-notified (`shareReplay` reset / refCount behavior differs from the old session-owned buffer).
+
+Do not treat `shareReplay` as a complete substitute for the deleted feature.
+
+### Browser support detection
+
+Web Serial availability is not per-session state. Calling `createSerialSession()` only to check support was confusing.
+
+**Before creating a session** (sync feature detection):
+
+```typescript
+import { isWebSerialSupported } from '@gurezo/web-serial-rxjs';
+
+if (!isWebSerialSupported()) {
+  // fallback UI
+}
+```
+
+**After the session exists**, prefer `state$` for UI that follows lifecycle:
+
+```typescript
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Unsupported) {
+    // unsupported UI
+  }
+});
+```
+
+`session.isBrowserSupported()` is removed. See also [API concepts – `isWebSerialSupported`](./concepts.md#iswebserialsupported-boolean).
+
+### Session options layout
+
+`SerialSessionOptions` remains a single factory argument, but responsibilities are clearer:
+
+```text
+SerialConnectionOptions     = W3C connection parameters for port.open
+SerialSessionFeatureOptions = library-specific session features
+SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFeatureOptions
+```
+
+- **Connection:** `baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`
+- **Features:** `filters`, `terminalBuffer`, `lineBuffer` (`receiveReplay` is gone)
+
+Boundary semantics (`0` = unlimited for buffer limits only; connection fields require `> 0`) are documented in [API concepts – SerialSessionOptions](./concepts.md#serialsessionoptions).
+
+---
+
+## Streams kept in v4
+
+These are **not** duplicates. Each abstracts a different use case:
+
+| API | Use it for |
+| --- | --- |
+| `receive$` | Decoded UTF-8 **chunks** from the read pump |
+| `lines$` | Newline-framed **complete lines** (logs / protocols) |
+| `terminalText$` | Cumulative text for **terminal display** (including `\r` redraw behavior) |
+
+They stay on `SerialSession` so apps do not reimplement framing, incomplete tails, or terminal buffer limits. Details: [API concepts – SerialSession](./concepts.md#serialsession).
+
+---
+
+## Unchanged in Phase 2
+
+The following stay as in v3 / Phase 1 completion:
+
+- Operation Observables (`connect$`, `send$`, `disconnect$`, `dispose$`) run when **subscribed** (cold)
+- No Promise-based duplicate APIs are added
+- `errors$` and operation-Observable error notification semantics are unchanged
+- `lines$` / `terminalText$` are **not** moved to user-land operators
+- No new selector / convenience APIs are added in Phase 2
+
+Target public shape:
+
+```typescript
+export interface SerialSession {
+  readonly state$: Observable<SerialSessionState>;
+  readonly errors$: Observable<SerialError>;
+
+  readonly receive$: Observable<string>;
+  readonly lines$: Observable<string>;
+  readonly terminalText$: Observable<string>;
+
+  connect$(): Observable<void>;
+  disconnect$(): Observable<void>;
+  send$(data: SerialPayload): Observable<void>;
+  dispose$(): Observable<void>;
+}
+```
+
+Plus the top-level helper:
+
+```typescript
+export function isWebSerialSupported(): boolean;
+```
+
+---
+
+## Migration checklist
+
+- [ ] Replace `destroy$()` with `dispose$()`; drive lifecycle UI from `state$`
+- [ ] Replace `isConnected$` / `portInfo$` / `getPortInfo()` / `getCurrentPort()` with `state$` / `state.portInfo`
+- [ ] Remove `receiveReplay$` subscriptions and `receiveReplay` options
+- [ ] If you need replay, compose RxJS operators on `receive$` and accept the differences above
+- [ ] Replace `session.isBrowserSupported()` with `isWebSerialSupported()` or `state$` `Unsupported`
+- [ ] Drop handling for removed receive-replay error codes (`INVALID_RECEIVE_REPLAY_OPTIONS`, `RECEIVE_REPLAY_BUFFER_OVERFLOW`)
+- [ ] Confirm you pick `receive$` / `lines$` / `terminalText$` by use case, not as interchangeable aliases
+
+---
+
+## Release notes (Phase 2)
+
+- Removed `SerialSession.receiveReplay$` and `SerialSessionOptions.receiveReplay`
+- Removed related receive-replay error codes and internal buffer implementation
+- Removed `SerialSession.isBrowserSupported()`; use top-level `isWebSerialSupported()`
+- Clarified `SerialSessionOptions` as connection fields + feature options (`filters`, `terminalBuffer`, `lineBuffer`)
+- Public API boundary locked by regression tests ([#489](https://github.com/gurezo/web-serial-rxjs/issues/489))
+
+---
+
+## See also
+
+- [Migrating to v3](./migration-v3.md) — `SerialErrorCode`, discriminated-union `state$`, Phase 1 detail sections
+- [Migrating from v1 to v2](./migration-v2.md) — `SerialClient` → `SerialSession` (note: v4 browser check is top-level again)
+- [API concepts and design notes](./concepts.md)
+- Parent issue [#485](https://github.com/gurezo/web-serial-rxjs/issues/485)

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v4.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v4.md
@@ -124,7 +124,7 @@ session.state$.subscribe((state) => {
 });
 ```
 
-`session.isBrowserSupported()` is removed. See also [API concepts – `isWebSerialSupported`](./concepts.md#iswebserialsupported-boolean).
+`session.isBrowserSupported()` is removed. See also [API concepts – SerialSession / `isWebSerialSupported`](./concepts.md#serialsession).
 
 ### Session options layout
 

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -13,6 +13,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 
 既存コードから移行する場合:
 
+- **[v3 → v4 マイグレーション](./migration-v4.md)** — Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理）
 - **[v2 → v3 マイグレーション](./migration-v3.md)** — `state$` discriminated union、`SerialSessionStatus`、`context.cause`
 - **[v1 → v2 マイグレーション](./migration-v2.md)** — 削除された v1 API の対応表
 
@@ -24,6 +25,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | **[クイックスタート](./quick-start.md)** | インストールから切断までの基本フロー |
 | **[高度な使用方法](./advanced-usage.md)** | 応用パターンと RxJS レシピ |
 | **[API の概念と設計メモ](./concepts.md)** | オプション・エラーコード・型の表形式補足 |
+| **[v3 → v4 マイグレーション](./migration-v4.md)** | Phase 1+2 公開 API 整理の統合ガイド |
 | **[v2 → v3 マイグレーション](./migration-v3.md)** | v3 canonical API への移行手順 |
 | **[v1 → v2 マイグレーション](./migration-v2.md)** | v1 廃止 API の置き換え |
 | **[Phase 5（アーカイブ）](./archive/migration-phase5.md)** | 旧 v1 ドキュメントの参照用 |
@@ -36,8 +38,10 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 - **英語 TypeDoc API Reference** — [../../api/modules.html](../../api/modules.html)
 - **親 Issue** — [#453](https://github.com/gurezo/web-serial-rxjs/issues/453)（ドキュメント構成整備）
 
-## v3 canonical API の要点
+## Canonical API の要点
 
 - **`state$`** — 接続ライフサイクルの canonical source。`state.status` と `SerialSessionStatus` で分岐し、connected 時は `state.portInfo` を利用する
 - **`errors$`** — fatal / non-fatal エラーの canonical event channel。`SerialError.is(SerialErrorCode.*)` で分岐する
-- **`dispose$()`** — セッション破棄の唯一の API（購読により実行）。削除された convenience API（`destroy$`、`isConnected$`、`portInfo$`、`getPortInfo()`、`getCurrentPort()`）は [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照
+- **`dispose$()`** — セッション破棄の唯一の API（購読により実行）
+- **`isWebSerialSupported()`** — トップレベルの同期 feature detection（セッションメソッドではない）
+- Phase 1+2 で削除された API（`destroy$`、`isConnected$`、`portInfo$`、`getPortInfo()`、`getCurrentPort()`、`receiveReplay$`、`isBrowserSupported()`）は [v4 への移行](./migration-v4.md) を参照

--- a/packages/web-serial-rxjs/docs/guide/ja/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/concepts.md
@@ -217,7 +217,7 @@ interface SerialSession {
 
 ### `isWebSerialSupported(): boolean`
 
-同期的な feature detection。`navigator.serial` が存在すれば `true` を返します。
+同期的な feature detection。`navigator.serial` が存在すれば `true` を返します。セッション生成**前**に使ってください。生成後の unsupported UI は `state$` の `SerialSessionStatus.Unsupported` を推奨します。詳細は [v4 への移行 – ブラウザー対応判定](./migration-v4.md#ブラウザー対応判定) を参照してください。
 
 ### `connect$(): Observable<void>`
 
@@ -235,7 +235,7 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 
 ### `state$: Observable<SerialSessionState>`
 
-購読時に現在値をリプレイします。`BehaviorSubject` を自前で再構築する代わりに、このストリームを UI の駆動源として使ってください。`state.status` が `SerialSessionStatus.Connected` のときは **`state.portInfo`** でデバイス識別します。公開 API に `portInfo$` / `getPortInfo()` / `isConnected$` / `destroy$()` / `getCurrentPort()` はありません — [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照してください。
+購読時に現在値をリプレイします。`BehaviorSubject` を自前で再構築する代わりに、このストリームを UI の駆動源として使ってください。`state.status` が `SerialSessionStatus.Connected` のときは **`state.portInfo`** でデバイス識別します。公開 API に `portInfo$` / `getPortInfo()` / `isConnected$` / `destroy$()` / `getCurrentPort()` / `receiveReplay$` / `isBrowserSupported()` はありません — [v4 への移行](./migration-v4.md) を参照してください。
 
 ### `errors$: Observable<SerialError>`
 
@@ -281,7 +281,7 @@ try {
 
 上記と同じ文字列のユニオン型に加え、**定数オブジェクト** `SerialErrorCode`（例: `SerialErrorCode.READ_FAILED` は `'READ_FAILED'`）が export され、補完やタイポ防止に使えます。従来どおり文字列リテラルで型注釈・比較しても問題ありません。enum から const object への宣言変更は [v3 移行ガイド](./migration-v3.md) を参照してください。
 
-全 17 code の runtime emission coverage は [v3 移行ガイド §8](./migration-v3.md#8-serialerrorcode-runtime-emission-監査) で監査済みです。
+実装済み code の runtime emission coverage は [v3 移行ガイド §8](./migration-v3.md#8-serialerrorcode-runtime-emission-監査) で監査済みです。receive-replay 関連 code は [v4 への移行 – Phase 2](./migration-v4.md#phase-2-api-削除) で削除されました。
 
 | Code                     | `context` の形 | emit されるタイミング                                              |
 | ------------------------ | -------------- | ------------------------------------------------------------------ |

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md
@@ -4,6 +4,8 @@ v2 では、v1 の `SerialClient` / `ShellClient` / ブラウザユーティリ�
 
 本ガイドでは削除された API と v2 での置換先をすべて対応付けます。
 
+> **注（v4）:** v2/v3 ではブラウザ対応判定は `session.isBrowserSupported()` にありました。**v4 ではトップレベルの** `isWebSerialSupported()`（および生成後 UI 向けの `state$` の `Unsupported`）に戻しています。詳細は [v4 への移行](./migration-v4.md) を参照してください。以下の v2 対応表は、v1 → v2 移行時点の歴史的な対応としてそのまま残しています。
+
 ## 一言まとめ
 
 ```typescript
@@ -24,6 +26,10 @@ if (!session.isBrowserSupported()) return;
 session.connect$().subscribe();
 session.receive$.subscribe(console.log);
 session.send$('hi').subscribe();
+
+// v4（現行）: セッションメソッドではなくトップレベルヘルパーを使う
+// import { createSerialSession, isWebSerialSupported } from '@gurezo/web-serial-rxjs';
+// if (!isWebSerialSupported()) return;
 ```
 
 ## 削除された公開 export

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
@@ -404,8 +404,9 @@ public API contract として定義されている `SerialErrorCode` のうち�
 
 | 分類 | 件数 | 説明 |
 | --- | --- | --- |
-| **Implemented** | 17 | v3.x で runtime から emit される（または factory 時に throw される） |
-| **Reserved** | 2 | public API に存在するが v3.x では emit されない。次回 major version で削除予定 |
+| **Implemented** | 15 | v3.x / v4 で runtime から emit される（または factory 時に throw される） |
+| **Reserved** | 2 | public API に存在するが emit されない。次回 major version で削除予定 |
+| **v4 Phase 2 で削除** | 2 | `receiveReplay$` / `receiveReplay` と共に削除された receive-replay コード |
 
 ### Reserved code（v3.x では emit されない）
 
@@ -430,13 +431,20 @@ v3.x では `@deprecated` 注記のみ付与し、runtime 値と export は維�
 | `INVALID_FILTER_OPTIONS` | `createSerialSession` factory | throw | `ValidationErrorContext` | 単体 + 統合 |
 | `OPERATION_CANCELLED` | `requestPort` ダイアログキャンセル | fatal | `{ cause }` | 統合 |
 | `LINE_BUFFER_OVERFLOW` | `lines$` tail 超過 | non-fatal | `{ maxChars }` | 統合 |
-| `INVALID_RECEIVE_REPLAY_OPTIONS` | factory | throw | `ValidationErrorContext` | 単体 + 統合 |
 | `INVALID_TERMINAL_BUFFER_OPTIONS` | factory | throw | `ValidationErrorContext` | 単体 |
 | `INVALID_LINE_BUFFER_OPTIONS` | factory | throw | `ValidationErrorContext` | 単体 |
 | `INVALID_CONNECTION_OPTIONS` | factory | throw | `ValidationErrorContext` | 単体 + 統合 |
-| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` 超過 | non-fatal | `{ maxChars, bufferSize }` | 統合 |
 | `SESSION_DISPOSED` | `dispose$` 後の `connect$` / `send$` | fatal | `undefined` | 統合 |
 | `UNKNOWN` | dispose / disconnect の分類不能 fallback | fatal | `{ cause }` | 単体 |
+
+### v4 Phase 2 で削除
+
+| Code | 旧 emit 箇所 | 備考 |
+| --- | --- | --- |
+| `INVALID_RECEIVE_REPLAY_OPTIONS` | factory | `options.receiveReplay` と共に削除 |
+| `RECEIVE_REPLAY_BUFFER_OVERFLOW` | `receiveReplay$` 超過 | `receiveReplay$` と共に削除 |
+
+詳細は [v4 への移行 – Phase 2](./migration-v4.md#phase-2-api-削除) を参照してください。
 
 fatal / non-fatal の判定は `reportError` 経由の `ERROR_SEVERITY` に従います。factory throw の `INVALID_*` code は `reportError` を通らず、呼び出し元に直接 throw されます。
 
@@ -559,19 +567,20 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 ```
 
 - `SerialConnectionOptions` — `baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`（`port.open` に渡される）
-- `SerialSessionFeatureOptions` — `filters`, `terminalBuffer`, `lineBuffer`（library-specific。`receiveReplay` は v4 Phase 2 で削除）
+- `SerialSessionFeatureOptions` — `filters`, `terminalBuffer`, `lineBuffer`（library-specific。`receiveReplay` は v4 Phase 2 で削除 — [v4 への移行](./migration-v4.md) を参照）
 - `SerialSessionOptions` — 上記 2 つの composition（factory 引数）
 
 詳細は [概念と設計メモ – SerialSessionOptions](./concepts.md#serialsessionoptions) を参照してください。境界値の意味（バッファ上限のみ `0` = 無制限、接続フィールドは `> 0` 必須）も同ページに記載しています（[#488](https://github.com/gurezo/web-serial-rxjs/issues/488)）。
 
 ### v3.x での互換性
 
-`createSerialSession(options?)` のシグネチャと、既存の options オブジェクトリテラルは **変更不要** です。`SerialSessionFeatureOptions` は新規 public export として追加されます。
+`createSerialSession(options?)` のシグネチャと、接続・バッファ系の既存 options オブジェクトリテラルは **変更不要** です。`SerialSessionFeatureOptions` は新規 public export として追加されます。`receiveReplay` は v4 で削除されるため、[v4 への移行](./migration-v4.md) に従ってください。
 
 ---
 
 ## 関連ドキュメント
 
+- [v4 への移行](./migration-v4.md)
 - [v1 から v2 への移行](./migration-v2.md)
 - [概念と設計メモ – SerialSessionState / SerialSessionStatus](./concepts.md#serialsessionstate--serialsessionstatus)
 - [概念と設計メモ – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode)

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md
@@ -1,0 +1,223 @@
+# v4 への移行
+
+v4 は Phase 1（[#472](https://github.com/gurezo/web-serial-rxjs/issues/472)）と Phase 2（[#485](https://github.com/gurezo/web-serial-rxjs/issues/485)）の公開 API 整理を、ひとつのメジャーアップグレードにまとめます。本ガイドは両フェーズを扱い、一度の移行で完了できるようにします。
+
+v3 で導入された TypeScript 向けの変更（`SerialErrorCode` の const object、discriminated union の `state$`）は、引き続き [v3 への移行](./migration-v3.md) を参照してください。
+
+## TL;DR
+
+```typescript
+import {
+  createSerialSession,
+  isWebSerialSupported,
+  SerialSessionStatus,
+} from '@gurezo/web-serial-rxjs';
+import { shareReplay } from 'rxjs';
+
+if (!isWebSerialSupported()) {
+  // セッション生成前の fallback UI
+}
+
+const session = createSerialSession({ baudRate: 9600 });
+
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Unsupported) {
+    // セッション生成後の unsupported UI
+  }
+});
+
+// 用途に合ったストリームを選ぶ:
+session.receive$.subscribe(/* デコード済みチャンク */);
+session.lines$.subscribe(/* 完了した行 */);
+session.terminalText$.subscribe(/* ターミナル表示用テキスト */);
+
+// 以前 receiveReplay$ を使っていた場合は、operator を自分で組み合わせる。
+// 削除された API のドロップイン置換ではない。
+const replayedReceive$ = session.receive$.pipe(
+  shareReplay({
+    bufferSize: 1,
+    refCount: true,
+  }),
+);
+```
+
+---
+
+## Phase 1 API 削除
+
+[#472](https://github.com/gurezo/web-serial-rxjs/issues/472) の Phase 1 では、重複・escape hatch な API を削除し、ライフサイクルと破棄の正規情報源を `state$` と `dispose$()` に統一しました。ドキュメント整備は [#478](https://github.com/gurezo/web-serial-rxjs/issues/478) です。
+
+| 削除 API | 移行先 |
+| --- | --- |
+| `destroy$()` | `dispose$()` |
+| `isConnected$` | `state$` の `state.status`（または `state$` から boolean を derive） |
+| `portInfo$` | `state.status === SerialSessionStatus.Connected` 時の `state.portInfo` |
+| `getPortInfo()` | 同上（Connected 時の `state.portInfo`） |
+| `getCurrentPort()` | 直接の代替なし。識別は `state.portInfo`。生の `SerialPort` は公開しない |
+
+詳細な例とチェックリスト: [v3 への移行 – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除)。
+
+---
+
+## Phase 2 API 削除
+
+[#485](https://github.com/gurezo/web-serial-rxjs/issues/485) の Phase 2 では、名前と挙動が一致しない派生 API や、セッション責務に属さないオプションを削除します。実装: [#486](https://github.com/gurezo/web-serial-rxjs/issues/486)、[#487](https://github.com/gurezo/web-serial-rxjs/issues/487)、[#488](https://github.com/gurezo/web-serial-rxjs/issues/488)。ドキュメント: [#490](https://github.com/gurezo/web-serial-rxjs/issues/490)。
+
+| v3 以前 | v4 |
+| --- | --- |
+| `session.receiveReplay$` | `session.receive$` に必要な RxJS operator を明示的に組み合わせる |
+| `options.receiveReplay` | 削除 |
+| `session.isBrowserSupported()` | トップレベル `isWebSerialSupported()`、または `state$` の `Unsupported` |
+| 混在・分かりにくい公開オプション | `SerialConnectionOptions` + `SerialSessionFeatureOptions` の構成へ |
+
+### `receiveReplay$` と `receiveReplay` オプション
+
+`receiveReplay$` は、セッション生成時に `receiveReplay.enabled` が有効な場合のみ過去チャンクを再通知しました。無効時は `receive$` と同じ非リプレイ動作になり、API 名と挙動が一致しませんでした。リプレイ対象はデコード済み受信チャンクのみで、`lines$` / `terminalText$` には適用されず、`bufferSize` と `maxChars` の両方を理解する必要がありました。
+
+**v4 ではストリームとオプションの両方を削除します。** アプリ側でリプレイ相当が必要な場合は、`receive$` に operator を自分で組み合わせてください。
+
+```typescript
+import { shareReplay } from 'rxjs';
+
+const replayedReceive$ = session.receive$.pipe(
+  shareReplay({
+    bufferSize: 1,
+    refCount: true,
+  }),
+);
+```
+
+#### 完全互換ではない
+
+このパターンは、削除された `receiveReplay$` API との **完全互換を保証しません**。
+
+- `shareReplay` の `bufferSize` は **イベント数**であり、文字数ではない。旧オプションには `maxChars` もあった
+- この例には **`maxChars` 相当の文字数上限は含まれない**
+- 接続切替・切断・破棄をまたぐキャッシュ寿命はアプリ側で設計する必要がある
+- エラーと complete の再通知（`shareReplay` の reset / refCount）は旧セッション所有バッファと異なる
+
+`shareReplay` を削除機能の完全な代替として案内しないでください。
+
+### ブラウザー対応判定
+
+Web Serial の利用可否はセッションごとの状態ではありません。対応確認のためだけに `createSerialSession()` を呼ぶ形は責務が分かりにくくなっていました。
+
+**セッション生成前**（同期的な feature detection）:
+
+```typescript
+import { isWebSerialSupported } from '@gurezo/web-serial-rxjs';
+
+if (!isWebSerialSupported()) {
+  // fallback UI
+}
+```
+
+**セッション生成後**の UI では、ライフサイクルに沿う `state$` を推奨します。
+
+```typescript
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+session.state$.subscribe((state) => {
+  if (state.status === SerialSessionStatus.Unsupported) {
+    // unsupported UI
+  }
+});
+```
+
+`session.isBrowserSupported()` は削除されています。関連: [API concepts – `isWebSerialSupported`](./concepts.md#iswebserialsupported-boolean)。
+
+### セッションオプションの整理
+
+`SerialSessionOptions` は引き続き単一の factory 引数ですが、責務の境界を明確にしています。
+
+```text
+SerialConnectionOptions     = port.open 向けの W3C 接続パラメータ
+SerialSessionFeatureOptions = ライブラリ固有のセッション機能
+SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFeatureOptions
+```
+
+- **接続:** `baudRate`, `dataBits`, `stopBits`, `parity`, `bufferSize`, `flowControl`
+- **機能:** `filters`, `terminalBuffer`, `lineBuffer`（`receiveReplay` は削除済み）
+
+境界セマンティクス（バッファ上限のみ `0` = 無制限、接続フィールドは `> 0` 必須）は [API concepts – SerialSessionOptions](./concepts.md#serialsessionoptions) を参照してください。
+
+---
+
+## v4 で維持するストリーム
+
+これらは重複ではなく、用途の異なる抽象化です。
+
+| API | 用途 |
+| --- | --- |
+| `receive$` | 読み取りポンプからのデコード済み UTF-8 **チャンク** |
+| `lines$` | 改行で区切られた **完了行**（ログ / プロトコル） |
+| `terminalText$` | **ターミナル表示**向けの累積テキスト（`\r` 再描画を含む） |
+
+フレーミング・未完成行・ターミナルバッファ上限を利用者が再実装しなくて済むよう、`SerialSession` 上に残します。詳細: [API concepts – SerialSession](./concepts.md#serialsession)。
+
+---
+
+## Phase 2 で変更しない仕様
+
+次は v3 / Phase 1 完了時点の仕様を維持します。
+
+- 操作 Observable（`connect$`、`send$`、`disconnect$`、`dispose$`）は **購読により実行**される（cold）
+- Promise 形式の重複 API は追加しない
+- `errors$` と操作 Observable のエラー通知仕様は維持する
+- `lines$` / `terminalText$` を利用者側 operator へ移動しない
+- Phase 2 で新しい selector / 便利 API は追加しない
+
+目標とする公開形:
+
+```typescript
+export interface SerialSession {
+  readonly state$: Observable<SerialSessionState>;
+  readonly errors$: Observable<SerialError>;
+
+  readonly receive$: Observable<string>;
+  readonly lines$: Observable<string>;
+  readonly terminalText$: Observable<string>;
+
+  connect$(): Observable<void>;
+  disconnect$(): Observable<void>;
+  send$(data: SerialPayload): Observable<void>;
+  dispose$(): Observable<void>;
+}
+```
+
+加えてトップレベルヘルパー:
+
+```typescript
+export function isWebSerialSupported(): boolean;
+```
+
+---
+
+## 移行チェックリスト
+
+- [ ] `destroy$()` を `dispose$()` に置き換え、ライフサイクル UI は `state$` から駆動する
+- [ ] `isConnected$` / `portInfo$` / `getPortInfo()` / `getCurrentPort()` を `state$` / `state.portInfo` に置き換える
+- [ ] `receiveReplay$` の購読と `receiveReplay` オプションを削除する
+- [ ] リプレイが必要なら `receive$` に RxJS operator を組み合わせ、上記の差異を受け入れる
+- [ ] `session.isBrowserSupported()` を `isWebSerialSupported()` または `state$` の `Unsupported` に置き換える
+- [ ] 削除された receive-replay エラーコード（`INVALID_RECEIVE_REPLAY_OPTIONS`、`RECEIVE_REPLAY_BUFFER_OVERFLOW`）の分岐をやめる
+- [ ] `receive$` / `lines$` / `terminalText$` を用途で選び、互換エイリアスとして扱わない
+
+---
+
+## リリースノート（Phase 2）
+
+- `SerialSession.receiveReplay$` と `SerialSessionOptions.receiveReplay` を削除
+- 関連する receive-replay エラーコードと内部バッファ実装を削除
+- `SerialSession.isBrowserSupported()` を削除し、トップレベル `isWebSerialSupported()` に統一
+- `SerialSessionOptions` を接続フィールド + 機能オプション（`filters`、`terminalBuffer`、`lineBuffer`）として整理
+- 公開 API 境界を回帰テストで固定（[#489](https://github.com/gurezo/web-serial-rxjs/issues/489)）
+
+---
+
+## 関連リンク
+
+- [v3 への移行](./migration-v3.md) — `SerialErrorCode`、discriminated union の `state$`、Phase 1 の詳細節
+- [v1 から v2 への移行](./migration-v2.md) — `SerialClient` → `SerialSession`（注: v4 のブラウザ判定は再びトップレベル）
+- [API concepts and design notes](./concepts.md)
+- 親 Issue [#485](https://github.com/gurezo/web-serial-rxjs/issues/485)

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md
@@ -124,7 +124,7 @@ session.state$.subscribe((state) => {
 });
 ```
 
-`session.isBrowserSupported()` は削除されています。関連: [API concepts – `isWebSerialSupported`](./concepts.md#iswebserialsupported-boolean)。
+`session.isBrowserSupported()` は削除されています。関連: [API concepts – SerialSession / `isWebSerialSupported`](./concepts.md#serialsession)。
 
 ### セッションオプションの整理
 

--- a/packages/web-serial-rxjs/src/session/internal/has-web-serial-support.ts
+++ b/packages/web-serial-rxjs/src/session/internal/has-web-serial-support.ts
@@ -1,9 +1,13 @@
 /**
  * Synchronous feature detection for the Web Serial API.
  *
+ * Prefer this helper **before** creating a session. After a session exists,
+ * drive unsupported UI from `state$` with `SerialSessionStatus.Unsupported`.
  * This helper is SSR-safe: it returns `false` when `navigator` is not available.
  *
  * @returns `true` when `navigator.serial` is available.
+ *
+ * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/490 | Issue #490}
  */
 export function isWebSerialSupported(): boolean {
   return (

--- a/packages/web-serial-rxjs/src/session/serial-session.ts
+++ b/packages/web-serial-rxjs/src/session/serial-session.ts
@@ -18,7 +18,15 @@ import type { SerialSessionState } from './serial-session-state';
  *
  * @example
  * ```typescript
- * import { createSerialSession, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+ * import {
+ *   createSerialSession,
+ *   isWebSerialSupported,
+ *   SerialSessionStatus,
+ * } from '@gurezo/web-serial-rxjs';
+ *
+ * if (!isWebSerialSupported()) {
+ *   // fallback UI
+ * }
  *
  * const session = createSerialSession({ baudRate: 115200 });
  *


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): add v4 phase 2 migration guide

## Summary
v4 Phase 2 で削除された派生 API（`receiveReplay$` / `receiveReplay` / `isBrowserSupported()`）とブラウザー対応判定の移行情報を、Phase 1 と統合した v4 移行ガイドとして追加しました。`shareReplay` による代替例は完全互換ではないことを明記しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #490
- Related to #485

## What changed?
- `docs/guide/{en,ja}/migration-v4.md` を新設（Phase 1+2 統合移行表、`shareReplay` 注意、リリースノート）
- ルート / package / Guide README から v4 ガイドへの導線を追加
- `migration-v2` / `migration-v3` / `concepts` の矛盾（旧 `isBrowserSupported`、receive-replay エラーコード）を解消
- `isWebSerialSupported` / `SerialSession` の JSDoc を現行 API に合わせて更新
- `pnpm run docs` で docs build・リンクチェックを確認

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes: 破壊的変更自体は #486–#488 で実施済み。本 PR はその移行説明のみ。

## How to test
1. `pnpm run docs` が成功すること
2. 生成された `docs/guide/en/migration-v4.html` / `docs/guide/ja/migration-v4.html` が表示できること
3. Guide README / ルート README から v4 移行ガイドへ辿れること
4. `receiveReplay$` / `isBrowserSupported` の通常利用例が残っていないこと（移行表・削除注記は許容）

## Environment (if relevant)
- Browser: N/A（ドキュメント変更）
- OS: macOS
- web-serial-rxjs version (for verification): main (docs branch)
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)