### PR TITLE
fix(web-serial-rxjs): move dist api audit into verify-dist

### DIFF
--- a/packages/web-serial-rxjs/scripts/public-api-allowlist.mjs
+++ b/packages/web-serial-rxjs/scripts/public-api-allowlist.mjs
@@ -1,0 +1,58 @@
+/**
+ * Canonical public API allowlists for post-build dist verification (Issue #498).
+ *
+ * Keep in sync with:
+ * - `tests/session/public-api-boundary-audit.test.ts` (source / runtime audits)
+ * - `src/index.ts` when the public surface changes intentionally
+ */
+
+/** Runtime values exported from the package root barrel / dist/index.d.ts. */
+export const CANONICAL_RUNTIME_EXPORTS = [
+  'assertNever',
+  'createSerialSession',
+  'createTerminalBuffer',
+  'DEFAULT_LINE_BUFFER_OPTIONS',
+  'DEFAULT_TERMINAL_BUFFER_OPTIONS',
+  'isConnectedSessionState',
+  'isWebSerialSupported',
+  'resolveSerialSessionOptions',
+  'SerialError',
+  'SerialErrorCode',
+  'SerialSessionStatus',
+];
+
+/** Type-only exports from package root / dist/index.d.ts. */
+export const CANONICAL_TYPE_EXPORTS = [
+  'ConnectedSessionState',
+  'ConnectingSessionState',
+  'DisconnectingSessionState',
+  'DisposedSessionState',
+  'ErrorSessionState',
+  'IdleSessionState',
+  'LineBufferOptions',
+  'ResolvedSerialSessionOptions',
+  'SerialConnectionOptions',
+  'SerialErrorCauseContext',
+  'SerialErrorContextMap',
+  'SerialPayload',
+  'SerialSession',
+  'SerialSessionFeatureOptions',
+  'SerialSessionOptions',
+  'SerialSessionState',
+  'TerminalBuffer',
+  'TerminalBufferOptions',
+  'UnsupportedSessionState',
+  'ValidationErrorConstraint',
+  'ValidationErrorContext',
+];
+
+/** APIs removed in Phase 1 / Phase 2 that must not appear in declaration output. */
+export const REMOVED_SESSION_APIS = [
+  'destroy$',
+  'getCurrentPort',
+  'getPortInfo',
+  'isBrowserSupported',
+  'isConnected$',
+  'portInfo$',
+  'receiveReplay$',
+];

