### PR TITLE
feat(examples-shared): show web serial requirements on examples

### DIFF
--- a/apps/example-angular/src/app/app.html
+++ b/apps/example-angular/src/app/app.html
@@ -75,17 +75,20 @@
   </header>
 
   <main>
-    <!-- ブラウザサポート -->
+    <!-- 利用条件・ブラウザサポート -->
     <section class="section">
-      <h2>ブラウザサポート</h2>
+      <h2>{{ requirements.title }}</h2>
+      <ul class="requirements-list">
+        @for (item of requirements.items; track item) {
+          <li>{{ item }}</li>
+        }
+      </ul>
+      <h3 class="subsection-title">ブラウザサポート</h3>
       <div
         class="status-message"
-        [ngClass]="browserSupported ? 'success' : 'error'"
+        [ngClass]="supportStatus.statusType"
       >
-        {{ browserSupported ? 'ブラウザは Web Serial API
-        をサポートしています。' : 'このブラウザは Web Serial API
-        をサポートしていません。Chrome、Edge、Opera などの Chromium
-        ベースのブラウザをご使用ください。' }}
+        {{ supportStatus.statusMessage }}
       </div>
     </section>
 
@@ -111,7 +114,7 @@
         <button
           class="btn btn-primary"
           (click)="handleConnect()"
-          [disabled]="!browserSupported || isConnected() || connecting()"
+          [disabled]="!canConnect || isConnected() || connecting()"
         >
           接続
         </button>

--- a/apps/example-angular/src/app/app.scss
+++ b/apps/example-angular/src/app/app.scss
@@ -78,6 +78,23 @@ main {
   padding-bottom: 8px;
 }
 
+.subsection-title {
+  font-size: 1.1rem;
+  margin: 20px 0 12px;
+  color: #2c3e50;
+}
+
+.requirements-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #555;
+  font-size: 0.95rem;
+
+  li + li {
+    margin-top: 0.5rem;
+  }
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -3,9 +3,14 @@ import { Component, computed, inject, linkedSignal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
-import { getExampleNavLinks } from '@gurezo/examples-shared';
 import {
-  isWebSerialSupported,
+  formatExampleSerialError,
+  getExampleNavLinks,
+  getExampleRequirementsCopy,
+  getExampleSupportStatus,
+  type ExampleErrorDisplay,
+} from '@gurezo/examples-shared';
+import {
   SerialSessionStatus,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
@@ -24,11 +29,13 @@ export class App {
   baudRate = 9600;
   sendInput = '';
   readonly navLinks = getExampleNavLinks('angular');
+  readonly requirements = getExampleRequirementsCopy();
+  readonly supportStatus = getExampleSupportStatus();
   readonly externalLinkRel = 'noopener noreferrer';
 
   private readonly serialService = inject(SerialClientService);
 
-  readonly browserSupported = isWebSerialSupported();
+  readonly canConnect = this.supportStatus.canConnect;
   readonly state = toSignal(this.serialService.state$, {
     initialValue: {
       status: SerialSessionStatus.Idle,
@@ -44,14 +51,14 @@ export class App {
     source: () => this.terminalText(),
     computation: (text) => text,
   });
-  private readonly lastError = toSignal(
+  private readonly lastErrorDisplay = toSignal(
     this.serialService.errors$.pipe(
-      map((error): string | null => error.message),
+      map((error): ExampleErrorDisplay => formatExampleSerialError(error)),
     ),
-    { initialValue: null },
+    { initialValue: null as ExampleErrorDisplay | null },
   );
 
-  readonly errorMessage = computed(() => {
+  readonly errorDisplay = computed(() => {
     const status = this.state().status;
     if (
       status === SerialSessionStatus.Connected ||
@@ -60,7 +67,7 @@ export class App {
     ) {
       return null;
     }
-    return this.lastError();
+    return this.lastErrorDisplay();
   });
 
   readonly connecting = computed(
@@ -74,9 +81,13 @@ export class App {
   readonly hasReceivedData = computed(() => this.receivedData().length > 0);
 
   readonly status = computed((): { type: StatusType; message: string } => {
-    const error = this.errorMessage();
+    const error = this.errorDisplay();
     if (error) {
-      return { type: 'error', message: `エラー: ${error}` };
+      return {
+        type: error.type,
+        message:
+          error.type === 'info' ? error.message : `エラー: ${error.message}`,
+      };
     }
     switch (this.state().status) {
       case SerialSessionStatus.Connecting:
@@ -88,8 +99,7 @@ export class App {
       case SerialSessionStatus.Unsupported:
         return {
           type: 'error',
-          message:
-            'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
+          message: this.supportStatus.statusMessage,
         };
       case SerialSessionStatus.Error:
         return { type: 'error', message: 'エラーが発生しました。' };

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -53,7 +53,9 @@ export class App {
   });
   private readonly lastErrorDisplay = toSignal(
     this.serialService.errors$.pipe(
-      map((error): ExampleErrorDisplay => formatExampleSerialError(error)),
+      map(
+        (error): ExampleErrorDisplay | null => formatExampleSerialError(error),
+      ),
     ),
     { initialValue: null as ExampleErrorDisplay | null },
   );

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -86,6 +86,10 @@ const latestMock = (): MockSession => {
 describe('App', () => {
   beforeEach(() => {
     mockSessions = [];
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
   });
 
   afterEach(() => {
@@ -104,10 +108,16 @@ describe('App', () => {
     ).toBeInTheDocument();
   });
 
-  it('ブラウザサポート状況を表示する', () => {
+  it('利用条件とブラウザサポート状況を表示する', () => {
     render(<App />);
+    expect(screen.getByText('利用条件')).toBeInTheDocument();
     expect(
-      screen.getByText('ブラウザは Web Serial API をサポートしています。'),
+      screen.getByText(/HTTPS または localhost/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'ブラウザは Web Serial API をサポートしており、セキュアコンテキストで実行中です。',
+      ),
     ).toBeInTheDocument();
   });
 
@@ -208,7 +218,10 @@ describe('App', () => {
   it('errors$ 発火時にエラーメッセージを表示する', async () => {
     render(<App />);
 
-    const err = { message: 'write failed' } as SerialError;
+    const err = new webSerialRxjs.SerialError(
+      webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+      'write failed',
+    );
     act(() => latestMock().errorsSubject.next(err));
 
     await waitFor(() => {

--- a/apps/example-react/src/App.tsx
+++ b/apps/example-react/src/App.tsx
@@ -1,11 +1,16 @@
-import { getExampleNavLinks } from '@gurezo/examples-shared';
+import {
+  getExampleNavLinks,
+  getExampleRequirementsCopy,
+  getExampleSupportStatus,
+} from '@gurezo/examples-shared';
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSerialSession } from './hooks/useSerialSession';
 
 type StatusType = 'info' | 'success' | 'error';
 
 const navLinks = getExampleNavLinks('react');
+const requirements = getExampleRequirementsCopy();
 const externalLinkProps = {
   target: '_blank',
   rel: 'noopener noreferrer',
@@ -14,12 +19,14 @@ const externalLinkProps = {
 export function App() {
   const [baudRate, setBaudRate] = useState(9600);
   const [sendInput, setSendInput] = useState('');
+  const supportStatus = useMemo(() => getExampleSupportStatus(), []);
   const {
-    browserSupported,
+    canConnect,
     state,
     isConnected,
     receivedData,
     errorMessage,
+    errorType,
     connect$,
     disconnect$,
     send$,
@@ -30,7 +37,11 @@ export function App() {
   const disconnecting = state.status === SerialSessionStatus.Disconnecting;
 
   const status: { type: StatusType; message: string } = errorMessage
-    ? { type: 'error', message: `エラー: ${errorMessage}` }
+    ? {
+        type: errorType === 'info' ? 'info' : 'error',
+        message:
+          errorType === 'info' ? errorMessage : `エラー: ${errorMessage}`,
+      }
     : connecting
       ? { type: 'info', message: '接続中...' }
       : disconnecting
@@ -123,11 +134,15 @@ export function App() {
       </header>
       <main>
         <section className="section">
-          <h2>ブラウザサポート</h2>
-          <div className={`status-message ${browserSupported ? 'success' : 'error'}`}>
-            {browserSupported
-              ? 'ブラウザは Web Serial API をサポートしています。'
-              : 'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。'}
+          <h2>{requirements.title}</h2>
+          <ul className="requirements-list">
+            {requirements.items.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+          <h3 className="subsection-title">ブラウザサポート</h3>
+          <div className={`status-message ${supportStatus.statusType}`}>
+            {supportStatus.statusMessage}
           </div>
         </section>
         <section className="section">
@@ -152,7 +167,7 @@ export function App() {
             <button
               className="btn btn-primary"
               onClick={handleConnect}
-              disabled={!browserSupported || isConnected || connecting}
+              disabled={!canConnect || isConnected || connecting}
             >
               接続
             </button>

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useSerialSession } from './useSerialSession';
 
 const SS = webSerialRxjs.SerialSessionStatus;
+const { SerialError, SerialErrorCode } = webSerialRxjs;
 
 interface MockCore {
   session: SerialSession;
@@ -90,6 +91,10 @@ describe('useSerialSession', () => {
   beforeEach(() => {
     mockCores = [];
     nextSupported = true;
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
   });
 
   afterEach(() => {
@@ -102,7 +107,9 @@ describe('useSerialSession', () => {
     expect(result.current.isConnected).toBe(false);
     expect(result.current.receivedData).toBe('');
     expect(result.current.errorMessage).toBeNull();
+    expect(result.current.errorType).toBeNull();
     expect(result.current.browserSupported).toBe(true);
+    expect(result.current.canConnect).toBe(true);
   });
 
   it('createSerialSession に初期ボーレートを渡す', () => {
@@ -138,19 +145,39 @@ describe('useSerialSession', () => {
   it('errors$ の値が errorMessage に反映される', () => {
     const { result } = renderHook(() => useSerialSession());
     act(() =>
-      latestMock().errorsSubject.next({ message: 'boom' } as SerialError),
+      latestMock().errorsSubject.next(
+        new SerialError(SerialErrorCode.WRITE_FAILED, 'boom'),
+      ),
     );
     expect(result.current.errorMessage).toBe('boom');
+    expect(result.current.errorType).toBe('error');
+  });
+
+  it('OPERATION_CANCELLED は info 案内文言に整形される', () => {
+    const { result } = renderHook(() => useSerialSession());
+    act(() =>
+      latestMock().errorsSubject.next(
+        new SerialError(
+          SerialErrorCode.OPERATION_CANCELLED,
+          'Port selection was cancelled by the user',
+        ),
+      ),
+    );
+    expect(result.current.errorType).toBe('info');
+    expect(result.current.errorMessage).toContain('キャンセル');
   });
 
   it('state$ が connected / idle になると errorMessage がクリアされる', () => {
     const { result } = renderHook(() => useSerialSession());
     act(() =>
-      latestMock().errorsSubject.next({ message: 'boom' } as SerialError),
+      latestMock().errorsSubject.next(
+        new SerialError(SerialErrorCode.WRITE_FAILED, 'boom'),
+      ),
     );
     expect(result.current.errorMessage).toBe('boom');
     act(() => latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } }));
     expect(result.current.errorMessage).toBeNull();
+    expect(result.current.errorType).toBeNull();
   });
 
   it('clearReceivedData で receivedData が空になる', () => {

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,23 +1,26 @@
 import {
-  isWebSerialSupported,
+  createSerialSessionController,
+  formatExampleSerialError,
+  getExampleSupportStatus,
+  type SerialSessionController,
+} from '@gurezo/examples-shared';
+import {
   SerialSessionStatus,
   type SerialError,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import {
-  createSerialSessionController,
-  type SerialSessionController,
-} from '@gurezo/examples-shared';
 import { useEffect, useRef, useState } from 'react';
 import { type Observable, Subscription } from 'rxjs';
 
 /** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続時は世代でリセット）。 */
 export interface UseSerialSessionReturn {
   browserSupported: boolean;
+  canConnect: boolean;
   state: SerialSessionState;
   isConnected: boolean;
   receivedData: string;
   errorMessage: string | null;
+  errorType: 'info' | 'error' | null;
   connect$: (baudRate?: number) => Observable<void>;
   disconnect$: () => Observable<void>;
   send$: (data: string | Uint8Array) => Observable<void>;
@@ -41,13 +44,19 @@ export function useSerialSession(
 
   ensureController(initialBaudRate);
 
-  const [browserSupported] = useState(() => isWebSerialSupported());
+  const [supportStatus] = useState(() => getExampleSupportStatus());
   const [state, setState] = useState<SerialSessionState>({
     status: SerialSessionStatus.Idle,
   });
   const [isConnected, setIsConnected] = useState(false);
   const [receivedData, setReceivedData] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorType, setErrorType] = useState<'info' | 'error' | null>(null);
+
+  const clearError = () => {
+    setErrorMessage(null);
+    setErrorType(null);
+  };
 
   useEffect(() => {
     ensureController(initialBaudRate);
@@ -60,13 +69,18 @@ export function useSerialSession(
         if (
           next.status === SerialSessionStatus.Connected ||
           next.status === SerialSessionStatus.Idle
-        )
-          setErrorMessage(null);
+        ) {
+          clearError();
+        }
       }),
     );
     sub.add(controller.terminalText$.subscribe(setReceivedData));
     sub.add(
-      controller.errors$.subscribe((e: SerialError) => setErrorMessage(e.message)),
+      controller.errors$.subscribe((e: SerialError) => {
+        const display = formatExampleSerialError(e);
+        setErrorMessage(display.message);
+        setErrorType(display.type);
+      }),
     );
     return () => {
       sub.unsubscribe();
@@ -89,11 +103,13 @@ export function useSerialSession(
   };
 
   return {
-    browserSupported,
+    browserSupported: supportStatus.apiSupported,
+    canConnect: supportStatus.canConnect,
     state,
     isConnected,
     receivedData,
     errorMessage,
+    errorType,
     connect$,
     disconnect$,
     send$,

--- a/apps/example-react/src/styles.css
+++ b/apps/example-react/src/styles.css
@@ -93,6 +93,23 @@ main {
   padding-bottom: 8px;
 }
 
+.subsection-title {
+  font-size: 1.1rem;
+  margin: 20px 0 12px;
+  color: #2c3e50;
+}
+
+.requirements-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.requirements-list li + li {
+  margin-top: 0.5rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-svelte/src/App.svelte
+++ b/apps/example-svelte/src/App.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import { getExampleNavLinks } from '@gurezo/examples-shared';
+  import {
+    getExampleNavLinks,
+    getExampleRequirementsCopy,
+    getExampleSupportStatus,
+  } from '@gurezo/examples-shared';
   import {
     SerialSessionStatus,
     type SerialSessionState,
@@ -7,17 +11,20 @@
   import { useSerialSession } from './stores/useSerialSession';
 
   const navLinks = getExampleNavLinks('svelte');
+  const requirements = getExampleRequirementsCopy();
+  const supportStatus = getExampleSupportStatus();
   const externalLinkRel = 'noopener noreferrer';
 
   let baudRate = 9600;
   let sendInput = '';
 
   const {
-    browserSupported,
+    canConnect,
     state,
     isConnected,
     receivedData,
     errorMessage,
+    errorType,
     connect$,
     disconnect$,
     send$,
@@ -29,9 +36,13 @@
   const statusFor = (
     current: SerialSessionState,
     error: string | null,
+    tone: 'info' | 'error' | null,
   ): { type: StatusType; message: string } => {
     if (error) {
-      return { type: 'error', message: `エラー: ${error}` };
+      return {
+        type: tone === 'info' ? 'info' : 'error',
+        message: tone === 'info' ? error : `エラー: ${error}`,
+      };
     }
     switch (current.status) {
       case SerialSessionStatus.Connecting:
@@ -43,8 +54,7 @@
       case SerialSessionStatus.Unsupported:
         return {
           type: 'error',
-          message:
-            'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
+          message: supportStatus.statusMessage,
         };
       case SerialSessionStatus.Error:
         return { type: 'error', message: 'エラーが発生しました。' };
@@ -53,7 +63,7 @@
     }
   };
 
-  $: status = statusFor($state, $errorMessage);
+  $: status = statusFor($state, $errorMessage, $errorType);
   $: connecting = $state.status === SerialSessionStatus.Connecting;
   $: disconnecting = $state.status === SerialSessionStatus.Disconnecting;
 
@@ -170,13 +180,17 @@
   </header>
 
   <main>
-    <!-- ブラウザサポート -->
+    <!-- 利用条件・ブラウザサポート -->
     <section class="section">
-      <h2>ブラウザサポート</h2>
-      <div class="status-message {$browserSupported ? 'success' : 'error'}">
-        {$browserSupported
-          ? 'ブラウザは Web Serial API をサポートしています。'
-          : 'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。'}
+      <h2>{requirements.title}</h2>
+      <ul class="requirements-list">
+        {#each requirements.items as item}
+          <li>{item}</li>
+        {/each}
+      </ul>
+      <h3 class="subsection-title">ブラウザサポート</h3>
+      <div class="status-message {supportStatus.statusType}">
+        {supportStatus.statusMessage}
       </div>
     </section>
 
@@ -202,7 +216,7 @@
         <button
           class="btn btn-primary"
           on:click={handleConnect}
-          disabled={!$browserSupported || $isConnected || connecting}
+          disabled={!$canConnect || $isConnected || connecting}
         >
           接続
         </button>

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -100,6 +100,10 @@ describe('useSerialSession', () => {
   beforeEach(() => {
     mockCores = [];
     nextSupported = true;
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
     (globalThis as unknown as { __svelteCleanup?: () => void }).__svelteCleanup =
       undefined;
   });
@@ -120,7 +124,9 @@ describe('useSerialSession', () => {
     expect(get(s.isConnected)).toBe(false);
     expect(get(s.receivedData)).toBe('');
     expect(get(s.errorMessage)).toBeNull();
+    expect(get(s.errorType)).toBeNull();
     expect(get(s.browserSupported)).toBe(true);
+    expect(get(s.canConnect)).toBe(true);
   });
 
   it('createSerialSession に初期ボーレートを渡す', () => {
@@ -158,18 +164,30 @@ describe('useSerialSession', () => {
   it('errors$ の値が errorMessage に反映される', () => {
     const s = useSerialSession();
     const unsub = s.errorMessage.subscribe(() => void 0);
-    latestMock().errorsSubject.next({ message: 'boom' } as SerialError);
+    latestMock().errorsSubject.next(
+      new webSerialRxjs.SerialError(
+        webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+        'boom',
+      ),
+    );
     expect(get(s.errorMessage)).toBe('boom');
+    expect(get(s.errorType)).toBe('error');
     unsub();
   });
 
   it('state$ が connected / idle になると errorMessage がクリアされる', () => {
     const s = useSerialSession();
     const unsub = s.errorMessage.subscribe(() => void 0);
-    latestMock().errorsSubject.next({ message: 'boom' } as SerialError);
+    latestMock().errorsSubject.next(
+      new webSerialRxjs.SerialError(
+        webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+        'boom',
+      ),
+    );
     expect(get(s.errorMessage)).toBe('boom');
     latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
     expect(get(s.errorMessage)).toBeNull();
+    expect(get(s.errorType)).toBeNull();
     unsub();
   });
 

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,10 +1,13 @@
 import {
-  isWebSerialSupported,
+  createSerialSessionController,
+  formatExampleSerialError,
+  getExampleSupportStatus,
+} from '@gurezo/examples-shared';
+import {
   SerialSessionStatus,
   type SerialError,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import { createSerialSessionController } from '@gurezo/examples-shared';
 import { type Observable, Subscription } from 'rxjs';
 import { onDestroy } from 'svelte';
 import { derived, readable, writable, type Readable } from 'svelte/store';
@@ -12,10 +15,12 @@ import { derived, readable, writable, type Readable } from 'svelte/store';
 /** v2 `SerialSession` を Svelte store に薄く写す。表示は `terminalText$`（再接続は世代でリセット）。 */
 export interface UseSerialSessionReturn {
   browserSupported: Readable<boolean>;
+  canConnect: Readable<boolean>;
   state: Readable<SerialSessionState>;
   isConnected: Readable<boolean>;
   receivedData: Readable<string>;
   errorMessage: Readable<string | null>;
+  errorType: Readable<'info' | 'error' | null>;
   connect$: (baudRate?: number) => Observable<void>;
   disconnect$: () => Observable<void>;
   send$: (data: string | Uint8Array) => Observable<void>;
@@ -29,7 +34,9 @@ export function useSerialSession(
     initialBaudRate,
   });
 
-  const browserSupported = readable(isWebSerialSupported());
+  const supportStatus = getExampleSupportStatus();
+  const browserSupported = readable(supportStatus.apiSupported);
+  const canConnect = readable(supportStatus.canConnect);
 
   const state = readable<SerialSessionState>(
     { status: SerialSessionStatus.Idle },
@@ -49,25 +56,32 @@ export function useSerialSession(
     receivedData.set(t);
   });
 
-  const errorMessage = readable<string | null>(null, (set) => {
-    const subs = new Subscription();
-    subs.add(
-      controller.errors$.subscribe((e: SerialError) => set(e.message)),
-    );
-    subs.add(
-      controller.state$.subscribe((next) => {
-        if (
-          next.status === SerialSessionStatus.Connected ||
-          next.status === SerialSessionStatus.Idle
-        )
-          set(null);
-      }),
-    );
-    return () => subs.unsubscribe();
-  });
+  const errorMessage = writable<string | null>(null);
+  const errorType = writable<'info' | 'error' | null>(null);
+
+  const errorSub = new Subscription();
+  errorSub.add(
+    controller.errors$.subscribe((e: SerialError) => {
+      const display = formatExampleSerialError(e);
+      errorMessage.set(display.message);
+      errorType.set(display.type);
+    }),
+  );
+  errorSub.add(
+    controller.state$.subscribe((next) => {
+      if (
+        next.status === SerialSessionStatus.Connected ||
+        next.status === SerialSessionStatus.Idle
+      ) {
+        errorMessage.set(null);
+        errorType.set(null);
+      }
+    }),
+  );
 
   onDestroy(() => {
     terminalSub.unsubscribe();
+    errorSub.unsubscribe();
     controller.dispose();
   });
 
@@ -88,10 +102,12 @@ export function useSerialSession(
 
   return {
     browserSupported,
+    canConnect,
     state,
     isConnected,
     receivedData,
     errorMessage,
+    errorType,
     connect$,
     disconnect$,
     send$,

--- a/apps/example-svelte/src/styles.css
+++ b/apps/example-svelte/src/styles.css
@@ -93,6 +93,23 @@ main {
   padding-bottom: 8px;
 }
 
+.subsection-title {
+  font-size: 1.1rem;
+  margin: 20px 0 12px;
+  color: #2c3e50;
+}
+
+.requirements-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.requirements-list li + li {
+  margin-top: 0.5rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-vanilla-js/index.html
+++ b/apps/example-vanilla-js/index.html
@@ -14,9 +14,11 @@
       </header>
 
       <main>
-        <!-- Browser Support Check -->
-        <section id="browser-support-section" class="section">
-          <h2>ブラウザサポート</h2>
+        <!-- Requirements / Browser Support -->
+        <section id="requirements-section" class="section">
+          <h2 id="requirements-title">利用条件</h2>
+          <ul id="requirements-list" class="requirements-list"></ul>
+          <h3 class="subsection-title">ブラウザサポート</h3>
           <div id="browser-support-status" class="status-message"></div>
         </section>
 

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,22 +1,13 @@
 import {
   createSerialSessionController,
+  formatExampleSerialError,
   getExampleNavLinks,
+  getExampleRequirementsCopy,
+  getExampleSupportStatus,
 } from '@gurezo/examples-shared';
-import { isWebSerialSupported, SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
-
-const UNSUPPORTED_MSG =
-  'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。';
-const STATUS = {
-  idle: ['info', 'シリアルポートから切断しました。'],
-  connecting: ['info', '接続中です...'],
-  connected: ['success', 'シリアルポートに接続しました。'],
-  disconnecting: ['info', '切断中です...'],
-  unsupported: ['error', UNSUPPORTED_MSG],
-  error: ['error', 'エラーが発生しました。errors$ を確認してください。'],
-  disposed: ['info', 'セッションは破棄されました。'],
-};
 
 const $ = (id) => {
   const el = document.getElementById(id);
@@ -75,9 +66,32 @@ const mountExampleNav = (slug) => {
   header.appendChild(nav);
 };
 
+const mountRequirements = () => {
+  const requirements = getExampleRequirementsCopy();
+  const supportStatus = getExampleSupportStatus();
+
+  $('requirements-title').textContent = requirements.title;
+  const list = $('requirements-list');
+  list.replaceChildren();
+  for (const item of requirements.items) {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  }
+
+  setStatus(
+    $('browser-support-status'),
+    supportStatus.statusType,
+    supportStatus.statusMessage,
+  );
+
+  return supportStatus;
+};
+
 export class App {
   constructor() {
     mountExampleNav('vanilla-js');
+    const supportStatus = mountRequirements();
 
     const connectBtn = $('connect-btn');
     const disconnectBtn = $('disconnect-btn');
@@ -88,19 +102,22 @@ export class App {
     const receiveOutput = $('receive-output');
     this.controller = createSerialSessionController({ initialBaudRate: 9600 });
 
-    const supported = isWebSerialSupported();
-    setStatus(
-      $('browser-support-status'),
-      supported ? 'success' : 'error',
-      supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
-    );
+    const STATUS = {
+      idle: ['info', 'シリアルポートから切断しました。'],
+      connecting: ['info', '接続中です...'],
+      connected: ['success', 'シリアルポートに接続しました。'],
+      disconnecting: ['info', '切断中です...'],
+      unsupported: ['error', supportStatus.statusMessage],
+      error: ['error', 'エラーが発生しました。errors$ を確認してください。'],
+      disposed: ['info', 'セッションは破棄されました。'],
+    };
 
     this.controller.state$.subscribe((state) => {
       const connected = state.status === SerialSessionStatus.Connected;
       const busy =
         state.status === SerialSessionStatus.Connecting ||
         state.status === SerialSessionStatus.Disconnecting;
-      connectBtn.disabled = !supported || connected || busy;
+      connectBtn.disabled = !supportStatus.canConnect || connected || busy;
       baudRateSelect.disabled = connected || busy;
       disconnectBtn.disabled = !connected;
       sendInput.disabled = sendBtn.disabled = !connected;
@@ -113,7 +130,12 @@ export class App {
     });
 
     this.controller.errors$.subscribe((error) => {
-      setStatus(status, 'error', `エラー: ${error.message}`);
+      const display = formatExampleSerialError(error);
+      setStatus(
+        status,
+        display.type,
+        display.type === 'info' ? display.message : `エラー: ${display.message}`,
+      );
       console.error('Serial port error:', error);
     });
 

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -41,8 +41,14 @@ describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSessions = [];
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
     container = document.createElement('div');
     container.innerHTML = `
+      <h2 id="requirements-title"></h2>
+      <ul id="requirements-list"></ul>
       <div id="browser-support-status"></div>
       <button id="connect-btn"></button>
       <button id="disconnect-btn"></button>
@@ -79,10 +85,17 @@ describe('App', () => {
     });
   });
 
-  it('should render browser support status based on isWebSerialSupported', () => {
+  it('should render requirements and browser support status', () => {
     app = new App();
+    expect(document.getElementById('requirements-title').textContent).toBe(
+      '利用条件',
+    );
+    expect(document.getElementById('requirements-list').textContent).toContain(
+      'HTTPS',
+    );
     const el = document.getElementById('browser-support-status');
     expect(el.textContent).toContain('Web Serial API');
+    expect(el.textContent).toContain('セキュアコンテキスト');
     expect(el.className).toContain('success');
   });
 

--- a/apps/example-vanilla-js/src/styles.css
+++ b/apps/example-vanilla-js/src/styles.css
@@ -93,6 +93,23 @@ main {
   padding-bottom: 8px;
 }
 
+.subsection-title {
+  font-size: 1.1rem;
+  margin: 20px 0 12px;
+  color: #2c3e50;
+}
+
+.requirements-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.requirements-list li + li {
+  margin-top: 0.5rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-vanilla-ts/index.html
+++ b/apps/example-vanilla-ts/index.html
@@ -14,9 +14,11 @@
       </header>
 
       <main>
-        <!-- Browser Support Check -->
-        <section id="browser-support-section" class="section">
-          <h2>ブラウザサポート</h2>
+        <!-- Requirements / Browser Support -->
+        <section id="requirements-section" class="section">
+          <h2 id="requirements-title">利用条件</h2>
+          <ul id="requirements-list" class="requirements-list"></ul>
+          <h3 class="subsection-title">ブラウザサポート</h3>
           <div id="browser-support-status" class="status-message"></div>
         </section>
 

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -54,8 +54,14 @@ describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSessions = [];
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
     container = document.createElement('div');
     container.innerHTML = `
+      <h2 id="requirements-title"></h2>
+      <ul id="requirements-list"></ul>
       <div id="browser-support-status"></div>
       <button id="connect-btn"></button>
       <button id="disconnect-btn"></button>
@@ -92,10 +98,17 @@ describe('App', () => {
     });
   });
 
-  it('should render browser support status based on isWebSerialSupported', () => {
+  it('should render requirements and browser support status', () => {
     app = new App();
+    expect(document.getElementById('requirements-title')?.textContent).toBe(
+      '利用条件',
+    );
+    expect(
+      document.getElementById('requirements-list')?.textContent,
+    ).toContain('HTTPS');
     const el = document.getElementById('browser-support-status');
     expect(el?.textContent).toContain('Web Serial API');
+    expect(el?.textContent).toContain('セキュアコンテキスト');
     expect(el?.className).toContain('success');
   });
 

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,11 +1,13 @@
 import {
   createSerialSessionController,
+  formatExampleSerialError,
   getExampleNavLinks,
+  getExampleRequirementsCopy,
+  getExampleSupportStatus,
   type ExampleNavLink,
   type ExampleSlug,
 } from '@gurezo/examples-shared';
 import {
-  isWebSerialSupported,
   SerialSessionStatus,
   type SerialSessionStatus as SerialSessionStatusType,
 } from '@gurezo/web-serial-rxjs';
@@ -14,19 +16,7 @@ import { filter } from 'rxjs/operators';
 
 type StatusType = 'info' | 'success' | 'error';
 
-const UNSUPPORTED_MSG =
-  'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。';
 const S = SerialSessionStatus;
-
-const STATUS: Record<SerialSessionStatusType, [StatusType, string]> = {
-  [S.Idle]: ['info', 'シリアルポートから切断しました。'],
-  [S.Connecting]: ['info', '接続中です...'],
-  [S.Connected]: ['success', 'シリアルポートに接続しました。'],
-  [S.Disconnecting]: ['info', '切断中です...'],
-  [S.Unsupported]: ['error', UNSUPPORTED_MSG],
-  [S.Error]: ['error', 'エラーが発生しました。errors$ を確認してください。'],
-  [S.Disposed]: ['info', 'セッションは破棄されました。'],
-};
 
 const $ = <T extends HTMLElement>(id: string): T => {
   const el = document.getElementById(id);
@@ -85,6 +75,28 @@ const mountExampleNav = (slug: ExampleSlug): void => {
   header.appendChild(nav);
 };
 
+const mountRequirements = (): ReturnType<typeof getExampleSupportStatus> => {
+  const requirements = getExampleRequirementsCopy();
+  const supportStatus = getExampleSupportStatus();
+
+  $<HTMLElement>('requirements-title').textContent = requirements.title;
+  const list = $<HTMLUListElement>('requirements-list');
+  list.replaceChildren();
+  for (const item of requirements.items) {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  }
+
+  setStatus(
+    $<HTMLElement>('browser-support-status'),
+    supportStatus.statusType,
+    supportStatus.statusMessage,
+  );
+
+  return supportStatus;
+};
+
 export class App {
   private readonly controller = createSerialSessionController({
     initialBaudRate: 9600,
@@ -92,6 +104,7 @@ export class App {
 
   constructor() {
     mountExampleNav('vanilla-ts');
+    const supportStatus = mountRequirements();
 
     const connectBtn = $<HTMLButtonElement>('connect-btn');
     const disconnectBtn = $<HTMLButtonElement>('disconnect-btn');
@@ -101,17 +114,20 @@ export class App {
     const sendBtn = $<HTMLButtonElement>('send-btn');
     const receiveOutput = $<HTMLTextAreaElement>('receive-output');
 
-    const supported = isWebSerialSupported();
-    setStatus(
-      $<HTMLElement>('browser-support-status'),
-      supported ? 'success' : 'error',
-      supported ? 'ブラウザは Web Serial API をサポートしています。' : UNSUPPORTED_MSG,
-    );
+    const STATUS: Record<SerialSessionStatusType, [StatusType, string]> = {
+      [S.Idle]: ['info', 'シリアルポートから切断しました。'],
+      [S.Connecting]: ['info', '接続中です...'],
+      [S.Connected]: ['success', 'シリアルポートに接続しました。'],
+      [S.Disconnecting]: ['info', '切断中です...'],
+      [S.Unsupported]: ['error', supportStatus.statusMessage],
+      [S.Error]: ['error', 'エラーが発生しました。errors$ を確認してください。'],
+      [S.Disposed]: ['info', 'セッションは破棄されました。'],
+    };
 
     this.controller.state$.subscribe((state) => {
       const connected = state.status === S.Connected;
       const busy = state.status === S.Connecting || state.status === S.Disconnecting;
-      connectBtn.disabled = !supported || connected || busy;
+      connectBtn.disabled = !supportStatus.canConnect || connected || busy;
       baudRateSelect.disabled = connected || busy;
       disconnectBtn.disabled = !connected;
       sendInput.disabled = sendBtn.disabled = !connected;
@@ -124,7 +140,12 @@ export class App {
     });
 
     this.controller.errors$.subscribe((error) => {
-      setStatus(status, 'error', `エラー: ${error.message}`);
+      const display = formatExampleSerialError(error);
+      setStatus(
+        status,
+        display.type,
+        display.type === 'info' ? display.message : `エラー: ${display.message}`,
+      );
       console.error('Serial port error:', error);
     });
 

--- a/apps/example-vanilla-ts/src/styles.css
+++ b/apps/example-vanilla-ts/src/styles.css
@@ -93,6 +93,23 @@ main {
   padding-bottom: 8px;
 }
 
+.subsection-title {
+  font-size: 1.1rem;
+  margin: 20px 0 12px;
+  color: #2c3e50;
+}
+
+.requirements-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.requirements-list li + li {
+  margin-top: 0.5rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -97,6 +97,10 @@ describe('App', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSessions = [];
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
   });
 
   afterEach(() => {
@@ -111,10 +115,12 @@ describe('App', () => {
     );
   });
 
-  it('should display browser support status', () => {
+  it('should display requirements and browser support status', () => {
     const wrapper = mount(App);
+    expect(wrapper.text()).toContain('利用条件');
+    expect(wrapper.text()).toContain('HTTPS');
     expect(wrapper.text()).toContain(
-      'ブラウザは Web Serial API をサポートしています。',
+      'ブラウザは Web Serial API をサポートしており、セキュアコンテキストで実行中です。',
     );
   });
 
@@ -196,7 +202,12 @@ describe('App', () => {
     const wrapper = mount(App);
     const mock = latestMock();
 
-    mock.errorsSubject.next({ message: 'write failed' } as SerialError);
+    mock.errorsSubject.next(
+      new webSerialRxjs.SerialError(
+        webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+        'write failed',
+      ),
+    );
     await wrapper.vm.$nextTick();
 
     expect(wrapper.text()).toContain('エラー: write failed');

--- a/apps/example-vue/src/app/App.vue
+++ b/apps/example-vue/src/app/App.vue
@@ -1,5 +1,9 @@
 <script setup lang="ts">
-import { getExampleNavLinks } from '@gurezo/examples-shared';
+import {
+  getExampleNavLinks,
+  getExampleRequirementsCopy,
+  getExampleSupportStatus,
+} from '@gurezo/examples-shared';
 import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
 import { computed, ref } from 'vue';
 import { useSerialClient } from '../composables/useSerialClient';
@@ -7,17 +11,20 @@ import { useSerialClient } from '../composables/useSerialClient';
 type StatusType = 'info' | 'success' | 'error';
 
 const navLinks = getExampleNavLinks('vue');
+const requirements = getExampleRequirementsCopy();
+const supportStatus = getExampleSupportStatus();
 const externalLinkRel = 'noopener noreferrer';
 
 const baudRate = ref(9600);
 const sendInput = ref('');
 
 const {
-  browserSupported,
+  canConnect,
   state,
   isConnected,
   receivedData,
   errorMessage,
+  errorType,
   connect$,
   disconnect$,
   send$,
@@ -33,7 +40,13 @@ const disconnecting = computed(
 
 const status = computed<{ type: StatusType; message: string }>(() => {
   if (errorMessage.value) {
-    return { type: 'error', message: `エラー: ${errorMessage.value}` };
+    return {
+      type: errorType.value === 'info' ? 'info' : 'error',
+      message:
+        errorType.value === 'info'
+          ? errorMessage.value
+          : `エラー: ${errorMessage.value}`,
+    };
   }
   switch (state.value.status) {
     case SerialSessionStatus.Connecting:
@@ -45,8 +58,7 @@ const status = computed<{ type: StatusType; message: string }>(() => {
     case SerialSessionStatus.Unsupported:
       return {
         type: 'error',
-        message:
-          'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。',
+        message: supportStatus.statusMessage,
       };
     case SerialSessionStatus.Error:
       return { type: 'error', message: 'エラーが発生しました。' };
@@ -175,20 +187,15 @@ const handleKeyDown = (e: KeyboardEvent) => {
     </header>
 
     <main>
-      <!-- ブラウザサポート -->
+      <!-- 利用条件・ブラウザサポート -->
       <section class="section">
-        <h2>ブラウザサポート</h2>
-        <div
-          :class="[
-            'status-message',
-            browserSupported ? 'success' : 'error',
-          ]"
-        >
-          {{
-            browserSupported
-              ? 'ブラウザは Web Serial API をサポートしています。'
-              : 'このブラウザは Web Serial API をサポートしていません。Chrome、Edge、Opera などの Chromium ベースのブラウザをご使用ください。'
-          }}
+        <h2>{{ requirements.title }}</h2>
+        <ul class="requirements-list">
+          <li v-for="item in requirements.items" :key="item">{{ item }}</li>
+        </ul>
+        <h3 class="subsection-title">ブラウザサポート</h3>
+        <div :class="['status-message', supportStatus.statusType]">
+          {{ supportStatus.statusMessage }}
         </div>
       </section>
 
@@ -215,7 +222,7 @@ const handleKeyDown = (e: KeyboardEvent) => {
           <button
             class="btn btn-primary"
             @click="handleConnect"
-            :disabled="!browserSupported || isConnected || connecting"
+            :disabled="!canConnect || isConnected || connecting"
           >
             接続
           </button>

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -109,6 +109,10 @@ describe('useSerialClient', () => {
     vi.clearAllMocks();
     mockCores = [];
     nextSupported = true;
+    Object.defineProperty(window, 'isSecureContext', {
+      configurable: true,
+      value: true,
+    });
   });
 
   afterEach(() => {
@@ -128,10 +132,12 @@ describe('useSerialClient', () => {
   it('should initialize with default refs', () => {
     const { api } = mountHarness();
     expect(api.browserSupported.value).toBe(true);
+    expect(api.canConnect.value).toBe(true);
     expect(api.state.value).toEqual({ status: SS.Idle });
     expect(api.isConnected.value).toBe(false);
     expect(api.receivedData.value).toBe('');
     expect(api.errorMessage.value).toBe(null);
+    expect(api.errorType.value).toBe(null);
   });
 
   it('browserSupported reflects isWebSerialSupported when unsupported', () => {
@@ -155,11 +161,17 @@ describe('useSerialClient', () => {
     const { api } = mountHarness();
     const mock = latestMock();
 
-    mock.errorsSubject.next({ message: 'boom' } as SerialError);
+    mock.errorsSubject.next(
+      new webSerialRxjs.SerialError(
+        webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+        'boom',
+      ),
+    );
     expect(api.errorMessage.value).toBe('boom');
 
     mock.stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
     expect(api.errorMessage.value).toBe(null);
+    expect(api.errorType.value).toBe(null);
   });
 
   it('should connect through the session', () => {
@@ -219,8 +231,14 @@ describe('useSerialClient', () => {
     const { api } = mountHarness();
     const mock = latestMock();
 
-    mock.errorsSubject.next({ message: 'write failed' } as SerialError);
+    mock.errorsSubject.next(
+      new webSerialRxjs.SerialError(
+        webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+        'write failed',
+      ),
+    );
     expect(api.errorMessage.value).toBe('write failed');
+    expect(api.errorType.value).toBe('error');
   });
 
   it('should propagate connect$ errors to subscribers', () => {

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,20 +1,25 @@
 import {
-  isWebSerialSupported,
+  createSerialSessionController,
+  formatExampleSerialError,
+  getExampleSupportStatus,
+} from '@gurezo/examples-shared';
+import {
   SerialSessionStatus,
   type SerialError,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
-import { createSerialSessionController } from '@gurezo/examples-shared';
 import { type Observable } from 'rxjs';
 import { onUnmounted, ref, type Ref } from 'vue';
 
 /** v2 `SerialSession` を薄くラップ。表示は `terminalText$`（再接続時は世代でリセット）。 */
 export interface UseSerialClientReturn {
   browserSupported: Ref<boolean>;
+  canConnect: Ref<boolean>;
   state: Ref<SerialSessionState>;
   isConnected: Ref<boolean>;
   receivedData: Ref<string>;
   errorMessage: Ref<string | null>;
+  errorType: Ref<'info' | 'error' | null>;
   connect$: (baudRate?: number) => Observable<void>;
   disconnect$: () => Observable<void>;
   send$: (data: string | Uint8Array) => Observable<void>;
@@ -26,11 +31,19 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     initialBaudRate,
   });
 
-  const browserSupported = ref(isWebSerialSupported());
+  const supportStatus = getExampleSupportStatus();
+  const browserSupported = ref(supportStatus.apiSupported);
+  const canConnect = ref(supportStatus.canConnect);
   const state = ref<SerialSessionState>({ status: SerialSessionStatus.Idle });
   const isConnected = ref(false);
   const receivedData = ref('');
   const errorMessage = ref<string | null>(null);
+  const errorType = ref<'info' | 'error' | null>(null);
+
+  const clearError = () => {
+    errorMessage.value = null;
+    errorType.value = null;
+  };
 
   const stateSub = controller.state$.subscribe((next) => {
     state.value = next;
@@ -39,14 +52,16 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
       next.status === SerialSessionStatus.Connected ||
       next.status === SerialSessionStatus.Idle
     ) {
-      errorMessage.value = null;
+      clearError();
     }
   });
   const receiveSub = controller.terminalText$.subscribe((text) => {
     receivedData.value = text;
   });
   const errorsSub = controller.errors$.subscribe((error: SerialError) => {
-    errorMessage.value = error.message;
+    const display = formatExampleSerialError(error);
+    errorMessage.value = display.message;
+    errorType.value = display.type;
   });
 
   const connect$ = (baudRate?: number): Observable<void> => {
@@ -70,10 +85,12 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
 
   return {
     browserSupported,
+    canConnect,
     state,
     isConnected,
     receivedData,
     errorMessage,
+    errorType,
     connect$,
     disconnect$,
     send$,

--- a/apps/example-vue/src/styles.css
+++ b/apps/example-vue/src/styles.css
@@ -93,6 +93,23 @@ main {
   padding-bottom: 8px;
 }
 
+.subsection-title {
+  font-size: 1.1rem;
+  margin: 20px 0 12px;
+  color: #2c3e50;
+}
+
+.requirements-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #555;
+  font-size: 0.95rem;
+}
+
+.requirements-list li + li {
+  margin-top: 0.5rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/libs/examples-shared/src/example-requirements.spec.ts
+++ b/libs/examples-shared/src/example-requirements.spec.ts
@@ -1,0 +1,101 @@
+import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  formatExampleSerialError,
+  getExampleRequirementsCopy,
+  getExampleSupportStatus,
+} from './example-requirements';
+
+describe('getExampleRequirementsCopy', () => {
+  it('returns Japanese requirements title and items', () => {
+    const copy = getExampleRequirementsCopy();
+
+    expect(copy.title).toBe('利用条件');
+    expect(copy.items).toHaveLength(3);
+    expect(copy.items[0]).toContain('HTTPS');
+    expect(copy.items[1]).toContain('ユーザー操作');
+    expect(copy.items[2]).toContain('デスクトップ');
+  });
+});
+
+describe('getExampleSupportStatus', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reports canConnect when Web Serial and secure context are available', () => {
+    vi.stubGlobal('navigator', { serial: {} });
+    vi.stubGlobal('window', { isSecureContext: true });
+
+    const status = getExampleSupportStatus();
+
+    expect(status.apiSupported).toBe(true);
+    expect(status.secureContext).toBe(true);
+    expect(status.canConnect).toBe(true);
+    expect(status.unsupportedReason).toBe('none');
+    expect(status.statusType).toBe('success');
+    expect(status.statusMessage).toContain('サポート');
+  });
+
+  it('reports no-web-serial when navigator.serial is missing', () => {
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('window', { isSecureContext: true });
+
+    const status = getExampleSupportStatus();
+
+    expect(status.apiSupported).toBe(false);
+    expect(status.canConnect).toBe(false);
+    expect(status.unsupportedReason).toBe('no-web-serial');
+    expect(status.statusType).toBe('error');
+    expect(status.statusMessage).toContain('サポートしていません');
+    expect(status.statusMessage).toContain('Firefox');
+  });
+
+  it('reports insecure-context when isSecureContext is false', () => {
+    vi.stubGlobal('navigator', { serial: {} });
+    vi.stubGlobal('window', { isSecureContext: false });
+
+    const status = getExampleSupportStatus();
+
+    expect(status.apiSupported).toBe(true);
+    expect(status.secureContext).toBe(false);
+    expect(status.canConnect).toBe(false);
+    expect(status.unsupportedReason).toBe('insecure-context');
+    expect(status.statusMessage).toContain('セキュアコンテキスト');
+  });
+
+  it('reports both when API and secure context are unavailable', () => {
+    vi.stubGlobal('navigator', {});
+    vi.stubGlobal('window', { isSecureContext: false });
+
+    const status = getExampleSupportStatus();
+
+    expect(status.unsupportedReason).toBe('both');
+    expect(status.canConnect).toBe(false);
+    expect(status.statusMessage).toContain('HTTPS');
+  });
+});
+
+describe('formatExampleSerialError', () => {
+  it('maps OPERATION_CANCELLED to an info guidance message', () => {
+    const error = new SerialError(
+      SerialErrorCode.OPERATION_CANCELLED,
+      'Port selection was cancelled by the user',
+    );
+
+    expect(formatExampleSerialError(error)).toEqual({
+      type: 'info',
+      message:
+        'ポート選択がキャンセルされました。再度『接続』を押してポートを選んでください。',
+    });
+  });
+
+  it('keeps other errors as error tone with original message', () => {
+    const error = new SerialError(SerialErrorCode.WRITE_FAILED, 'write failed');
+
+    expect(formatExampleSerialError(error)).toEqual({
+      type: 'error',
+      message: 'write failed',
+    });
+  });
+});

--- a/libs/examples-shared/src/example-requirements.ts
+++ b/libs/examples-shared/src/example-requirements.ts
@@ -1,0 +1,122 @@
+import {
+  isWebSerialSupported,
+  SerialErrorCode,
+  type SerialError,
+} from '@gurezo/web-serial-rxjs';
+
+export interface ExampleRequirementsCopy {
+  title: string;
+  items: readonly string[];
+}
+
+export type ExampleUnsupportedReason =
+  | 'none'
+  | 'no-web-serial'
+  | 'insecure-context'
+  | 'both';
+
+export interface ExampleSupportStatus {
+  apiSupported: boolean;
+  secureContext: boolean;
+  canConnect: boolean;
+  unsupportedReason: ExampleUnsupportedReason;
+  statusMessage: string;
+  statusType: 'success' | 'error';
+}
+
+export interface ExampleErrorDisplay {
+  type: 'info' | 'error';
+  message: string;
+}
+
+const CANCEL_MESSAGE =
+  'ポート選択がキャンセルされました。再度『接続』を押してポートを選んでください。';
+
+const RECOMMENDED_BROWSERS =
+  'Chrome、Edge、Opera、Firefox などの対応ブラウザ（デスクトップ）をご使用ください。Safari およびモバイルブラウザは非対応です。';
+
+/**
+ * Static copy for the Example “利用条件” panel (Japanese UI).
+ */
+export function getExampleRequirementsCopy(): ExampleRequirementsCopy {
+  return {
+    title: '利用条件',
+    items: [
+      'ページは HTTPS または localhost（セキュアコンテキスト）で開いてください。',
+      '「接続」はユーザー操作（ボタンクリック）から実行してください。そうでないとポート選択ダイアログが開きません。',
+      'Web Serial はデスクトップブラウザのみ対応です（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）。実機のシリアルデバイス（または互換アダプタ）が必要です。',
+    ],
+  };
+}
+
+function resolveUnsupportedReason(
+  apiSupported: boolean,
+  secureContext: boolean,
+): ExampleUnsupportedReason {
+  if (apiSupported && secureContext) {
+    return 'none';
+  }
+  if (!apiSupported && !secureContext) {
+    return 'both';
+  }
+  if (!apiSupported) {
+    return 'no-web-serial';
+  }
+  return 'insecure-context';
+}
+
+function statusMessageFor(reason: ExampleUnsupportedReason): string {
+  switch (reason) {
+    case 'none':
+      return 'ブラウザは Web Serial API をサポートしており、セキュアコンテキストで実行中です。';
+    case 'no-web-serial':
+      return `このブラウザは Web Serial API をサポートしていません。${RECOMMENDED_BROWSERS}`;
+    case 'insecure-context':
+      return 'セキュアコンテキストではありません。HTTPS または localhost でページを開いてください。';
+    case 'both':
+      return `Web Serial を利用できません。セキュアコンテキスト（HTTPS / localhost）で、対応ブラウザを使用してください。${RECOMMENDED_BROWSERS}`;
+  }
+}
+
+/**
+ * Runtime support status for Example UIs (API + secure context).
+ */
+export function getExampleSupportStatus(): ExampleSupportStatus {
+  const apiSupported = isWebSerialSupported();
+  const secureContext =
+    typeof window !== 'undefined' && window.isSecureContext === true;
+  const unsupportedReason = resolveUnsupportedReason(
+    apiSupported,
+    secureContext,
+  );
+  const canConnect = unsupportedReason === 'none';
+
+  return {
+    apiSupported,
+    secureContext,
+    canConnect,
+    unsupportedReason,
+    statusMessage: statusMessageFor(unsupportedReason),
+    statusType: canConnect ? 'success' : 'error',
+  };
+}
+
+/**
+ * Maps a {@link SerialError} to Example status copy.
+ * Port-selection cancel is shown as info, not as a hard error.
+ */
+export function formatExampleSerialError(
+  error: SerialError,
+): ExampleErrorDisplay {
+  if (error.is(SerialErrorCode.OPERATION_CANCELLED)) {
+    return {
+      type: 'info',
+      message: CANCEL_MESSAGE,
+    };
+  }
+
+  return {
+    type: 'error',
+    message: error.message,
+  };
+}

--- a/libs/examples-shared/src/example-requirements.ts
+++ b/libs/examples-shared/src/example-requirements.ts
@@ -108,7 +108,12 @@ export function getExampleSupportStatus(): ExampleSupportStatus {
 export function formatExampleSerialError(
   error: SerialError,
 ): ExampleErrorDisplay {
-  if (error.is(SerialErrorCode.OPERATION_CANCELLED)) {
+  const isCancelled =
+    typeof error.is === 'function'
+      ? error.is(SerialErrorCode.OPERATION_CANCELLED)
+      : error.code === SerialErrorCode.OPERATION_CANCELLED;
+
+  if (isCancelled) {
     return {
       type: 'info',
       message: CANCEL_MESSAGE,

--- a/libs/examples-shared/src/index.ts
+++ b/libs/examples-shared/src/index.ts
@@ -10,3 +10,12 @@ export {
   type ExampleNavLinks,
   type ExampleSlug,
 } from './example-nav-links';
+export {
+  formatExampleSerialError,
+  getExampleRequirementsCopy,
+  getExampleSupportStatus,
+  type ExampleErrorDisplay,
+  type ExampleRequirementsCopy,
+  type ExampleSupportStatus,
+  type ExampleUnsupportedReason,
+} from './example-requirements';


### PR DESCRIPTION
## Summary
各 Example アプリ上に Web Serial の利用条件・ブラウザ対応・実機要件を表示し、非対応環境での誤操作を防げるようにしました（#520 / 親 #516）。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #520
- Parent: #516

## What changed?
- `examples-shared` に利用条件コピー・サポート判定（API + セキュアコンテキスト）・キャンセル文言整形ヘルパーを追加
- 6 つの Example（React / Angular / Vue / Svelte / Vanilla TS / Vanilla JS）に「利用条件」パネルと強化したブラウザサポート表示を配線
- 非対応または非セキュアコンテキストでは Connect を無効化
- ポート選択キャンセル（`OPERATION_CANCELLED`）を info 案内文言として表示

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `npx nx test examples-shared` および各 `example-*` のテストが通ることを確認
2. Chromium 系ブラウザで任意の Example を開き、「利用条件」と対応ステータスが表示されること
3. 非対応ブラウザ、または非 HTTPS（非 localhost）では Connect が無効になること
4. Connect 後にポート選択をキャンセルすると、エラーではなく案内メッセージになること

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / Firefox (desktop)
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): workspace main
- RxJS version: ^7.8.0

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)