### PR TITLE
docs(web-serial-rxjs): add portal static docs artifact build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "docs:gitignore": "node -e \"require('fs').writeFileSync('docs/.gitignore','# Generated documentation output — do not commit.\\n# Source lives under packages/web-serial-rxjs/docs/guide/\\n# See packages/web-serial-rxjs/docs/ARCHITECTURE.md\\n*\\n!.gitignore\\n')\"",
     "docs:nojekyll": "node -e \"require('fs').mkdirSync('docs',{recursive:true});require('fs').writeFileSync('docs/.nojekyll','')\"",
     "docs:clean": "node -e \"const fs=require('fs'),p=require('path'),d='docs';fs.mkdirSync(d,{recursive:true});for(const e of fs.readdirSync(d))e!=='.gitignore'&&fs.rmSync(p.join(d,e),{recursive:true,force:true});\"",
-    "docs": "pnpm run docs:clean && pnpm run docs:generate && pnpm run docs:guide && pnpm run docs:patch-assets && pnpm run docs:index && pnpm run docs:check-links && pnpm run docs:nojekyll && pnpm run docs:gitignore",
+    "docs:portal": "node packages/web-serial-rxjs/scripts/package-docs-portal.mjs",
+    "docs": "pnpm run docs:clean && pnpm run docs:generate && pnpm run docs:guide && pnpm run docs:patch-assets && pnpm run docs:index && pnpm run docs:check-links && pnpm run docs:nojekyll && pnpm run docs:gitignore && pnpm run docs:portal",
     "publish:test": "pnpm publish --dry-run --no-git-checks --filter @gurezo/web-serial-rxjs",
     "publish": "pnpm publish --filter @gurezo/web-serial-rxjs"
   },
@@ -108,6 +109,7 @@
       "docs:patch-assets",
       "docs:clean",
       "docs:nojekyll",
+      "docs:portal",
       "publish",
       "publish:test"
     ]

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
@@ -112,12 +112,27 @@ Guide の source は `guide/{en,ja}/` に配置済み。legacy flat パスは #4
 | `packages/web-serial-rxjs/docs/guide/**` | する（手書き source） |
 | `docs/index.html`、`docs/media/**`、`docs/api/**`、`docs/guide/**` | しない（CI 生成 artifact） |
 | `docs/.gitignore` | する（生成物を除外） |
+| `dist/portal/web-serial-rxjs/**` | しない（portal fragment。ルート `dist/` gitignore で除外） |
 
-- ローカル生成: `pnpm run docs`（Guide HTML、TypeDoc API Reference、サイト index、内部リンク検証）
-- 公開: `.github/workflows/deploy-docs.yml` が `./docs` を Pages artifact としてアップロード
+- ローカル生成: `pnpm run docs`（Guide HTML、TypeDoc API Reference、サイト index、内部リンク検証、portal fragment パッケージ）
+- 公開（GitHub Pages、#361 まで）: `.github/workflows/deploy-docs.yml` が `./docs` を Pages artifact としてアップロード
 - ルート `docs/` 配下は**編集しない**（`docs/.gitignore` を除く）
 
-## GitHub Pages 配信（#151 完了まで）
+## Portal fragment（#352）
+
+`pnpm run docs` の末尾で `docs:portal` が走り、生成済み `docs/` ツリー（`docs/.gitignore` を除く）を次へコピーする:
+
+| 項目 | 値 |
+| --- | --- |
+| Fragment 出力先 | `dist/portal/web-serial-rxjs/` |
+| 公開 URL（想定） | `https://gurezo.net/web-serial-rxjs/` |
+| portal 取り込み先 | `gurezo/portal` → `firebase-public/web-serial-rxjs/` |
+
+- 本リポジトリは**静的 fragment の生成のみ**を行う。Firebase Hosting への最終 deploy は `gurezo/portal` の責務。
+- 相対リンクは GitHub project Pages と同じ `/web-serial-rxjs/` のパス深さに既に整合しているため、HTML 内の絶対 `base` 書き換えは不要。
+- SPA fallback / clean URL rewrite（必要な場合）は portal 側 Hosting 設定の確認事項。docs はマルチページ静的 HTML（`*.html`）である。
+
+## GitHub Pages 配信（#151 / #361 完了まで）
 
 Firebase Hosting（#151）で github.io を置き換えるまでは、公開サイトは GitHub Actions 経由でのみ配信する。
 
