### PR TITLE
fix(ci): restore GitHub Pages docs via Actions source

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -572,7 +572,9 @@ nx graph
 
 - Guide の Markdown は `packages/web-serial-rxjs/docs/guide/` 配下を編集してください。
 - ルート `docs/` 配下は `docs/.gitignore` を除き**編集しない**でください。
-- TypeDoc 出力の確認は `pnpm run docs` でローカル生成できます。
+- `docs/` 配下の生成 HTML は**コミットしない**でください（CI が artifact をビルドします）。
+- ローカル確認は `pnpm run docs` でフル生成してください（Guide HTML、TypeDoc、サイト index、内部リンク検証）。
+- GitHub Pages の Source は **GitHub Actions** にしてください（Deploy from a branch / `main` + `/docs` は不可）。詳細は [ドキュメント構成](packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md#github-pages-配信151-完了まで) を参照。
 
 ## ヘルプの取得
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -569,7 +569,9 @@ Hand-written Guide source and generated API Reference output are separated. See 
 
 - Edit Guide Markdown under `packages/web-serial-rxjs/docs/guide/`.
 - Do **not** edit files under root `docs/` except `docs/.gitignore`.
+- Do **not** commit generated HTML under `docs/` (CI builds the artifact).
 - Regenerate locally with `pnpm run docs` when validating the full documentation artifact (Guide HTML, TypeDoc, site index, and internal link check).
+- GitHub Pages Source must be **GitHub Actions** (not Deploy from a branch / `main` + `/docs`). See [Documentation Architecture](packages/web-serial-rxjs/docs/ARCHITECTURE.md#github-pages-hosting-until-151).
 
 ## Getting Help
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "docs:generate": "typedoc --options packages/web-serial-rxjs/typedoc.json && node packages/web-serial-rxjs/scripts/fix-typedoc-links.mjs",
     "docs:patch-assets": "node packages/web-serial-rxjs/scripts/patch-docs-assets.mjs",
     "docs:gitignore": "node -e \"require('fs').writeFileSync('docs/.gitignore','# Generated documentation output — do not commit.\\n# Source lives under packages/web-serial-rxjs/docs/guide/\\n# See packages/web-serial-rxjs/docs/ARCHITECTURE.md\\n*\\n!.gitignore\\n')\"",
+    "docs:nojekyll": "node -e \"require('fs').mkdirSync('docs',{recursive:true});require('fs').writeFileSync('docs/.nojekyll','')\"",
     "docs:clean": "node -e \"const fs=require('fs'),p=require('path'),d='docs';fs.mkdirSync(d,{recursive:true});for(const e of fs.readdirSync(d))e!=='.gitignore'&&fs.rmSync(p.join(d,e),{recursive:true,force:true});\"",
-    "docs": "pnpm run docs:clean && pnpm run docs:generate && pnpm run docs:guide && pnpm run docs:patch-assets && pnpm run docs:index && pnpm run docs:check-links && pnpm run docs:gitignore",
+    "docs": "pnpm run docs:clean && pnpm run docs:generate && pnpm run docs:guide && pnpm run docs:patch-assets && pnpm run docs:index && pnpm run docs:check-links && pnpm run docs:nojekyll && pnpm run docs:gitignore",
     "publish:test": "pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs",
     "publish": "pnpm publish --filter @gurezo/web-serial-rxjs"
   },
@@ -106,6 +107,7 @@
       "docs:generate",
       "docs:patch-assets",
       "docs:clean",
+      "docs:nojekyll",
       "publish",
       "publish:test"
     ]

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
@@ -117,6 +117,18 @@ Guide の source は `guide/{en,ja}/` に配置済み。legacy flat パスは #4
 - 公開: `.github/workflows/deploy-docs.yml` が `./docs` を Pages artifact としてアップロード
 - ルート `docs/` 配下は**編集しない**（`docs/.gitignore` を除く）
 
+## GitHub Pages 配信（#151 完了まで）
+
+Firebase Hosting（#151）で github.io を置き換えるまでは、公開サイトは GitHub Actions 経由でのみ配信する。
+
+| 設定 | 必須値 |
+| --- | --- |
+| Repo → Settings → Pages → Source | **GitHub Actions**（`build_type=workflow`） |
+| デプロイ workflow | [`.github/workflows/deploy-docs.yml`](../../../.github/workflows/deploy-docs.yml) |
+| 公開 URL | `https://gurezo.github.io/web-serial-rxjs/` |
+
+**Deploy from a branch**（`main` + `/docs`）は使わない。生成 HTML は git 管理外（`docs/.gitignore`）のため、その設定だと空のツリーが公開されサイトが 404 になる（#500）。
+
 ## Issue 間の責務境界
 
 | Issue | 責務 |

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.md
@@ -117,6 +117,18 @@ Guide source files live under `guide/{en,ja}/`. Legacy flat Guide paths were rem
 - Publishing: `.github/workflows/deploy-docs.yml` uploads `./docs` as the Pages artifact.
 - **Do not edit** files under root `docs/` except `docs/.gitignore`.
 
+## GitHub Pages hosting (until #151)
+
+Until Firebase Hosting (#151) replaces github.io, the live site is served only via GitHub Actions:
+
+| Setting | Required value |
+| --- | --- |
+| Repo → Settings → Pages → Source | **GitHub Actions** (`build_type=workflow`) |
+| Deploy workflow | [`.github/workflows/deploy-docs.yml`](../../../.github/workflows/deploy-docs.yml) |
+| Public URL | `https://gurezo.github.io/web-serial-rxjs/` |
+
+Do **not** use **Deploy from a branch** with `main` + `/docs`. Generated HTML is not tracked in git (`docs/.gitignore`), so that source publishes an empty tree and the site returns 404 (#500).
+
 ## Issue boundaries
 
 | Issue | Responsibility |


### PR DESCRIPTION
## PR Title (Conventional Commits)
`fix(ci): restore GitHub Pages docs via Actions source`

## Summary
GitHub Pages が空の `main`/`docs` を legacy 配信していたため、ドキュメントサイトが 404 になっていた。配信元を GitHub Actions に切り替え、再発防止のため要件を文書化し、生成 artifact に `.nojekyll` を含めるようにした。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #500

## What changed?
- リポジトリの GitHub Pages Source を **GitHub Actions**（`build_type=workflow`）に変更し、`deploy-docs.yml` を再実行して `https://gurezo.github.io/web-serial-rxjs/` を復旧
- `ARCHITECTURE.md` / `ARCHITECTURE.ja.md` に Pages Actions 必須要件と #500 の注意を追記
- `CONTRIBUTING.md` / `CONTRIBUTING.ja.md` に運用注意を追記
- `pnpm run docs` パイプラインで `docs/.nojekyll` を出力するよう変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `https://gurezo.github.io/web-serial-rxjs/` が 200 で表示されること
2. `https://gurezo.github.io/web-serial-rxjs/api/` と `https://gurezo.github.io/web-serial-rxjs/guide/en/README.html` が 200 であること
3. `gh api repos/gurezo/web-serial-rxjs/pages` で `build_type` が `"workflow"` であること
4. ローカルで `pnpm run docs:nojekyll` を実行し、`docs/.nojekyll` が生成されること

## Environment (if relevant)
- Browser: Firefox / Chromium（ドキュメント閲覧）
- OS: macOS
- web-serial-rxjs version (for verification): 4.0.0
- RxJS version: N/A（ドキュメント配信の修正）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [x] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)