### PR TITLE
feat(examples-shared): add source and docs navigation to examples

### DIFF
--- a/apps/example-angular/src/app/app.html
+++ b/apps/example-angular/src/app/app.html
@@ -2,6 +2,76 @@
   <header>
     <h1>Web Serial RxJS - Angular Example</h1>
     <p class="subtitle">Angular Service を使用した Web Serial API のサンプル</p>
+    <nav class="example-nav" aria-label="Example links">
+      <ul class="example-nav-primary">
+        <li>
+          <a
+            [href]="navLinks.viewSource.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.viewSource.label }}</a
+          >
+        </li>
+        <li>
+          <a
+            [href]="navLinks.documentation.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.documentation.label }}</a
+          >
+        </li>
+        <li>
+          <a
+            [href]="navLinks.backToExamples.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.backToExamples.label }}</a
+          >
+        </li>
+        <li>
+          <a
+            [href]="navLinks.reportIssue.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.reportIssue.label }}</a
+          >
+        </li>
+      </ul>
+      <ul class="example-nav-source">
+        <li>
+          <a
+            [href]="navLinks.sourceParts.entry.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.sourceParts.entry.label }}</a
+          >
+        </li>
+        <li>
+          <a
+            [href]="navLinks.sourceParts.serviceHookStore.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.sourceParts.serviceHookStore.label }}</a
+          >
+        </li>
+        <li>
+          <a
+            [href]="navLinks.sourceParts.ui.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.sourceParts.ui.label }}</a
+          >
+        </li>
+        <li>
+          <a
+            [href]="navLinks.sourceParts.readme.href"
+            target="_blank"
+            [rel]="externalLinkRel"
+            >{{ navLinks.sourceParts.readme.label }}</a
+          >
+        </li>
+      </ul>
+    </nav>
   </header>
 
   <main>

--- a/apps/example-angular/src/app/app.scss
+++ b/apps/example-angular/src/app/app.scss
@@ -24,6 +24,39 @@ h1 {
   font-size: 0.9rem;
 }
 
