### PR TITLE
docs(web-serial-rxjs): add getting started path on docs landing

### DIFF
--- a/packages/web-serial-rxjs/docs/guide/en/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/en/quick-start.md
@@ -4,6 +4,11 @@ This is the **shortest path** to opening a serial port, receiving **newline-deli
 
 Use **`lines$`** for standard newline-framed text (`\n`, `\r\n`). **`receive$`** is the raw UTF-8 decoder chunk stream when you need custom framing (see [Advanced Usage](./advanced-usage.md#line-framing)). Prefer **`state$`** with `state.status` narrowing for lifecycle UI. Derive a connected boolean from `state$` when you only need a flag. **`connect$()`**, **`send$()`**, **`disconnect$()`**, and **`dispose$()`** run when you subscribe.
 
+## Requirements
+
+- Serve the page over **HTTPS** or **localhost** (a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts)). Web Serial is unavailable on plain `http://` hosts other than localhost.
+- Call **`connect$()`** from a **user gesture** (for example a button click). The browser will not show the port picker otherwise.
+
 ## Installation
 
 Install the package with npm or pnpm.

--- a/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
@@ -4,6 +4,11 @@
 
 標準的な改行区切り（`\n` / `\r\n`）には **`lines$`** を使います。**`receive$`** はデコーダが返す生のチャンク列のままです。ライフサイクル UI には **`state$`** の `state.status` narrowing を優先してください。boolean だけ必要な場合は `state$` から derive してください。**`connect$()`**、**`send$()`**、**`disconnect$()`**、**`dispose$()`** は購読により実行されます。
 
+## 利用条件
+
+- ページは **HTTPS** または **localhost**（[セキュアコンテキスト](https://developer.mozilla.org/ja/docs/Web/Security/Secure_Contexts)）で配信してください。localhost 以外の平文 `http://` では Web Serial は使えません。
+- **`connect$()`** は **ユーザー操作**（ボタンクリックなど）から呼び出してください。そうでないとブラウザはポート選択ダイアログを開きません。
+
 ## インストール
 
 npm または pnpm でパッケージを導入します。

--- a/packages/web-serial-rxjs/scripts/build-docs-index.mjs
+++ b/packages/web-serial-rxjs/scripts/build-docs-index.mjs
@@ -29,8 +29,61 @@ const toolbarLinks = buildToolbarLinks({
 const mainContent = `<div class="col-content">
 <div class="tsd-page-title"><h1>web-serial-rxjs Documentation</h1></div>
 <div class="tsd-panel tsd-typography">
-<p class="lead">Guides explain how to use the library. The API Reference documents the public TypeScript API (English TypeDoc).</p>
+<p class="lead"><strong>web-serial-rxjs</strong> wraps the Web Serial API with a minimal, session-oriented RxJS <code>SerialSession</code> so apps can connect, send/receive, and drive UI from <code>state$</code> and <code>errors$</code>.</p>
+
+<h2>Get started</h2>
+<ol>
+<li>Install the package</li>
+<li>Create a <code>SerialSession</code></li>
+<li>Connect from a user action</li>
+<li>Receive and send data</li>
+</ol>
+
+<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;margin:1.25rem 0;background:var(--color-background-secondary, transparent);">
+<p style="margin:0 0 0.5rem;"><strong>Requirements</strong></p>
+<ul style="margin:0;padding-left:1.25rem;">
+<li>Serve the page over <strong>HTTPS</strong> or <strong>localhost</strong> (secure context).</li>
+<li>Call <code>connect$()</code> from a <strong>user gesture</strong> (for example a button click). The browser will not open the port picker otherwise.</li>
+</ul>
+</section>
+
+<pre><code class="language-bash">npm install @gurezo/web-serial-rxjs rxjs</code></pre>
+<pre><code class="language-typescript">import { createSerialSession } from '@gurezo/web-serial-rxjs';
+
+const session = createSerialSession({ baudRate: 115200 });
+
+// Wire this to a button click (user gesture required)
+document.getElementById('connect')?.addEventListener('click', () => {
+  session.connect$().subscribe({
+    error: (e) => console.error(e),
+  });
+});
+
+session.lines$.subscribe((line) => console.log(line));
+</code></pre>
+<p style="color:var(--color-text-secondary);">Full walkthrough: <a href="guide/en/quick-start.html">Quick Start (English)</a> · <a href="guide/ja/quick-start.html">クイックスタート（日本語）</a></p>
+
 <div class="cards" style="display:grid;gap:1rem;margin-top:2rem;">
+<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
+<h2 style="margin:0 0 0.5rem;font-size:1.15rem;">Quick Start</h2>
+<p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Shortest path: install, connect from a user action, receive lines, send, and disconnect.</p>
+<p style="margin:0;"><a href="guide/en/quick-start.html"><strong>English Quick Start</strong></a> · <a href="guide/ja/quick-start.html"><strong>日本語クイックスタート</strong></a></p>
+</section>
+<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
+<h2 style="margin:0 0 0.5rem;font-size:1.15rem;">Examples</h2>
+<p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Interactive Angular, React, Svelte, Vue, and Vanilla JS/TS examples using SerialSession.</p>
+<a href="examples/"><strong>Open Examples</strong></a>
+</section>
+<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
+<h2 style="margin:0 0 0.5rem;font-size:1.15rem;">API Reference (English / TypeDoc)</h2>
+<p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Exported classes, interfaces, types, methods, and API contracts from TypeScript JSDoc.</p>
+<a href="${assetBase}index.html"><strong>Open API Reference</strong></a>
+</section>
+</div>
+
+<h2 style="margin-top:2.5rem;">Guides</h2>
+<p style="color:var(--color-text-secondary);">Recommended reading order (overview → quick start → advanced → concepts) and migration notes.</p>
+<div class="cards" style="display:grid;gap:1rem;margin-top:1rem;">
 <section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
 <h2 style="margin:0 0 0.5rem;font-size:1.15rem;">日本語 Guide</h2>
 <p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">インストール、接続フロー、ライフサイクル、エラーハンドリングなどの利用ガイド。</p>
@@ -40,16 +93,6 @@ const mainContent = `<div class="col-content">
 <h2 style="margin:0 0 0.5rem;font-size:1.15rem;">English Guide</h2>
 <p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Installation, connection flow, lifecycle, error handling, and usage patterns.</p>
 <a href="guide/en/README.html"><strong>Open English Guide</strong></a>
-</section>
-<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
-<h2 style="margin:0 0 0.5rem;font-size:1.15rem;">API Reference (English / TypeDoc)</h2>
-<p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Exported classes, interfaces, types, methods, and API contracts from TypeScript JSDoc.</p>
-<a href="${assetBase}index.html"><strong>Open API Reference</strong></a>
-</section>
-<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
-<h2 style="margin:0 0 0.5rem;font-size:1.15rem;">Examples</h2>
-<p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Interactive Angular, React, Svelte, Vue, and Vanilla JS/TS examples using SerialSession.</p>
-<a href="examples/"><strong>Open Examples</strong></a>
 </section>
 </div>
 </div>


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): add getting started path on docs landing

## Summary
ドキュメントトップをリンク一覧中心から、導入〜接続までの最短導線付きに変更しました。初見ユーザーがトップだけで最初の操作を把握し、Quick Start / Examples / API / Guide へ 1 クリックで移動できるようにします。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #517
- Related to #516

## What changed?
- ドキュメントトップ（`build-docs-index.mjs`）に Get started・利用条件・最小コード例・主要 CTA を追加
- Quick Start / Examples / API Reference を主要 CTA、日本語・English Guide を二次セクションへ整理
- EN/JA Quick Start に secure context（HTTPS / localhost）とユーザー操作起点の `connect$` 要件を追記

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs:index`（または `pnpm run docs:generate && pnpm run docs:guide && pnpm run docs:index`）を実行する
2. `docs/index.html` を開き、目的説明・4 ステップ・Requirements・最小コード・CTA（Quick Start / Examples / API）・Guide セクションを確認する
3. 各 CTA が `guide/*/quick-start.html`・`examples/`・API・`guide/*/README.html` へ遷移することを確認する
4. `pnpm run docs:check-links` で内部リンクが通ることを確認する
5. `docs/guide/en/quick-start.html` と `docs/guide/ja/quick-start.html` に利用条件セクションがあることを確認する

## Environment (if relevant)
- Browser: N/A（静的ドキュメントの導線変更）
- OS: macOS
- web-serial-rxjs version (for verification): 4.0.1
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)