@@ -138,7 +153,10 @@ Firebase Hosting（#151）で github.io を置き換えるまでは、公開サ�
 | **#456** | 日本語 Guide に対応する English Guide の整備 |
 | **#457** | 英語のみの TypeDoc API Reference（`typedoc.json` → `docs/api/`） |
 | **#458** | Guide と API Reference のビルド統合、相互導線、サイト index |
-| **#151** | Firebase Hosting への配信（artifact の*レイアウト*は本 Issue、*Hosting 設定*は #151） |
+| **#352** | docs を `dist/portal/web-serial-rxjs/` の portal fragment としてパッケージ |
+| **#151** | Firebase Hosting 移行の親（レイアウトは本リポ、最終 deploy は portal） |
+| **#360** | docs + examples の静的 artifact 集約 workflow |
+| **#361** | URL 更新と GitHub Pages 停止 |
 
 ## 後続 Issue 向けチェックリスト
 
@@ -146,11 +164,14 @@ Firebase Hosting（#151）で github.io を置き換えるまでは、公開サ�
 - [x] **#456** — English Guide を `guide/en/` へ移行・更新
 - [x] **#457** — TypeDoc `out` を `../../docs/api` に変更。`projectDocuments` は英語 Guide のみ
 - [x] **#458** — `docs/guide/{ja,en}/` をビルドし、Guide ↔ API Reference の導線を追加
