### PR TITLE
ci(workspace): add portal static artifact workflow

### DIFF
--- a/.github/workflows/portal-static-artifact.yml
+++ b/.github/workflows/portal-static-artifact.yml
@@ -1,0 +1,68 @@
+name: Portal Static Artifact
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'apps/example-*/**'
+      - 'packages/web-serial-rxjs/src/**'
+      - 'packages/web-serial-rxjs/typedoc.json'
+      - 'packages/web-serial-rxjs/scripts/**'
+      - 'packages/web-serial-rxjs/docs/**'
+      - '.github/workflows/portal-static-artifact.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-artifact:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        id: pnpm-cache
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build docs and examples portal fragment
+        run: pnpm run docs
+
+      - name: Stage portal static tree
+        run: |
+          mkdir -p web-serial-rxjs-static
+          cp -a dist/portal/web-serial-rxjs web-serial-rxjs-static/
+
+      - name: Upload portal static artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-serial-rxjs-static
+          path: web-serial-rxjs-static
+          if-no-files-found: error

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
@@ -166,6 +166,35 @@ dist/portal/web-serial-rxjs/
 - Vue example は Vite `base` `/web-serial-rxjs/examples/vue/` を使う（`nx build example-vue --configuration=portal`）。
 - SPA fallback / clean URL rewrite（必要な場合）は portal 側 Hosting 設定の確認事項。docs はマルチページ静的 HTML（`*.html`）である。
 
+### Portal static artifact CI（#360）
+
+GitHub Actions workflow [`.github/workflows/portal-static-artifact.yml`](../../../.github/workflows/portal-static-artifact.yml) が `pnpm run docs` を実行し、portal 取り込み用に staging したうえでダウンロード可能な artifact を upload する。Firebase Hosting への deploy は**行わない**。
+
+| 項目 | 値 |
+| --- | --- |
+| Workflow | [`.github/workflows/portal-static-artifact.yml`](../../../.github/workflows/portal-static-artifact.yml) |
+| Artifact 名 | `web-serial-rxjs-static` |
+| Staging レイアウト | `web-serial-rxjs-static/web-serial-rxjs/`（`dist/portal/web-serial-rxjs/` からコピー） |
+| トリガー | `main` への `push`（path filter あり）および `workflow_dispatch` |
+| Deploy | 本リポジトリでは行わない（`gurezo/portal` の責務） |
+
+```text
+web-serial-rxjs-static/
+└── web-serial-rxjs/
+    ├── index.html
+    ├── api/ guide/ media/
+    └── examples/
+        ├── index.html
+        ├── angular/
+        ├── react/
+        ├── svelte/
+        ├── vanilla-js/
+        ├── vanilla-ts/
+        └── vue/
+```
+
+`gurezo/portal` は artifact をダウンロードし、`web-serial-rxjs/` を `firebase-public/web-serial-rxjs/` へ配置する。ビルド失敗時は upload ステップに到達しないため、失敗時に artifact は公開されない。
+
 ## GitHub Pages 配信（#151 / #361 完了まで）
 
 Firebase Hosting（#151）で github.io を置き換えるまでは、公開サイトは GitHub Actions 経由でのみ配信する。
@@ -192,6 +221,7 @@ Firebase Hosting（#151）で github.io を置き換えるまでは、公開サ�
 | **#354** | Angular example を `dist/portal/web-serial-rxjs/examples/angular/` に出力 |
 | **#355** | React example を `dist/portal/web-serial-rxjs/examples/react/` に出力 |
 | **#356** | Svelte example を `dist/portal/web-serial-rxjs/examples/svelte/` に出力 |
+| **#357** | Vanilla JS example を `dist/portal/web-serial-rxjs/examples/vanilla-js/` に出力 |
 | **#358** | Vanilla TS example を `dist/portal/web-serial-rxjs/examples/vanilla-ts/` に出力 |
 | **#359** | Vue example を `dist/portal/web-serial-rxjs/examples/vue/` に出力 |
 | **#151** | Firebase Hosting 移行の親（レイアウトは本リポ、最終 deploy は portal） |