+.example-nav {
+  margin-top: 16px;
+}
+
+.example-nav-primary,
+.example-nav-source {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 16px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.example-nav-source {
+  margin-top: 8px;
+  font-size: 0.85rem;
+}
+
+.example-nav a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+.example-nav a:hover {
+  text-decoration: underline;
+}
+
+.example-nav-source a {
+  color: #7f8c8d;
+}
+
 main {
   display: flex;
   flex-direction: column;

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -3,6 +3,7 @@ import { Component, computed, inject, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
+import { getExampleNavLinks } from '@gurezo/examples-shared';
 import {
   isWebSerialSupported,
   SerialSessionStatus,
@@ -22,6 +23,8 @@ type StatusType = 'info' | 'success' | 'error';
 export class App {
   baudRate = 9600;
   sendInput = '';
+  readonly navLinks = getExampleNavLinks('angular');
+  readonly externalLinkRel = 'noopener noreferrer';
 
   private readonly serialService = inject(SerialClientService);
 

--- a/apps/example-react/src/App.tsx
+++ b/apps/example-react/src/App.tsx
@@ -1,8 +1,15 @@
+import { getExampleNavLinks } from '@gurezo/examples-shared';
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { useState } from 'react';
 import { useSerialSession } from './hooks/useSerialSession';
 
 type StatusType = 'info' | 'success' | 'error';
+
+const navLinks = getExampleNavLinks('react');
+const externalLinkProps = {
+  target: '_blank',
+  rel: 'noopener noreferrer',
+} as const;
 
 export function App() {
   const [baudRate, setBaudRate] = useState(9600);
@@ -64,6 +71,55 @@ export function App() {
         <p className="subtitle">
           React カスタムフックを使用した Web Serial API のサンプル
         </p>
+        <nav className="example-nav" aria-label="Example links">
+          <ul className="example-nav-primary">
+            <li>
+              <a href={navLinks.viewSource.href} {...externalLinkProps}>
+                {navLinks.viewSource.label}
+              </a>
+            </li>
+            <li>
+              <a href={navLinks.documentation.href} {...externalLinkProps}>
+                {navLinks.documentation.label}
+              </a>
+            </li>
+            <li>
+              <a href={navLinks.backToExamples.href} {...externalLinkProps}>
+                {navLinks.backToExamples.label}
+              </a>
+            </li>
+            <li>
+              <a href={navLinks.reportIssue.href} {...externalLinkProps}>
+                {navLinks.reportIssue.label}
+              </a>
+            </li>
+          </ul>
+          <ul className="example-nav-source">
+            <li>
+              <a href={navLinks.sourceParts.entry.href} {...externalLinkProps}>
+                {navLinks.sourceParts.entry.label}
+              </a>
+            </li>
+            <li>
+              <a
+                href={navLinks.sourceParts.serviceHookStore.href}
+                {...externalLinkProps}
+              >
+                {navLinks.sourceParts.serviceHookStore.label}
+              </a>
+            </li>
+            <li>
+              <a href={navLinks.sourceParts.ui.href} {...externalLinkProps}>
+                {navLinks.sourceParts.ui.label}
+              </a>
+            </li>
+            <li>
+              <a href={navLinks.sourceParts.readme.href} {...externalLinkProps}>
+                {navLinks.sourceParts.readme.label}
+              </a>
+            </li>
+          </ul>
+        </nav>
       </header>
       <main>
         <section className="section">

--- a/apps/example-react/src/styles.css
+++ b/apps/example-react/src/styles.css
@@ -39,6 +39,39 @@ h1 {
   font-size: 0.9rem;
 }
 
+.example-nav {
+  margin-top: 16px;
+}
+
+.example-nav-primary,
+.example-nav-source {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 16px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.example-nav-source {
+  margin-top: 8px;
+  font-size: 0.85rem;
+}
+
+.example-nav a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+.example-nav a:hover {
+  text-decoration: underline;
+}
+
+.example-nav-source a {
+  color: #7f8c8d;
+}
+
 main {
   display: flex;
   flex-direction: column;

--- a/apps/example-svelte/src/App.svelte
+++ b/apps/example-svelte/src/App.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
+  import { getExampleNavLinks } from '@gurezo/examples-shared';
   import {
     SerialSessionStatus,
     type SerialSessionState,
   } from '@gurezo/web-serial-rxjs';
   import { useSerialSession } from './stores/useSerialSession';
+
+  const navLinks = getExampleNavLinks('svelte');
+  const externalLinkRel = 'noopener noreferrer';
 
   let baudRate = 9600;
   let sendInput = '';
@@ -93,6 +97,76 @@
     <p class="subtitle">
       Svelte Store を使用した Web Serial API のサンプル
     </p>
+    <nav class="example-nav" aria-label="Example links">
+      <ul class="example-nav-primary">
+        <li>
+          <a
+            href={navLinks.viewSource.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.viewSource.label}</a
+          >
+        </li>
+        <li>
+          <a
+            href={navLinks.documentation.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.documentation.label}</a
+          >
+        </li>
+        <li>
+          <a
+            href={navLinks.backToExamples.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.backToExamples.label}</a
+          >
+        </li>
+        <li>
+          <a
+            href={navLinks.reportIssue.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.reportIssue.label}</a
+          >
+        </li>
+      </ul>
+      <ul class="example-nav-source">
+        <li>
+          <a
+            href={navLinks.sourceParts.entry.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.sourceParts.entry.label}</a
+          >
+        </li>
+        <li>
+          <a
+            href={navLinks.sourceParts.serviceHookStore.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.sourceParts.serviceHookStore.label}</a
+          >
+        </li>
+        <li>
+          <a
+            href={navLinks.sourceParts.ui.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.sourceParts.ui.label}</a
+          >
+        </li>
+        <li>
+          <a
+            href={navLinks.sourceParts.readme.href}
+            target="_blank"
+            rel={externalLinkRel}
+            >{navLinks.sourceParts.readme.label}</a
+          >
+        </li>
+      </ul>
+    </nav>
   </header>
 
   <main>

--- a/apps/example-svelte/src/styles.css
+++ b/apps/example-svelte/src/styles.css
@@ -39,6 +39,39 @@ h1 {
   font-size: 0.9rem;
 }
 
+.example-nav {
+  margin-top: 16px;
+}
+
+.example-nav-primary,
+.example-nav-source {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 16px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.example-nav-source {
+  margin-top: 8px;
+  font-size: 0.85rem;
+}
+
+.example-nav a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+.example-nav a:hover {
+  text-decoration: underline;
+}
+
+.example-nav-source a {
+  color: #7f8c8d;
+}
+
 main {
   display: flex;
   flex-direction: column;

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,5 +1,8 @@
+import {
+  createSerialSessionController,
+  getExampleNavLinks,
+} from '@gurezo/examples-shared';
 import { isWebSerialSupported, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
-import { createSerialSessionController } from '@gurezo/examples-shared';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -25,8 +28,57 @@ const setStatus = (el, type, msg) => {
   el.className = `status-message ${type}`;
 };
 
+const createLinkItem = (link) => {
+  const li = document.createElement('li');
+  const a = document.createElement('a');
+  a.href = link.href;
+  a.textContent = link.label;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  li.appendChild(a);
+  return li;
+};
+
+const mountExampleNav = (slug) => {
+  const header = document.querySelector('header');
+  if (!header) return;
+
+  const links = getExampleNavLinks(slug);
+  const nav = document.createElement('nav');
+  nav.className = 'example-nav';
+  nav.setAttribute('aria-label', 'Example links');
+
+  const primary = document.createElement('ul');
+  primary.className = 'example-nav-primary';
+  for (const link of [
+    links.viewSource,
+    links.documentation,
+    links.backToExamples,
+    links.reportIssue,
+  ]) {
+    primary.appendChild(createLinkItem(link));
+  }
+
+  const source = document.createElement('ul');
+  source.className = 'example-nav-source';
+  for (const link of [
+    links.sourceParts.entry,
+    links.sourceParts.serviceHookStore,
+    links.sourceParts.ui,
+    links.sourceParts.readme,
+  ]) {
+    source.appendChild(createLinkItem(link));
+  }
+
+  nav.appendChild(primary);
+  nav.appendChild(source);
+  header.appendChild(nav);
+};
+
 export class App {
   constructor() {
+    mountExampleNav('vanilla-js');
+
     const connectBtn = $('connect-btn');
     const disconnectBtn = $('disconnect-btn');
     const status = $('connection-status');

--- a/apps/example-vanilla-js/src/styles.css
+++ b/apps/example-vanilla-js/src/styles.css
@@ -39,6 +39,39 @@ h1 {
   font-size: 0.9rem;
 }
 
+.example-nav {
+  margin-top: 16px;
+}
+
+.example-nav-primary,
+.example-nav-source {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 16px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.example-nav-source {
+  margin-top: 8px;
+  font-size: 0.85rem;
+}
+
+.example-nav a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+.example-nav a:hover {
+  text-decoration: underline;
+}
+
+.example-nav-source a {
+  color: #7f8c8d;
+}
+
 main {
   display: flex;
   flex-direction: column;

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,9 +1,14 @@
 import {
+  createSerialSessionController,
+  getExampleNavLinks,
+  type ExampleNavLink,
+  type ExampleSlug,
+} from '@gurezo/examples-shared';
+import {
   isWebSerialSupported,
   SerialSessionStatus,
   type SerialSessionStatus as SerialSessionStatusType,
 } from '@gurezo/web-serial-rxjs';
-import { createSerialSessionController } from '@gurezo/examples-shared';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -33,12 +38,61 @@ const setStatus = (el: HTMLElement, type: StatusType, msg: string): void => {
   el.className = `status-message ${type}`;
 };
 
+const createLinkItem = (link: ExampleNavLink): HTMLLIElement => {
+  const li = document.createElement('li');
+  const a = document.createElement('a');
+  a.href = link.href;
+  a.textContent = link.label;
+  a.target = '_blank';
+  a.rel = 'noopener noreferrer';
+  li.appendChild(a);
+  return li;
+};
+
+const mountExampleNav = (slug: ExampleSlug): void => {
+  const header = document.querySelector('header');
+  if (!header) return;
+
+  const links = getExampleNavLinks(slug);
+  const nav = document.createElement('nav');
+  nav.className = 'example-nav';
+  nav.setAttribute('aria-label', 'Example links');
+
+  const primary = document.createElement('ul');
+  primary.className = 'example-nav-primary';
+  for (const link of [
+    links.viewSource,
+    links.documentation,
+    links.backToExamples,
+    links.reportIssue,
+  ]) {
+    primary.appendChild(createLinkItem(link));
+  }
+
+  const source = document.createElement('ul');
+  source.className = 'example-nav-source';
+  for (const link of [
+    links.sourceParts.entry,
+    links.sourceParts.serviceHookStore,
+    links.sourceParts.ui,
+    links.sourceParts.readme,
+  ]) {
+    source.appendChild(createLinkItem(link));
+  }
+
+  nav.appendChild(primary);
+  nav.appendChild(source);
+  header.appendChild(nav);
+};
+
 export class App {
   private readonly controller = createSerialSessionController({
     initialBaudRate: 9600,
   });
 
   constructor() {
+    mountExampleNav('vanilla-ts');
+
     const connectBtn = $<HTMLButtonElement>('connect-btn');
     const disconnectBtn = $<HTMLButtonElement>('disconnect-btn');
     const status = $<HTMLElement>('connection-status');

--- a/apps/example-vanilla-ts/src/styles.css
+++ b/apps/example-vanilla-ts/src/styles.css
@@ -39,6 +39,39 @@ h1 {
   font-size: 0.9rem;
 }
 
+.example-nav {
+  margin-top: 16px;
+}
+
+.example-nav-primary,
+.example-nav-source {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 16px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.example-nav-source {
+  margin-top: 8px;
+  font-size: 0.85rem;
+}
+
+.example-nav a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+.example-nav a:hover {
+  text-decoration: underline;
+}
+
+.example-nav-source a {
+  color: #7f8c8d;
+}
+
 main {
   display: flex;
   flex-direction: column;

--- a/apps/example-vue/src/app/App.vue
+++ b/apps/example-vue/src/app/App.vue
@@ -1,9 +1,13 @@
 <script setup lang="ts">
+import { getExampleNavLinks } from '@gurezo/examples-shared';
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { computed, ref } from 'vue';
 import { useSerialClient } from '../composables/useSerialClient';
 
 type StatusType = 'info' | 'success' | 'error';
+
+const navLinks = getExampleNavLinks('vue');
+const externalLinkRel = 'noopener noreferrer';
 
 const baudRate = ref(9600);
 const sendInput = ref('');
@@ -98,6 +102,76 @@ const handleKeyDown = (e: KeyboardEvent) => {
       <p class="subtitle">
         Vue Composition API を使用した Web Serial API のサンプル
       </p>
+      <nav class="example-nav" aria-label="Example links">
+        <ul class="example-nav-primary">
+          <li>
+            <a
+              :href="navLinks.viewSource.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.viewSource.label }}</a
+            >
+          </li>
+          <li>
+            <a
+              :href="navLinks.documentation.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.documentation.label }}</a
+            >
+          </li>
+          <li>
+            <a
+              :href="navLinks.backToExamples.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.backToExamples.label }}</a
+            >
+          </li>
+          <li>
+            <a
+              :href="navLinks.reportIssue.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.reportIssue.label }}</a
+            >
+          </li>
+        </ul>
+        <ul class="example-nav-source">
+          <li>
+            <a
+              :href="navLinks.sourceParts.entry.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.sourceParts.entry.label }}</a
+            >
+          </li>
+          <li>
+            <a
+              :href="navLinks.sourceParts.serviceHookStore.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.sourceParts.serviceHookStore.label }}</a
+            >
+          </li>
+          <li>
+            <a
+              :href="navLinks.sourceParts.ui.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.sourceParts.ui.label }}</a
+            >
+          </li>
+          <li>
+            <a
+              :href="navLinks.sourceParts.readme.href"
+              target="_blank"
+              :rel="externalLinkRel"
+              >{{ navLinks.sourceParts.readme.label }}</a
+            >
+          </li>
+        </ul>
+      </nav>
     </header>
 
     <main>

--- a/apps/example-vue/src/styles.css
+++ b/apps/example-vue/src/styles.css
@@ -39,6 +39,39 @@ h1 {
   font-size: 0.9rem;
 }
 
+.example-nav {
+  margin-top: 16px;
+}
+
+.example-nav-primary,
+.example-nav-source {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 8px 16px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.example-nav-source {
+  margin-top: 8px;
+  font-size: 0.85rem;
+}
+
+.example-nav a {
+  color: #3498db;
+  text-decoration: none;
+}
+
+.example-nav a:hover {
+  text-decoration: underline;
+}
+
+.example-nav-source a {
+  color: #7f8c8d;
+}
+
 main {
   display: flex;
   flex-direction: column;

--- a/libs/examples-shared/src/example-nav-links.spec.ts
+++ b/libs/examples-shared/src/example-nav-links.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXAMPLE_SLUGS,
+  getExampleNavLinks,
+  type ExampleSlug,
+} from './example-nav-links';
+
+const GITHUB_REPO = 'https://github.com/gurezo/web-serial-rxjs';
+const DOCS_ROOT = 'https://gurezo.net/web-serial-rxjs';
+
+describe('getExampleNavLinks', () => {
+  it.each(EXAMPLE_SLUGS)(
+    'returns required primary links for %s',
+    (slug: ExampleSlug) => {
+      const links = getExampleNavLinks(slug);
+
+      expect(links.viewSource.label).toBe('View source on GitHub');
+      expect(links.viewSource.href).toMatch(
+        new RegExp(`^${GITHUB_REPO}/tree/main/apps/example-`),
+      );
+      expect(links.documentation).toEqual({
+        label: 'Documentation',
+        href: `${DOCS_ROOT}/`,
+      });
+      expect(links.backToExamples).toEqual({
+        label: 'Back to Examples',
+        href: `${DOCS_ROOT}/examples/`,
+      });
+      expect(links.reportIssue).toEqual({
+        label: 'Report an issue',
+        href: `${GITHUB_REPO}/issues/new`,
+      });
+    },
+  );
+
+  it.each(EXAMPLE_SLUGS)(
+    'returns Entry / Service-Hook-Store / UI / README blob links for %s',
+    (slug: ExampleSlug) => {
+      const { sourceParts } = getExampleNavLinks(slug);
+
+      expect(sourceParts.entry.label).toBe('Entry');
+      expect(sourceParts.entry.href).toMatch(
+        new RegExp(`^${GITHUB_REPO}/blob/main/apps/example-.+/src/`),
+      );
+      expect(sourceParts.serviceHookStore.label.length).toBeGreaterThan(0);
+      expect(sourceParts.serviceHookStore.href).toMatch(
+        new RegExp(`^${GITHUB_REPO}/blob/main/apps/example-`),
+      );
+      expect(sourceParts.ui.label).toBe('UI');
+      expect(sourceParts.ui.href).toMatch(
+        new RegExp(`^${GITHUB_REPO}/blob/main/apps/example-`),
+      );
+      expect(sourceParts.readme).toEqual({
+        label: 'README',
+        href: expect.stringMatching(
+          new RegExp(`^${GITHUB_REPO}/blob/main/apps/example-.+/README\\.md$`),
+        ),
+      });
+    },
+  );
+
+  it('maps react paths to hook and App.tsx', () => {
+    const links = getExampleNavLinks('react');
+
+    expect(links.viewSource.href).toBe(
+      `${GITHUB_REPO}/tree/main/apps/example-react`,
+    );
+    expect(links.sourceParts.entry.href).toBe(
+      `${GITHUB_REPO}/blob/main/apps/example-react/src/main.tsx`,
+    );
+    expect(links.sourceParts.serviceHookStore).toEqual({
+      label: 'Hook',
+      href: `${GITHUB_REPO}/blob/main/apps/example-react/src/hooks/useSerialSession.ts`,
+    });
+    expect(links.sourceParts.ui.href).toBe(
+      `${GITHUB_REPO}/blob/main/apps/example-react/src/App.tsx`,
+    );
+  });
+
+  it('maps angular paths to service and app.html', () => {
+    const links = getExampleNavLinks('angular');
+
+    expect(links.sourceParts.serviceHookStore).toEqual({
+      label: 'Service',
+      href: `${GITHUB_REPO}/blob/main/apps/example-angular/src/app/services/serial-client.service.ts`,
+    });
+    expect(links.sourceParts.ui.href).toBe(
+      `${GITHUB_REPO}/blob/main/apps/example-angular/src/app/app.html`,
+    );
+  });
+});

--- a/libs/examples-shared/src/example-nav-links.ts
+++ b/libs/examples-shared/src/example-nav-links.ts
@@ -1,0 +1,134 @@
+const GITHUB_REPO = 'https://github.com/gurezo/web-serial-rxjs';
+const DOCS_ROOT = 'https://gurezo.net/web-serial-rxjs';
+
+export type ExampleSlug =
+  | 'angular'
+  | 'react'
+  | 'svelte'
+  | 'vanilla-js'
+  | 'vanilla-ts'
+  | 'vue';
+
+export interface ExampleNavLink {
+  label: string;
+  href: string;
+}
+
+export interface ExampleNavLinks {
+  viewSource: ExampleNavLink;
+  documentation: ExampleNavLink;
+  backToExamples: ExampleNavLink;
+  reportIssue: ExampleNavLink;
+  sourceParts: {
+    entry: ExampleNavLink;
+    serviceHookStore: ExampleNavLink;
+    ui: ExampleNavLink;
+    readme: ExampleNavLink;
+  };
+}
+
+interface ExampleSourcePaths {
+  appDir: string;
+  entry: string;
+  serviceHookStore: string;
+  serviceHookStoreLabel: string;
+  ui: string;
+}
+
+const EXAMPLE_SOURCE_PATHS: Record<ExampleSlug, ExampleSourcePaths> = {
+  angular: {
+    appDir: 'apps/example-angular',
+    entry: 'apps/example-angular/src/main.ts',
+    serviceHookStore: 'apps/example-angular/src/app/services/serial-client.service.ts',
+    serviceHookStoreLabel: 'Service',
+    ui: 'apps/example-angular/src/app/app.html',
+  },
+  react: {
+    appDir: 'apps/example-react',
+    entry: 'apps/example-react/src/main.tsx',
+    serviceHookStore: 'apps/example-react/src/hooks/useSerialSession.ts',
+    serviceHookStoreLabel: 'Hook',
+    ui: 'apps/example-react/src/App.tsx',
+  },
+  svelte: {
+    appDir: 'apps/example-svelte',
+    entry: 'apps/example-svelte/src/main.ts',
+    serviceHookStore: 'apps/example-svelte/src/stores/useSerialSession.ts',
+    serviceHookStoreLabel: 'Store',
+    ui: 'apps/example-svelte/src/App.svelte',
+  },
+  'vanilla-js': {
+    appDir: 'apps/example-vanilla-js',
+    entry: 'apps/example-vanilla-js/src/main.js',
+    serviceHookStore: 'apps/example-vanilla-js/src/app.js',
+    serviceHookStoreLabel: 'App logic',
+    ui: 'apps/example-vanilla-js/index.html',
+  },
+  'vanilla-ts': {
+    appDir: 'apps/example-vanilla-ts',
+    entry: 'apps/example-vanilla-ts/src/main.ts',
+    serviceHookStore: 'apps/example-vanilla-ts/src/app.ts',
+    serviceHookStoreLabel: 'App logic',
+    ui: 'apps/example-vanilla-ts/index.html',
+  },
+  vue: {
+    appDir: 'apps/example-vue',
+    entry: 'apps/example-vue/src/main.ts',
+    serviceHookStore: 'apps/example-vue/src/composables/useSerialClient.ts',
+    serviceHookStoreLabel: 'Composable',
+    ui: 'apps/example-vue/src/app/App.vue',
+  },
+};
+
+const githubTree = (path: string): string => `${GITHUB_REPO}/tree/main/${path}`;
+const githubBlob = (path: string): string => `${GITHUB_REPO}/blob/main/${path}`;
+
+export const EXAMPLE_SLUGS: readonly ExampleSlug[] = [
+  'angular',
+  'react',
+  'svelte',
+  'vanilla-js',
+  'vanilla-ts',
+  'vue',
+];
+
+export function getExampleNavLinks(slug: ExampleSlug): ExampleNavLinks {
+  const paths = EXAMPLE_SOURCE_PATHS[slug];
+
+  return {
+    viewSource: {
+      label: 'View source on GitHub',
+      href: githubTree(paths.appDir),
+    },
+    documentation: {
+      label: 'Documentation',
+      href: `${DOCS_ROOT}/`,
+    },
+    backToExamples: {
+      label: 'Back to Examples',
+      href: `${DOCS_ROOT}/examples/`,
+    },
+    reportIssue: {
+      label: 'Report an issue',
+      href: `${GITHUB_REPO}/issues/new`,
+    },
+    sourceParts: {
+      entry: {
+        label: 'Entry',
+        href: githubBlob(paths.entry),
+      },
+      serviceHookStore: {
+        label: paths.serviceHookStoreLabel,
+        href: githubBlob(paths.serviceHookStore),
+      },
+      ui: {
+        label: 'UI',
+        href: githubBlob(paths.ui),
+      },
+      readme: {
+        label: 'README',
+        href: githubBlob(`${paths.appDir}/README.md`),
+      },
+    },
+  };
+}

--- a/libs/examples-shared/src/index.ts
+++ b/libs/examples-shared/src/index.ts
@@ -3,3 +3,10 @@ export {
   type SerialSessionController,
   type SerialSessionControllerOptions,
 } from './create-serial-session-controller';
+export {
+  EXAMPLE_SLUGS,
+  getExampleNavLinks,
+  type ExampleNavLink,
+  type ExampleNavLinks,
+  type ExampleSlug,
+} from './example-nav-links';


### PR DESCRIPTION
## PR Title (Conventional Commits)
feat(examples-shared): add source and docs navigation to examples

## Summary
実行中の各 Example から、対応ソースコード・ドキュメント・Examples 一覧・Issue 報告へ往復できる共通ナビゲーションを追加しました（#519）。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #519
- Related to #516

## What changed?
- `@gurezo/examples-shared` に `getExampleNavLinks(slug)` を追加し、リンク定義を一元化
- Angular / React / Svelte / Vanilla JS / Vanilla TS / Vue のヘッダーに共通ナビを追加
  - View source on GitHub / Documentation / Back to Examples / Report an issue
  - Entry / Service・Hook・Store / UI / README への GitHub blob リンク
- ポータル／ローカル両対応のため Docs・Examples は `https://gurezo.net/web-serial-rxjs/...` の絶対 URL を使用

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: `examples-shared` に `getExampleNavLinks` / `EXAMPLE_SLUGS` および関連型を export（ライブラリ本体 `@gurezo/web-serial-rxjs` の公開 API には影響なし）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm nx test examples-shared` でリンクヘルパーの単体テストが通ることを確認
2. いずれかの Example を起動（例: `pnpm nx serve example-react`）し、ヘッダーにナビが表示されることを確認
3. 各リンク（GitHub ソース分割・Documentation・Back to Examples・Report an issue）が正しい先に遷移することを確認
4. （任意）`pnpm nx build example-react` などビルドが通ることを確認

## Environment (if relevant)
- Browser: Chromium 系（Web Serial 利用時）
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): main 時点
- RxJS version: workspace 依存どおり

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)