### PR TITLE
chore(web-serial-rxjs): bump version to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs/workspace",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "3.1.1",
+  "version": "4.0.0",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## PR Title (Conventional Commits)
chore(web-serial-rxjs): bump version to 4.0.0

## Summary
v4 向け API 整理（#472–#490）完了後のリリース準備として、npm パッケージと workspace root のバージョンを `3.1.1` から `4.0.0` に更新します。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #496

## What changed?
- `@gurezo/web-serial-rxjs`（`packages/web-serial-rxjs/package.json`）の version を `4.0.0` に更新
- workspace root（`package.json`）の version を `4.0.0` に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: 本 PR ではバージョン番号のみ変更。公開 API のコード変更なし
- [ ] This change is backward compatible
- [x] This change introduces a breaking change
  - Migration notes: セマンティックバージョニング上の major bump。破壊的変更自体は先行 Issue（#472–#490）で実施済み。移行手順は [v4 への移行](packages/web-serial-rxjs/docs/guide/ja/migration-v4.md) を参照

## How to test
1. `packages/web-serial-rxjs/package.json` と root `package.json` の `"version"` がともに `"4.0.0"` であることを確認
2. コミットメッセージが Conventional Commits（commitlint）に準拠していることを確認
3. （任意）`pnpm exec nx build web-serial-rxjs` でビルドが通ることを確認

※ `v4.0.0` タグの作成・npm publish は本 PR マージ後に [RELEASING.ja.md](RELEASING.ja.md) に従って別途実施

## Environment (if relevant)
- Browser: N/A（バージョン番号のみの変更）
- OS: N/A
- web-serial-rxjs version (for verification): 4.0.0
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)