### PR TITLE
fix(web-serial-rxjs): restore migration-v4 docs navigation links

### DIFF
--- a/packages/web-serial-rxjs/scripts/docs-paths.mjs
+++ b/packages/web-serial-rxjs/scripts/docs-paths.mjs
@@ -35,29 +35,30 @@ export function guideApiDataBase(guideRelPath) {
   return apiAssetPrefixFromDocsPath(guideRelPath);
 }
 
+/** Guide page paths relative to guide/{locale}/ (archive uses slash). */
+const GUIDE_PAGE_PATHS = [
+  'README.html',
+  'overview.html',
+  'quick-start.html',
+  'advanced-usage.html',
+  'concepts.html',
+  'migration-v2.html',
+  'migration-v3.html',
+  'migration-v4.html',
+  'archive/migration-phase5.html',
+];
+
 export function buildDocumentUrlMap() {
   const map = new Map();
-  const entries = [
-    ['en_README.html', 'guide/en/README.html'],
-    ['en_overview.html', 'guide/en/overview.html'],
-    ['en_quick-start.html', 'guide/en/quick-start.html'],
-    ['en_advanced-usage.html', 'guide/en/advanced-usage.html'],
-    ['en_concepts.html', 'guide/en/concepts.html'],
-    ['en_migration-v2.html', 'guide/en/migration-v2.html'],
-    ['en_migration-v3.html', 'guide/en/migration-v3.html'],
-    ['en_archive_migration-phase5.html', 'guide/en/archive/migration-phase5.html'],
-    ['ja_README.html', 'guide/ja/README.html'],
-    ['ja_overview.html', 'guide/ja/overview.html'],
-    ['ja_quick-start.html', 'guide/ja/quick-start.html'],
-    ['ja_advanced-usage.html', 'guide/ja/advanced-usage.html'],
-    ['ja_concepts.html', 'guide/ja/concepts.html'],
-    ['ja_migration-v2.html', 'guide/ja/migration-v2.html'],
-    ['ja_migration-v3.html', 'guide/ja/migration-v3.html'],
-    ['ja_archive_migration-phase5.html', 'guide/ja/archive/migration-phase5.html'],
-  ];
+  const locales = ['en', 'ja'];
 
-  for (const [typedocName, guidePath] of entries) {
-    map.set(`documents/${typedocName}`, `../${guidePath}`);
+  for (const locale of locales) {
+    for (const pagePath of GUIDE_PAGE_PATHS) {
+      const typedocSlug = pagePath.replace(/\.html$/, '').replaceAll('/', '_');
+      const typedocName = `${locale}_${typedocSlug}.html`;
+      const guidePath = `guide/${locale}/${pagePath}`;
+      map.set(`documents/${typedocName}`, `../${guidePath}`);
+    }
   }
 
   return map;

--- a/packages/web-serial-rxjs/scripts/relocate-typedoc-guide.mjs
+++ b/packages/web-serial-rxjs/scripts/relocate-typedoc-guide.mjs
@@ -3,7 +3,6 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
-  rmSync,
   writeFileSync,
 } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -28,6 +27,34 @@ const TYPEDOC_DOC_PATTERN = /^(en|ja)_.+\.html$/;
 function docsRootPrefix(guideRelPath) {
   const depth = guideRelPath.split('/').length - 1;
   return '../'.repeat(depth);
+}
+
+/** Relative href from docs/api/documents/*.html to the canonical guide page. */
+function guideRedirectHref(guideRelPath) {
+  return `../../${guideRelPath}`;
+}
+
+function buildDocumentRedirectHtml({ locale, guideRelPath }) {
+  const href = guideRedirectHref(guideRelPath);
+  const lang = locale === 'ja' ? 'ja' : 'en';
+  const message =
+    locale === 'ja'
+      ? 'ガイドページへ移動しています…'
+      : 'Redirecting to the guide page…';
+
+  return `<!DOCTYPE html>
+<html lang="${lang}">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=${href}">
+  <link rel="canonical" href="${href}">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <p><a href="${href}">${message}</a></p>
+</body>
+</html>
+`;
 }
 
 function rewriteGuideHtml(html, { locale, pagePath, guideRelPath }) {
@@ -114,11 +141,18 @@ for (const filename of documentFiles) {
   });
 
   writeFileSync(destPath, rewritten, 'utf8');
+
+  writeFileSync(
+    sourcePath,
+    buildDocumentRedirectHtml({
+      locale: mapping.locale,
+      guideRelPath: mapping.guideRelPath,
+    }),
+    'utf8',
+  );
+
   relocated += 1;
 }
 
-for (const filename of documentFiles) {
-  rmSync(join(apiDocumentsRoot, filename), { force: true });
-}
-
 console.log(`Relocated ${relocated} TypeDoc guide pages to docs/guide/.`);
+console.log(`Wrote ${relocated} redirects under docs/api/documents/.`);


### PR DESCRIPTION
## PR Title (Conventional Commits)
fix(web-serial-rxjs): restore migration-v4 docs navigation links

## Summary
TypeDoc ナビ／検索が削除済みの `api/documents/ja_migration-v4.html` を指したままだったため、document url map に migration-v4 を追加し、旧 documents URL は正準ガイドへリダイレクトするようにしました。

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #502

## What changed?
- `buildDocumentUrlMap` をページ一覧生成に整理し、`migration-v4` を追加（ナビ／検索のリンク書き換え漏れを解消）
- TypeDoc 中間パス `docs/api/documents/*.html` に、正準ガイド (`docs/guide/{en,ja}/...`) へのリダイレクト HTML を残すよう変更

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs` を実行する
2. `docs/guide/ja/migration-v4.html` が生成されることを確認する
3. `docs/api/documents/ja_migration-v4.html` が `../../guide/ja/migration-v4.html` へリダイレクトすることを確認する
4. `docs/api/assets/navigation.js` 展開後に migration-v4 が `../guide/{en,ja}/migration-v4.html` を指すことを確認する
5. マージ後、GitHub Pages で以下を確認する
   - https://gurezo.github.io/web-serial-rxjs/api/documents/ja_migration-v4.html （ガイドへ誘導）
   - https://gurezo.github.io/web-serial-rxjs/guide/ja/migration-v4.html （正準ページ）

## Environment (if relevant)
- Browser: Firefox / Chromium 系（ドキュメント閲覧のみ）
- OS: macOS
- web-serial-rxjs version (for verification): v4.x
- RxJS version: v7.x

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)