-- [ ] **#151** — `docs/` artifact を Firebase へデプロイ（内部パスは再定義しない）
+- [x] **#352** — portal docs fragment を `dist/portal/web-serial-rxjs/` に出力
+- [ ] **#151** — `gurezo/portal` 経由で公開（内部パスは再定義しない）
 
 ## 参照
 
 - [親 Issue #453](https://github.com/gurezo/web-serial-rxjs/issues/453)
+- [Portal docs fragment #352](https://github.com/gurezo/web-serial-rxjs/issues/352)
+- [Firebase 移行親 #151](https://github.com/gurezo/web-serial-rxjs/issues/151)
 - [TypeDoc 設定](../typedoc.json)
 - [デプロイ workflow](../../../.github/workflows/deploy-docs.yml)
 - [English version](./ARCHITECTURE.md)

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.md
@@ -112,12 +112,27 @@ Guide source files live under `guide/{en,ja}/`. Legacy flat Guide paths were rem
 | `packages/web-serial-rxjs/docs/guide/**` | Yes (hand-written source) |
 | `docs/index.html`, `docs/media/**`, `docs/api/**`, `docs/guide/**` | No (CI-generated artifact) |
 | `docs/.gitignore` | Yes (ignores all generated content) |
+| `dist/portal/web-serial-rxjs/**` | No (portal fragment; covered by root `dist/` gitignore) |
 
-- Local generation: `pnpm run docs` (Guide HTML, TypeDoc API Reference, site index, and internal link check).
-- Publishing: `.github/workflows/deploy-docs.yml` uploads `./docs` as the Pages artifact.
+- Local generation: `pnpm run docs` (Guide HTML, TypeDoc API Reference, site index, internal link check, and portal fragment packaging).
+- Publishing (GitHub Pages, until #361): `.github/workflows/deploy-docs.yml` uploads `./docs` as the Pages artifact.
 - **Do not edit** files under root `docs/` except `docs/.gitignore`.
 
-## GitHub Pages hosting (until #151)
+## Portal fragment (#352)
+
+`pnpm run docs` ends with `docs:portal`, which copies the generated `docs/` tree (excluding `docs/.gitignore`) to:
+
+| Item | Value |
+| --- | --- |
+| Fragment output | `dist/portal/web-serial-rxjs/` |
+| Target public URL | `https://gurezo.net/web-serial-rxjs/` |
+| Portal import path | `gurezo/portal` → `firebase-public/web-serial-rxjs/` |
+
+- This repository **only** builds the static fragment. Final Firebase Hosting deploy is owned by `gurezo/portal`.
+- Relative links already match the `/web-serial-rxjs/` path depth used by GitHub project Pages; no absolute `base` rewrite is required in HTML.
+- SPA fallback / clean-URL rewrites (if any) are portal Hosting configuration, not this repo. Docs are multi-page static HTML (`*.html` files).
+
+## GitHub Pages hosting (until #151 / #361)
 
 Until Firebase Hosting (#151) replaces github.io, the live site is served only via GitHub Actions:
 
@@ -138,7 +153,10 @@ Do **not** use **Deploy from a branch** with `main` + `/docs`. Generated HTML is
 | **#456** | Align English Guide with Japanese Guide |
 | **#457** | TypeDoc as English-only API Reference (`typedoc.json` → `docs/api/`) |
 | **#458** | Integrate Guide + API Reference build, cross-links, site landing |
-| **#151** | Firebase Hosting deploy target (artifact *layout* defined here; *hosting config* there) |
+| **#352** | Package docs as portal fragment under `dist/portal/web-serial-rxjs/` |
+| **#151** | Firebase Hosting migration parent (layout here; final deploy via portal) |
+| **#360** | Aggregate static artifact workflow (docs + examples) |
+| **#361** | URL updates and GitHub Pages shutdown |
 
 ## Checklist for downstream issues
 
@@ -146,11 +164,14 @@ Do **not** use **Deploy from a branch** with `main` + `/docs`. Generated HTML is
 - [x] **#456** — Move and update English Guide files into `guide/en/`
 - [x] **#457** — Set TypeDoc `out` to `../../docs/api`; limit `projectDocuments` to English Guide only
 - [x] **#458** — Build `docs/guide/{ja,en}/`, add site index, link Guide ↔ API Reference
-- [ ] **#151** — Deploy `docs/` artifact to Firebase without redefining internal paths
+- [x] **#352** — Emit portal docs fragment at `dist/portal/web-serial-rxjs/`
+- [ ] **#151** — Publish via `gurezo/portal` without redefining internal paths
 
 ## References
 
 - [Parent issue #453](https://github.com/gurezo/web-serial-rxjs/issues/453)
+- [Portal docs fragment #352](https://github.com/gurezo/web-serial-rxjs/issues/352)
+- [Firebase migration parent #151](https://github.com/gurezo/web-serial-rxjs/issues/151)
 - [TypeDoc configuration](../typedoc.json)
 - [Deploy workflow](../../../.github/workflows/deploy-docs.yml)
 - [日本語版](./ARCHITECTURE.ja.md)

--- a/packages/web-serial-rxjs/scripts/package-docs-portal.mjs
+++ b/packages/web-serial-rxjs/scripts/package-docs-portal.mjs
@@ -1,0 +1,43 @@
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, '../../..');
+const docsOutRoot = join(repoRoot, 'docs');
+const portalFragmentRoot = join(repoRoot, 'dist/portal/web-serial-rxjs');
+
+const indexPath = join(docsOutRoot, 'index.html');
+if (!existsSync(indexPath)) {
+  console.error(
+    'docs/index.html not found. Run `pnpm run docs` (or docs:index) before docs:portal.',
+  );
+  process.exit(1);
+}
+
+rmSync(portalFragmentRoot, { recursive: true, force: true });
+mkdirSync(portalFragmentRoot, { recursive: true });
+
+for (const entry of readdirSync(docsOutRoot)) {
+  if (entry === '.gitignore') {
+    continue;
+  }
+  const src = join(docsOutRoot, entry);
+  const dest = join(portalFragmentRoot, entry);
+  const stats = statSync(src);
+  if (stats.isDirectory()) {
+    cpSync(src, dest, { recursive: true });
+  } else {
+    cpSync(src, dest);
+  }
+}
+
+console.log(`Packaged docs portal fragment → ${portalFragmentRoot}`);


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): add portal static docs artifact build

## Summary
- `docs/` の生成成果物を portal 取り込み用 fragment として `dist/portal/web-serial-rxjs/` に出力できるようにする
- 公開先 `https://gurezo.net/web-serial-rxjs/` 向けの契約を ARCHITECTURE に明記する（最終 deploy は portal 側）

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #352
- Parent: #151

## What changed?
- `packages/web-serial-rxjs/scripts/package-docs-portal.mjs` を追加し、`docs/` を `dist/portal/web-serial-rxjs/` へコピー
- ルート `package.json` に `docs:portal` を追加し、`pnpm run docs` パイプライン末尾へ接続
- `ARCHITECTURE.md` / `ARCHITECTURE.ja.md` に portal fragment の出力先・責務分担を追記

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs` を実行する
2. `dist/portal/web-serial-rxjs/` に `index.html` / `guide/` / `api/` / `media/` があることを確認する（`.gitignore` は含まれないこと）
3. `npx serve dist/portal -p 4173` を起動し、`http://localhost:4173/web-serial-rxjs/` で CSS / JS / Guide ↔ API 遷移を確認する

## Environment (if relevant)
- Browser: N/A（静的 docs 成果物のローカル検証）
- OS: macOS
- web-serial-rxjs version (for verification): workspace main + this branch
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)