@@ -209,8 +239,10 @@ Firebase Hosting（#151）で github.io を置き換えるまでは、公開サ�
 - [x] **#354** — Angular example を `dist/portal/web-serial-rxjs/examples/angular/` に出力
 - [x] **#355** — React example を `dist/portal/web-serial-rxjs/examples/react/` に出力
 - [x] **#356** — Svelte example を `dist/portal/web-serial-rxjs/examples/svelte/` に出力
+- [x] **#357** — Vanilla JS example を `dist/portal/web-serial-rxjs/examples/vanilla-js/` に出力
 - [x] **#358** — Vanilla TS example を `dist/portal/web-serial-rxjs/examples/vanilla-ts/` に出力
 - [x] **#359** — Vue example を `dist/portal/web-serial-rxjs/examples/vue/` に出力
+- [x] **#360** — GitHub Actions で `web-serial-rxjs-static` artifact を upload
 - [ ] **#151** — `gurezo/portal` 経由で公開（内部パスは再定義しない）
 
 ## 参照
@@ -221,9 +253,12 @@ Firebase Hosting（#151）で github.io を置き換えるまでは、公開サ�
 - [Portal Angular example #354](https://github.com/gurezo/web-serial-rxjs/issues/354)
 - [Portal React example #355](https://github.com/gurezo/web-serial-rxjs/issues/355)
 - [Portal Svelte example #356](https://github.com/gurezo/web-serial-rxjs/issues/356)
+- [Portal Vanilla JS example #357](https://github.com/gurezo/web-serial-rxjs/issues/357)
 - [Portal Vanilla TS example #358](https://github.com/gurezo/web-serial-rxjs/issues/358)
 - [Portal Vue example #359](https://github.com/gurezo/web-serial-rxjs/issues/359)
+- [Portal static artifact CI #360](https://github.com/gurezo/web-serial-rxjs/issues/360)
 - [Firebase 移行親 #151](https://github.com/gurezo/web-serial-rxjs/issues/151)
 - [TypeDoc 設定](../typedoc.json)
 - [デプロイ workflow](../../../.github/workflows/deploy-docs.yml)
+- [Portal static artifact workflow](../../../.github/workflows/portal-static-artifact.yml)
 - [English version](./ARCHITECTURE.md)

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.md
@@ -166,6 +166,35 @@ dist/portal/web-serial-rxjs/
 - The Vue example uses Vite `base` `/web-serial-rxjs/examples/vue/` (`nx build example-vue --configuration=portal`).
 - SPA fallback / clean-URL rewrites (if any) are portal Hosting configuration, not this repo. Docs are multi-page static HTML (`*.html` files).
 
+### Portal static artifact CI (#360)
+
+GitHub Actions workflow [`.github/workflows/portal-static-artifact.yml`](../../../.github/workflows/portal-static-artifact.yml) runs `pnpm run docs`, stages the fragment for portal import, and uploads a downloadable artifact. It does **not** deploy to Firebase Hosting.
+
+| Item | Value |
+| --- | --- |
+| Workflow | [`.github/workflows/portal-static-artifact.yml`](../../../.github/workflows/portal-static-artifact.yml) |
+| Artifact name | `web-serial-rxjs-static` |
+| Staged layout | `web-serial-rxjs-static/web-serial-rxjs/` (copied from `dist/portal/web-serial-rxjs/`) |
+| Triggers | `push` to `main` (path-filtered) and `workflow_dispatch` |
+| Deploy | None in this repository (owned by `gurezo/portal`) |
+
+```text
+web-serial-rxjs-static/
+└── web-serial-rxjs/
+    ├── index.html
+    ├── api/ guide/ media/
+    └── examples/
+        ├── index.html
+        ├── angular/
+        ├── react/
+        ├── svelte/
+        ├── vanilla-js/
+        ├── vanilla-ts/
+        └── vue/
+```
+
+`gurezo/portal` downloads the artifact and places `web-serial-rxjs/` under `firebase-public/web-serial-rxjs/`. Build failure skips the upload step, so no artifact is published on failure.
+
 ## GitHub Pages hosting (until #151 / #361)
 
 Until Firebase Hosting (#151) replaces github.io, the live site is served only via GitHub Actions:
@@ -192,6 +221,7 @@ Do **not** use **Deploy from a branch** with `main` + `/docs`. Generated HTML is
 | **#354** | Angular example under `dist/portal/web-serial-rxjs/examples/angular/` |
 | **#355** | React example under `dist/portal/web-serial-rxjs/examples/react/` |
 | **#356** | Svelte example under `dist/portal/web-serial-rxjs/examples/svelte/` |
+| **#357** | Vanilla JS example under `dist/portal/web-serial-rxjs/examples/vanilla-js/` |
 | **#358** | Vanilla TS example under `dist/portal/web-serial-rxjs/examples/vanilla-ts/` |
 | **#359** | Vue example under `dist/portal/web-serial-rxjs/examples/vue/` |
 | **#151** | Firebase Hosting migration parent (layout here; final deploy via portal) |
@@ -209,8 +239,10 @@ Do **not** use **Deploy from a branch** with `main` + `/docs`. Generated HTML is
 - [x] **#354** — Emit Angular example at `dist/portal/web-serial-rxjs/examples/angular/`
 - [x] **#355** — Emit React example at `dist/portal/web-serial-rxjs/examples/react/`
 - [x] **#356** — Emit Svelte example at `dist/portal/web-serial-rxjs/examples/svelte/`
+- [x] **#357** — Emit Vanilla JS example at `dist/portal/web-serial-rxjs/examples/vanilla-js/`
 - [x] **#358** — Emit Vanilla TS example at `dist/portal/web-serial-rxjs/examples/vanilla-ts/`
 - [x] **#359** — Emit Vue example at `dist/portal/web-serial-rxjs/examples/vue/`
+- [x] **#360** — Upload `web-serial-rxjs-static` artifact via GitHub Actions
 - [ ] **#151** — Publish via `gurezo/portal` without redefining internal paths
 
 ## References
@@ -221,9 +253,12 @@ Do **not** use **Deploy from a branch** with `main` + `/docs`. Generated HTML is
 - [Portal Angular example #354](https://github.com/gurezo/web-serial-rxjs/issues/354)
 - [Portal React example #355](https://github.com/gurezo/web-serial-rxjs/issues/355)
 - [Portal Svelte example #356](https://github.com/gurezo/web-serial-rxjs/issues/356)
+- [Portal Vanilla JS example #357](https://github.com/gurezo/web-serial-rxjs/issues/357)
 - [Portal Vanilla TS example #358](https://github.com/gurezo/web-serial-rxjs/issues/358)
 - [Portal Vue example #359](https://github.com/gurezo/web-serial-rxjs/issues/359)
+- [Portal static artifact CI #360](https://github.com/gurezo/web-serial-rxjs/issues/360)
 - [Firebase migration parent #151](https://github.com/gurezo/web-serial-rxjs/issues/151)
 - [TypeDoc configuration](../typedoc.json)
 - [Deploy workflow](../../../.github/workflows/deploy-docs.yml)
+- [Portal static artifact workflow](../../../.github/workflows/portal-static-artifact.yml)
 - [日本語版](./ARCHITECTURE.ja.md)


### PR DESCRIPTION
## PR Title (Conventional Commits)
ci(workspace): add portal static artifact workflow

## Summary
`docs/` と各 example を `pnpm run docs` でビルドし、`gurezo/portal` が取り込める `web-serial-rxjs-static` artifact を GitHub Actions で upload する workflow を追加しました。Firebase Hosting への deploy は行いません。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #360
- Related to #151

## What changed?
- `.github/workflows/portal-static-artifact.yml` を追加（install → `pnpm run docs` → `web-serial-rxjs-static/web-serial-rxjs/` へ staging → `upload-artifact`）
- `ARCHITECTURE.md` / `ARCHITECTURE.ja.md` に artifact 名・レイアウト・workflow パスを追記し、#360 / #357 の checklist を整合

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. PR の diff で workflow の trigger / permissions / upload パスを確認する
2. merge 後、または Actions タブから `Portal Static Artifact` を `workflow_dispatch` で実行する
3. 成功 run から `web-serial-rxjs-static` artifact をダウンロードし、`web-serial-rxjs-static/web-serial-rxjs/{index.html,examples/...}` があることを確認する
4. build が失敗した場合に artifact が付かないこと（upload 未到達）を確認する

## Environment (if relevant)
- Browser: N/A（静的 artifact 生成 CI）
- OS: GitHub Actions `ubuntu-latest`
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)