--- a/packages/web-serial-rxjs/scripts/verify-dist.mjs
+++ b/packages/web-serial-rxjs/scripts/verify-dist.mjs
@@ -1,7 +1,12 @@
-import { existsSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
+import {
+  CANONICAL_RUNTIME_EXPORTS,
+  CANONICAL_TYPE_EXPORTS,
+  REMOVED_SESSION_APIS,
+} from './public-api-allowlist.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -43,6 +48,44 @@ function collectReferencedPaths() {
     .map((path) => join(packageRoot, path.replace(/^\.\//, '')));
 }
 
+function parseExportedNamesFromBlocks(source, kind) {
+  const names = [];
+  const pattern =
+    kind === 'type'
+      ? /export\s+type\s*\{([^}]+)\}/gs
+      : /export\s*\{([^}]+)\}/gs;
+  for (const match of source.matchAll(pattern)) {
+    const block = match[1] ?? '';
+    for (const part of block.split(',')) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      const localName = trimmed.split(/\s+as\s+/)[0]?.trim();
+      if (localName && /^[A-Za-z_][A-Za-z0-9_]*$/.test(localName)) {
+        names.push(localName);
+      }
+    }
+  }
+  return [...new Set(names)].sort();
+}
+
+function listDeclarationFiles(distRoot) {
+  return readdirSync(distRoot, { recursive: true, encoding: 'utf8' })
+    .filter((entry) => entry.endsWith('.d.ts'))
+    .sort();
+}
+
+function arraysEqual(actual, expected) {
+  if (actual.length !== expected.length) {
+    return false;
+  }
+  return actual.every((value, index) => value === expected[index]);
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
 const referencedPaths = collectReferencedPaths();
 const missing = referencedPaths.filter((path) => !existsSync(path));
 
@@ -55,3 +98,61 @@ if (missing.length > 0) {
 }
 
 console.log('Verified dist artifacts referenced by package.json exports.');
+
+const distRoot = join(packageRoot, 'dist');
+const dtsPath = join(distRoot, 'index.d.ts');
+
+if (!existsSync(distRoot)) {
+  fail('dist/ is missing; run `pnpm exec nx build web-serial-rxjs` before verify-dist');
+}
+
+if (!existsSync(dtsPath)) {
+  fail(
+    'dist/index.d.ts is missing; run `pnpm exec nx build web-serial-rxjs` before verify-dist',
+  );
+}
+
+const dtsSource = readFileSync(dtsPath, 'utf8');
+const actualRuntimeExports = parseExportedNamesFromBlocks(dtsSource, 'value');
+const expectedRuntimeExports = [...CANONICAL_RUNTIME_EXPORTS].sort();
+if (!arraysEqual(actualRuntimeExports, expectedRuntimeExports)) {
+  fail(
+    [
+      'dist/index.d.ts runtime exports are not aligned with the allowlist.',
+      `  actual:   ${JSON.stringify(actualRuntimeExports)}`,
+      `  expected: ${JSON.stringify(expectedRuntimeExports)}`,
+    ].join('\n'),
+  );
+}
+
+const actualTypeExports = parseExportedNamesFromBlocks(dtsSource, 'type');
+const expectedTypeExports = [...CANONICAL_TYPE_EXPORTS].sort();
+if (!arraysEqual(actualTypeExports, expectedTypeExports)) {
+  fail(
+    [
+      'dist/index.d.ts type exports are not aligned with the allowlist.',
+      `  actual:   ${JSON.stringify(actualTypeExports)}`,
+      `  expected: ${JSON.stringify(expectedTypeExports)}`,
+    ].join('\n'),
+  );
+}
+
+console.log('Verified dist/index.d.ts exports against the public API allowlist.');
+
+for (const relativePath of listDeclarationFiles(distRoot)) {
+  const source = readFileSync(join(distRoot, relativePath), 'utf8');
+  for (const name of REMOVED_SESSION_APIS) {
+    if (source.includes(name)) {
+      fail(
+        `Removed API "${name}" was reintroduced in declaration output: ${relativePath}`,
+      );
+    }
+  }
+  if (/receiveReplay/.test(source)) {
+    fail(
+      `Removed API fragment "receiveReplay" was reintroduced in declaration output: ${relativePath}`,
+    );
+  }
+}
+
+console.log('Verified declaration build output does not reintroduce removed APIs.');

--- a/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/session/public-api-boundary-audit.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
@@ -13,7 +13,11 @@ import {
  *
  * Keep the allowlists in sync with:
  * - `src/index.ts` (public barrel / TypeDoc entry)
+ * - `scripts/public-api-allowlist.mjs` (post-build dist checks via verify-dist)
  * - package README / concepts docs when the surface changes intentionally
+ *
+ * Declaration / dist audits live in `scripts/verify-dist.mjs` so unit tests do
+ * not require a prior build (release runs test before build for fail-fast).
  */
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -127,16 +131,6 @@ function parseExportedNamesFromBlocks(
 
 function parseExportedTypeNames(source: string): string[] {
   return parseExportedNamesFromBlocks(source, 'type');
-}
-
-function parseExportedValueNames(source: string): string[] {
-  return parseExportedNamesFromBlocks(source, 'value');
-}
-
-function listDeclarationFiles(distRoot: string): readonly string[] {
-  return readdirSync(distRoot, { recursive: true, encoding: 'utf8' })
-    .filter((entry) => entry.endsWith('.d.ts'))
-    .sort();
 }
 
 describe('v4 public API boundary audit (#489) — export allowlist', () => {
@@ -254,7 +248,7 @@ describe('v4 public API boundary audit (#489) — removed APIs', () => {
   });
 });
 
-describe('v4 public API boundary audit (#489) — package exports and declarations', () => {
+describe('v4 public API boundary audit (#489) — package exports', () => {
   it('restricts package.json exports to the root entry and package.json', () => {
     const packageJson = JSON.parse(
       readFileSync(join(packageRoot, 'package.json'), 'utf8'),
@@ -264,46 +258,5 @@ describe('v4 public API boundary audit (#489) — package exports and declaratio
       '.',
       './package.json',
     ]);
-  });
-
-  it('keeps dist/index.d.ts runtime exports aligned with the allowlist', () => {
-    const dtsPath = join(packageRoot, 'dist/index.d.ts');
-    expect(
-      existsSync(dtsPath),
-      'dist/index.d.ts is missing; run `pnpm exec nx build web-serial-rxjs` (CI builds before test)',
-    ).toBe(true);
-
-    const dtsSource = readFileSync(dtsPath, 'utf8');
-    const actual = parseExportedValueNames(dtsSource);
-    const expected = [...CANONICAL_RUNTIME_EXPORTS].sort();
-    expect(actual).toEqual(expected);
-  });
-
-  it('keeps dist/index.d.ts type exports aligned with the allowlist', () => {
-    const dtsPath = join(packageRoot, 'dist/index.d.ts');
-    expect(existsSync(dtsPath)).toBe(true);
-
-    const dtsSource = readFileSync(dtsPath, 'utf8');
-    const actual = parseExportedTypeNames(dtsSource);
-    const expected = [...CANONICAL_TYPE_EXPORTS].sort();
-    expect(actual).toEqual(expected);
-  });
-
-  it('does not reintroduce removed APIs in declaration build output', () => {
-    const distRoot = join(packageRoot, 'dist');
-    expect(
-      existsSync(distRoot),
-      'dist/ is missing; run `pnpm exec nx build web-serial-rxjs` (CI builds before test)',
-    ).toBe(true);
-
-    for (const relativePath of listDeclarationFiles(distRoot)) {
-      const source = readFileSync(join(distRoot, relativePath), 'utf8');
-      for (const name of REMOVED_SESSION_APIS) {
-        expect(source, `${relativePath} / ${name}`).not.toContain(name);
-      }
-      expect(source, `${relativePath} / receiveReplay`).not.toMatch(
-        /receiveReplay/,
-      );
-    }
   });
 });


### PR DESCRIPTION
## PR Title (Conventional Commits)
`fix(web-serial-rxjs): move dist api audit into verify-dist`

## Summary
release の fail-fast（test → build）を維持するため、`dist/` 依存の公開 API 監査を unit test から `verify-dist` へ移しました。これにより v4.0.0 タグ push 時の release CI 失敗（#498）を解消します。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #498

## What changed?
- `public-api-boundary-audit.test.ts` から `dist/index.d.ts` / 宣言出力依存の 3 テストを削除
- 同等の allowlist / 削除 API 検査を `scripts/verify-dist.mjs` に追加
- dist 監査用 allowlist を `scripts/public-api-allowlist.mjs` として切り出し
- `release.yml` / `ci.yml` のステップ順は変更なし

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `rm -rf packages/web-serial-rxjs/dist`
2. `pnpm exec nx test web-serial-rxjs` が通ること（build なしで unit test 可能）
3. `pnpm exec nx build web-serial-rxjs && pnpm exec nx run web-serial-rxjs:verify-dist` で dist API 監査が通ること

## Environment (if relevant)
- Browser: N/A（CI / ビルド検証）
- OS: macOS
- web-serial-rxjs version (for verification): 4.0.0
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)