### PR TITLE
feat(examples-shared): visualize serial session state on examples

### DIFF
--- a/apps/example-angular/src/app/app.html
+++ b/apps/example-angular/src/app/app.html
@@ -114,14 +114,14 @@
         <button
           class="btn btn-primary"
           (click)="handleConnect()"
-          [disabled]="!canConnect || isConnected() || connecting()"
+          [disabled]="!controls().connect"
         >
           接続
         </button>
         <button
           class="btn btn-secondary"
           (click)="handleDisconnect()"
-          [disabled]="!isConnected() || disconnecting()"
+          [disabled]="!controls().disconnect"
         >
           切断
         </button>
@@ -129,6 +129,60 @@
       <div class="status-message" [ngClass]="status().type">
         {{ status().message }}
       </div>
+      <h3 class="subsection-title">セッション状態</h3>
+      <dl class="session-state-list">
+        <div>
+          <dt>status</dt>
+          <dd data-testid="session-status">{{ sessionStatus().display }}</dd>
+        </div>
+        <div>
+          <dt>進行中</dt>
+          <dd data-testid="session-in-progress">
+            {{ sessionStatus().inProgress ? 'はい' : 'いいえ' }}
+          </dd>
+        </div>
+        @if (portInfoDisplay(); as portInfo) {
+          <div>
+            <dt>ポート情報</dt>
+            <dd data-testid="session-port-info">{{ portInfo.display }}</dd>
+          </div>
+        }
+      </dl>
+      <h3 class="subsection-title">最新エラー</h3>
+      @if (errorDetail(); as error) {
+        <dl class="session-state-list">
+          <div>
+            <dt>message</dt>
+            <dd data-testid="session-error-message">{{ error.message }}</dd>
+          </div>
+          <div>
+            <dt>code</dt>
+            <dd data-testid="session-error-code">{{ error.code }}</dd>
+          </div>
+          @if (error.contextSummary) {
+            <div>
+              <dt>context</dt>
+              <dd data-testid="session-error-context">
+                {{ error.contextSummary }}
+              </dd>
+            </div>
+          }
+        </dl>
+        <div class="button-group">
+          <button
+            type="button"
+            class="btn btn-outline"
+            (click)="clearError()"
+            data-testid="clear-error"
+          >
+            エラークリア
+          </button>
+        </div>
+      } @else {
+        <p class="session-empty" data-testid="session-error-empty">
+          エラーはありません。
+        </p>
+      }
     </section>
 
     <!-- データ送信 -->
@@ -143,13 +197,13 @@
             class="form-control"
             [(ngModel)]="sendInput"
             (keydown)="handleKeyDown($event)"
-            [disabled]="!isConnected()"
+            [disabled]="!controls().send"
             placeholder="送信するテキストを入力..."
           />
           <button
             class="btn btn-primary"
             (click)="handleSend()"
-            [disabled]="!isConnected() || !sendInput.trim()"
+            [disabled]="!controls().send || !sendInput.trim()"
           >
             送信
           </button>

--- a/apps/example-angular/src/app/app.scss
+++ b/apps/example-angular/src/app/app.scss
@@ -95,6 +95,39 @@ main {
   }
 }
 
+.session-state-list {
+  margin: 0 0 12px;
+  padding: 0;
+
+  > div {
+    display: grid;
+    grid-template-columns: 7rem 1fr;
+    gap: 8px 12px;
+    padding: 6px 0;
+    border-bottom: 1px solid #eee;
+    font-size: 0.95rem;
+  }
+
+  dt {
+    margin: 0;
+    font-weight: 600;
+    color: #555;
+  }
+
+  dd {
+    margin: 0;
+    font-family: 'Courier New', monospace;
+    color: #2c3e50;
+    word-break: break-word;
+  }
+}
+
+.session-empty {
+  margin: 0 0 12px;
+  color: #7f8c8d;
+  font-size: 0.95rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -1,16 +1,26 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject, linkedSignal } from '@angular/core';
+import {
+  Component,
+  computed,
+  effect,
+  inject,
+  linkedSignal,
+} from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import {
-  formatExampleSerialError,
+  formatExamplePortInfo,
+  formatExampleSerialErrorDetail,
+  formatExampleSessionStatus,
+  getExampleControlsEnabled,
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
-  type ExampleErrorDisplay,
+  type ExampleSerialErrorDetail,
 } from '@gurezo/examples-shared';
 import {
+  isConnectedSessionState,
   SerialSessionStatus,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
@@ -51,39 +61,38 @@ export class App {
     source: () => this.terminalText(),
     computation: (text) => text,
   });
-  private readonly lastErrorDisplay = toSignal(
+  private readonly lastErrorFromStream = toSignal(
     this.serialService.errors$.pipe(
       map(
-        (error): ExampleErrorDisplay | null => formatExampleSerialError(error),
+        (error): ExampleSerialErrorDetail =>
+          formatExampleSerialErrorDetail(error),
       ),
     ),
-    { initialValue: null as ExampleErrorDisplay | null },
+    { initialValue: null as ExampleSerialErrorDetail | null },
   );
 
-  readonly errorDisplay = computed(() => {
-    const status = this.state().status;
-    if (
-      status === SerialSessionStatus.Connected ||
-      status === SerialSessionStatus.Idle ||
-      status === SerialSessionStatus.Connecting
-    ) {
-      return null;
-    }
-    return this.lastErrorDisplay();
+  readonly errorDetail = linkedSignal({
+    source: () => this.lastErrorFromStream(),
+    computation: (detail) => detail,
   });
 
-  readonly connecting = computed(
-    () => this.state().status === SerialSessionStatus.Connecting,
+  readonly sessionStatus = computed(() =>
+    formatExampleSessionStatus(this.state()),
   );
-
-  readonly disconnecting = computed(
-    () => this.state().status === SerialSessionStatus.Disconnecting,
+  readonly controls = computed(() =>
+    getExampleControlsEnabled(this.state(), this.canConnect),
   );
+  readonly portInfoDisplay = computed(() => {
+    const current = this.state();
+    return isConnectedSessionState(current)
+      ? formatExamplePortInfo(current.portInfo)
+      : null;
+  });
 
   readonly hasReceivedData = computed(() => this.receivedData().length > 0);
 
   readonly status = computed((): { type: StatusType; message: string } => {
-    const error = this.errorDisplay();
+    const error = this.errorDetail();
     if (error) {
       return {
         type: error.type,
@@ -91,11 +100,14 @@ export class App {
           error.type === 'info' ? error.message : `エラー: ${error.message}`,
       };
     }
+    const session = this.sessionStatus();
+    if (session.inProgress) {
+      return {
+        type: 'info',
+        message: session.status === 'connecting' ? '接続中...' : '切断中...',
+      };
+    }
     switch (this.state().status) {
-      case SerialSessionStatus.Connecting:
-        return { type: 'info', message: '接続中...' };
-      case SerialSessionStatus.Disconnecting:
-        return { type: 'info', message: '切断中...' };
       case SerialSessionStatus.Connected:
         return { type: 'success', message: 'シリアルポートに接続しました。' };
       case SerialSessionStatus.Unsupported:
@@ -109,6 +121,22 @@ export class App {
         return { type: 'info', message: 'シリアルポートに接続していません。' };
     }
   });
+
+  constructor() {
+    effect(() => {
+      const status = this.state().status;
+      if (
+        status === SerialSessionStatus.Connected ||
+        status === SerialSessionStatus.Idle
+      ) {
+        this.errorDetail.set(null);
+      }
+    });
+  }
+
+  clearError(): void {
+    this.errorDetail.set(null);
+  }
 
   handleConnect(): void {
     this.resetTerminalView();

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -64,7 +64,7 @@ export class App {
   private readonly lastErrorFromStream = toSignal(
     this.serialService.errors$.pipe(
       map(
-        (error): ExampleSerialErrorDetail =>
+        (error): ExampleSerialErrorDetail | null =>
           formatExampleSerialErrorDetail(error),
       ),
     ),
@@ -72,8 +72,8 @@ export class App {
   );
 
   readonly errorDetail = linkedSignal({
-    source: () => this.lastErrorFromStream(),
-    computation: (detail) => detail,
+    source: (): ExampleSerialErrorDetail | null => this.lastErrorFromStream(),
+    computation: (detail: ExampleSerialErrorDetail | null) => detail,
   });
 
   readonly sessionStatus = computed(() =>

--- a/apps/example-react/src/App.test.tsx
+++ b/apps/example-react/src/App.test.tsx
@@ -226,7 +226,58 @@ describe('App', () => {
 
     await waitFor(() => {
       expect(screen.getByText('エラー: write failed')).toBeInTheDocument();
+      expect(screen.getByTestId('session-error-message')).toHaveTextContent(
+        'write failed',
+      );
+      expect(screen.getByTestId('session-error-code')).toHaveTextContent(
+        'WRITE_FAILED',
+      );
     });
+  });
+
+  it('セッション状態パネルに status と VID/PID を表示する', async () => {
+    render(<App />);
+
+    expect(screen.getByTestId('session-status')).toHaveTextContent(
+      'idle（アイドル）',
+    );
+    expect(screen.getByTestId('session-error-empty')).toBeInTheDocument();
+
+    act(() =>
+      latestMock().stateSubject.next({
+        status: SS.Connected,
+        portInfo: { usbVendorId: 0x2341, usbProductId: 0x0043 },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-status')).toHaveTextContent(
+        'connected（接続済み）',
+      );
+      expect(screen.getByTestId('session-port-info')).toHaveTextContent(
+        'Vendor ID: 0x2341 / Product ID: 0x0043',
+      );
+    });
+  });
+
+  it('エラークリアボタンで最新エラー表示を消せる', async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    act(() =>
+      latestMock().errorsSubject.next(
+        new webSerialRxjs.SerialError(
+          webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+          'write failed',
+        ),
+      ),
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('session-error-code')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('clear-error'));
+    expect(screen.getByTestId('session-error-empty')).toBeInTheDocument();
   });
 
   it('クリアボタンで受信データが空になる', async () => {

--- a/apps/example-react/src/App.tsx
+++ b/apps/example-react/src/App.tsx
@@ -1,9 +1,12 @@
 import {
+  formatExamplePortInfo,
+  formatExampleSessionStatus,
+  getExampleControlsEnabled,
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
 } from '@gurezo/examples-shared';
-import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
 import { useMemo, useState } from 'react';
 import { useSerialSession } from './hooks/useSerialSession';
 
@@ -27,14 +30,20 @@ export function App() {
     receivedData,
     errorMessage,
     errorType,
+    errorCode,
+    errorContext,
     connect$,
     disconnect$,
     send$,
     clearReceivedData,
+    clearError,
   } = useSerialSession(baudRate);
 
-  const connecting = state.status === SerialSessionStatus.Connecting;
-  const disconnecting = state.status === SerialSessionStatus.Disconnecting;
+  const sessionStatus = formatExampleSessionStatus(state);
+  const controls = getExampleControlsEnabled(state, canConnect);
+  const portInfoDisplay = isConnectedSessionState(state)
+    ? formatExamplePortInfo(state.portInfo)
+    : null;
 
   const status: { type: StatusType; message: string } = errorMessage
     ? {
@@ -42,13 +51,15 @@ export function App() {
         message:
           errorType === 'info' ? errorMessage : `エラー: ${errorMessage}`,
       }
-    : connecting
-      ? { type: 'info', message: '接続中...' }
-      : disconnecting
-        ? { type: 'info', message: '切断中...' }
-        : isConnected
-          ? { type: 'success', message: 'シリアルポートに接続しました。' }
-          : { type: 'info', message: 'シリアルポートに接続していません。' };
+    : sessionStatus.inProgress
+      ? {
+          type: 'info',
+          message:
+            sessionStatus.status === 'connecting' ? '接続中...' : '切断中...',
+        }
+      : isConnected
+        ? { type: 'success', message: 'シリアルポートに接続しました。' }
+        : { type: 'info', message: 'シリアルポートに接続していません。' };
 
   const handleConnect = () => {
     clearReceivedData();
@@ -167,19 +178,73 @@ export function App() {
             <button
               className="btn btn-primary"
               onClick={handleConnect}
-              disabled={!canConnect || isConnected || connecting}
+              disabled={!controls.connect}
             >
               接続
             </button>
             <button
               className="btn btn-secondary"
               onClick={handleDisconnect}
-              disabled={!isConnected || disconnecting}
+              disabled={!controls.disconnect}
             >
               切断
             </button>
           </div>
           <div className={`status-message ${status.type}`}>{status.message}</div>
+          <h3 className="subsection-title">セッション状態</h3>
+          <dl className="session-state-list">
+            <div>
+              <dt>status</dt>
+              <dd data-testid="session-status">{sessionStatus.display}</dd>
+            </div>
+            <div>
+              <dt>進行中</dt>
+              <dd data-testid="session-in-progress">
+                {sessionStatus.inProgress ? 'はい' : 'いいえ'}
+              </dd>
+            </div>
+            {portInfoDisplay ? (
+              <div>
+                <dt>ポート情報</dt>
+                <dd data-testid="session-port-info">{portInfoDisplay.display}</dd>
+              </div>
+            ) : null}
+          </dl>
+          <h3 className="subsection-title">最新エラー</h3>
+          {errorMessage ? (
+            <>
+              <dl className="session-state-list">
+                <div>
+                  <dt>message</dt>
+                  <dd data-testid="session-error-message">{errorMessage}</dd>
+                </div>
+                <div>
+                  <dt>code</dt>
+                  <dd data-testid="session-error-code">{errorCode}</dd>
+                </div>
+                {errorContext ? (
+                  <div>
+                    <dt>context</dt>
+                    <dd data-testid="session-error-context">{errorContext}</dd>
+                  </div>
+                ) : null}
+              </dl>
+              <div className="button-group">
+                <button
+                  type="button"
+                  className="btn btn-outline"
+                  onClick={clearError}
+                  data-testid="clear-error"
+                >
+                  エラークリア
+                </button>
+              </div>
+            </>
+          ) : (
+            <p className="session-empty" data-testid="session-error-empty">
+              エラーはありません。
+            </p>
+          )}
         </section>
         <section className="section">
           <h2>データ送信</h2>
@@ -193,13 +258,13 @@ export function App() {
                 value={sendInput}
                 onChange={(e) => setSendInput(e.target.value)}
                 onKeyDown={handleKeyDown}
-                disabled={!isConnected}
+                disabled={!controls.send}
                 placeholder="送信するテキストを入力..."
               />
               <button
                 className="btn btn-primary"
                 onClick={handleSend}
-                disabled={!isConnected || !sendInput.trim()}
+                disabled={!controls.send || !sendInput.trim()}
               >
                 送信
               </button>

--- a/apps/example-react/src/hooks/useSerialSession.test.ts
+++ b/apps/example-react/src/hooks/useSerialSession.test.ts
@@ -142,7 +142,7 @@ describe('useSerialSession', () => {
     expect(result.current.receivedData).toBe('foobar');
   });
 
-  it('errors$ の値が errorMessage に反映される', () => {
+  it('errors$ の値が errorMessage / errorCode に反映される', () => {
     const { result } = renderHook(() => useSerialSession());
     act(() =>
       latestMock().errorsSubject.next(
@@ -151,6 +151,7 @@ describe('useSerialSession', () => {
     );
     expect(result.current.errorMessage).toBe('boom');
     expect(result.current.errorType).toBe('error');
+    expect(result.current.errorCode).toBe(SerialErrorCode.WRITE_FAILED);
   });
 
   it('OPERATION_CANCELLED は info 案内文言に整形される', () => {
@@ -165,6 +166,7 @@ describe('useSerialSession', () => {
     );
     expect(result.current.errorType).toBe('info');
     expect(result.current.errorMessage).toContain('キャンセル');
+    expect(result.current.errorCode).toBe(SerialErrorCode.OPERATION_CANCELLED);
   });
 
   it('state$ が connected / idle になると errorMessage がクリアされる', () => {
@@ -178,6 +180,21 @@ describe('useSerialSession', () => {
     act(() => latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } }));
     expect(result.current.errorMessage).toBeNull();
     expect(result.current.errorType).toBeNull();
+    expect(result.current.errorCode).toBeNull();
+  });
+
+  it('clearError でエラー表示を手動クリアできる', () => {
+    const { result } = renderHook(() => useSerialSession());
+    act(() =>
+      latestMock().errorsSubject.next(
+        new SerialError(SerialErrorCode.WRITE_FAILED, 'boom'),
+      ),
+    );
+    expect(result.current.errorMessage).toBe('boom');
+    act(() => result.current.clearError());
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.errorCode).toBeNull();
+    expect(result.current.errorContext).toBeNull();
   });
 
   it('clearReceivedData で receivedData が空になる', () => {

--- a/apps/example-react/src/hooks/useSerialSession.ts
+++ b/apps/example-react/src/hooks/useSerialSession.ts
@@ -1,6 +1,6 @@
 import {
   createSerialSessionController,
-  formatExampleSerialError,
+  formatExampleSerialErrorDetail,
   getExampleSupportStatus,
   type SerialSessionController,
 } from '@gurezo/examples-shared';
@@ -21,10 +21,13 @@ export interface UseSerialSessionReturn {
   receivedData: string;
   errorMessage: string | null;
   errorType: 'info' | 'error' | null;
+  errorCode: string | null;
+  errorContext: string | null;
   connect$: (baudRate?: number) => Observable<void>;
   disconnect$: () => Observable<void>;
   send$: (data: string | Uint8Array) => Observable<void>;
   clearReceivedData: () => void;
+  clearError: () => void;
 }
 
 export function useSerialSession(
@@ -52,10 +55,14 @@ export function useSerialSession(
   const [receivedData, setReceivedData] = useState('');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [errorType, setErrorType] = useState<'info' | 'error' | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+  const [errorContext, setErrorContext] = useState<string | null>(null);
 
   const clearError = () => {
     setErrorMessage(null);
     setErrorType(null);
+    setErrorCode(null);
+    setErrorContext(null);
   };
 
   useEffect(() => {
@@ -77,9 +84,11 @@ export function useSerialSession(
     sub.add(controller.terminalText$.subscribe(setReceivedData));
     sub.add(
       controller.errors$.subscribe((e: SerialError) => {
-        const display = formatExampleSerialError(e);
+        const display = formatExampleSerialErrorDetail(e);
         setErrorMessage(display.message);
         setErrorType(display.type);
+        setErrorCode(display.code);
+        setErrorContext(display.contextSummary);
       }),
     );
     return () => {
@@ -110,9 +119,12 @@ export function useSerialSession(
     receivedData,
     errorMessage,
     errorType,
+    errorCode,
+    errorContext,
     connect$,
     disconnect$,
     send$,
     clearReceivedData,
+    clearError,
   };
 }

--- a/apps/example-react/src/styles.css
+++ b/apps/example-react/src/styles.css
@@ -110,6 +110,39 @@ main {
   margin-top: 0.5rem;
 }
 
+.session-state-list {
+  margin: 0 0 12px;
+  padding: 0;
+}
+
+.session-state-list > div {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 8px 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.95rem;
+}
+
+.session-state-list dt {
+  margin: 0;
+  font-weight: 600;
+  color: #555;
+}
+
+.session-state-list dd {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  color: #2c3e50;
+  word-break: break-word;
+}
+
+.session-empty {
+  margin: 0 0 12px;
+  color: #7f8c8d;
+  font-size: 0.95rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-svelte/src/App.svelte
+++ b/apps/example-svelte/src/App.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import {
+    formatExamplePortInfo,
+    formatExampleSessionStatus,
+    getExampleControlsEnabled,
     getExampleNavLinks,
     getExampleRequirementsCopy,
     getExampleSupportStatus,
   } from '@gurezo/examples-shared';
   import {
-    SerialSessionStatus,
+    isConnectedSessionState,
     type SerialSessionState,
   } from '@gurezo/web-serial-rxjs';
   import { useSerialSession } from './stores/useSerialSession';
@@ -25,10 +28,13 @@
     receivedData,
     errorMessage,
     errorType,
+    errorCode,
+    errorContext,
     connect$,
     disconnect$,
     send$,
     clearReceivedData,
+    clearError,
   } = useSerialSession(baudRate);
 
   type StatusType = 'info' | 'success' | 'error';
@@ -44,28 +50,34 @@
         message: tone === 'info' ? error : `エラー: ${error}`,
       };
     }
-    switch (current.status) {
-      case SerialSessionStatus.Connecting:
-        return { type: 'info', message: '接続中...' };
-      case SerialSessionStatus.Disconnecting:
-        return { type: 'info', message: '切断中...' };
-      case SerialSessionStatus.Connected:
-        return { type: 'success', message: 'シリアルポートに接続しました。' };
-      case SerialSessionStatus.Unsupported:
-        return {
-          type: 'error',
-          message: supportStatus.statusMessage,
-        };
-      case SerialSessionStatus.Error:
-        return { type: 'error', message: 'エラーが発生しました。' };
-      default:
-        return { type: 'info', message: 'シリアルポートに接続していません。' };
+    const session = formatExampleSessionStatus(current);
+    if (session.inProgress) {
+      return {
+        type: 'info',
+        message: session.status === 'connecting' ? '接続中...' : '切断中...',
+      };
     }
+    if (isConnectedSessionState(current)) {
+      return { type: 'success', message: 'シリアルポートに接続しました。' };
+    }
+    if (current.status === 'unsupported') {
+      return {
+        type: 'error',
+        message: supportStatus.statusMessage,
+      };
+    }
+    if (current.status === 'error') {
+      return { type: 'error', message: 'エラーが発生しました。' };
+    }
+    return { type: 'info', message: 'シリアルポートに接続していません。' };
   };
 
   $: status = statusFor($state, $errorMessage, $errorType);
-  $: connecting = $state.status === SerialSessionStatus.Connecting;
-  $: disconnecting = $state.status === SerialSessionStatus.Disconnecting;
+  $: sessionStatus = formatExampleSessionStatus($state);
+  $: controls = getExampleControlsEnabled($state, $canConnect);
+  $: portInfoDisplay = isConnectedSessionState($state)
+    ? formatExamplePortInfo($state.portInfo)
+    : null;
 
   const handleConnect = () => {
     clearReceivedData();
@@ -216,14 +228,14 @@
         <button
           class="btn btn-primary"
           on:click={handleConnect}
-          disabled={!$canConnect || $isConnected || connecting}
+          disabled={!controls.connect}
         >
           接続
         </button>
         <button
           class="btn btn-secondary"
           on:click={handleDisconnect}
-          disabled={!$isConnected || disconnecting}
+          disabled={!controls.disconnect}
         >
           切断
         </button>
@@ -231,6 +243,58 @@
       <div class="status-message {status.type}">
         {status.message}
       </div>
+      <h3 class="subsection-title">セッション状態</h3>
+      <dl class="session-state-list">
+        <div>
+          <dt>status</dt>
+          <dd data-testid="session-status">{sessionStatus.display}</dd>
+        </div>
+        <div>
+          <dt>進行中</dt>
+          <dd data-testid="session-in-progress"
+            >{sessionStatus.inProgress ? 'はい' : 'いいえ'}</dd
+          >
+        </div>
+        {#if portInfoDisplay}
+          <div>
+            <dt>ポート情報</dt>
+            <dd data-testid="session-port-info">{portInfoDisplay.display}</dd>
+          </div>
+        {/if}
+      </dl>
+      <h3 class="subsection-title">最新エラー</h3>
+      {#if $errorMessage}
+        <dl class="session-state-list">
+          <div>
+            <dt>message</dt>
+            <dd data-testid="session-error-message">{$errorMessage}</dd>
+          </div>
+          <div>
+            <dt>code</dt>
+            <dd data-testid="session-error-code">{$errorCode}</dd>
+          </div>
+          {#if $errorContext}
+            <div>
+              <dt>context</dt>
+              <dd data-testid="session-error-context">{$errorContext}</dd>
+            </div>
+          {/if}
+        </dl>
+        <div class="button-group">
+          <button
+            type="button"
+            class="btn btn-outline"
+            data-testid="clear-error"
+            on:click={clearError}
+          >
+            エラークリア
+          </button>
+        </div>
+      {:else}
+        <p class="session-empty" data-testid="session-error-empty">
+          エラーはありません。
+        </p>
+      {/if}
     </section>
 
     <!-- データ送信 -->
@@ -245,13 +309,13 @@
             class="form-control"
             bind:value={sendInput}
             on:keydown={handleKeyDown}
-            disabled={!$isConnected}
+            disabled={!controls.send}
             placeholder="送信するテキストを入力..."
           />
           <button
             class="btn btn-primary"
             on:click={handleSend}
-            disabled={!$isConnected || !sendInput.trim()}
+            disabled={!controls.send || !sendInput.trim()}
           >
             送信
           </button>

--- a/apps/example-svelte/src/stores/useSerialSession.test.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.test.ts
@@ -161,7 +161,7 @@ describe('useSerialSession', () => {
     unsub();
   });
 
-  it('errors$ の値が errorMessage に反映される', () => {
+  it('errors$ の値が errorMessage / errorCode に反映される', () => {
     const s = useSerialSession();
     const unsub = s.errorMessage.subscribe(() => void 0);
     latestMock().errorsSubject.next(
@@ -172,6 +172,7 @@ describe('useSerialSession', () => {
     );
     expect(get(s.errorMessage)).toBe('boom');
     expect(get(s.errorType)).toBe('error');
+    expect(get(s.errorCode)).toBe(webSerialRxjs.SerialErrorCode.WRITE_FAILED);
     unsub();
   });
 
@@ -188,6 +189,23 @@ describe('useSerialSession', () => {
     latestMock().stateSubject.next({ status: SS.Connected, portInfo: { usbVendorId: 0, usbProductId: 0 } });
     expect(get(s.errorMessage)).toBeNull();
     expect(get(s.errorType)).toBeNull();
+    expect(get(s.errorCode)).toBeNull();
+    unsub();
+  });
+
+  it('clearError でエラー表示を手動クリアできる', () => {
+    const s = useSerialSession();
+    const unsub = s.errorMessage.subscribe(() => void 0);
+    latestMock().errorsSubject.next(
+      new webSerialRxjs.SerialError(
+        webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+        'boom',
+      ),
+    );
+    s.clearError();
+    expect(get(s.errorMessage)).toBeNull();
+    expect(get(s.errorCode)).toBeNull();
+    expect(get(s.errorContext)).toBeNull();
     unsub();
   });
 

--- a/apps/example-svelte/src/stores/useSerialSession.ts
+++ b/apps/example-svelte/src/stores/useSerialSession.ts
@@ -1,6 +1,6 @@
 import {
   createSerialSessionController,
-  formatExampleSerialError,
+  formatExampleSerialErrorDetail,
   getExampleSupportStatus,
 } from '@gurezo/examples-shared';
 import {
@@ -21,10 +21,13 @@ export interface UseSerialSessionReturn {
   receivedData: Readable<string>;
   errorMessage: Readable<string | null>;
   errorType: Readable<'info' | 'error' | null>;
+  errorCode: Readable<string | null>;
+  errorContext: Readable<string | null>;
   connect$: (baudRate?: number) => Observable<void>;
   disconnect$: () => Observable<void>;
   send$: (data: string | Uint8Array) => Observable<void>;
   clearReceivedData: () => void;
+  clearError: () => void;
 }
 
 export function useSerialSession(
@@ -58,13 +61,24 @@ export function useSerialSession(
 
   const errorMessage = writable<string | null>(null);
   const errorType = writable<'info' | 'error' | null>(null);
+  const errorCode = writable<string | null>(null);
+  const errorContext = writable<string | null>(null);
+
+  const clearError = (): void => {
+    errorMessage.set(null);
+    errorType.set(null);
+    errorCode.set(null);
+    errorContext.set(null);
+  };
 
   const errorSub = new Subscription();
   errorSub.add(
     controller.errors$.subscribe((e: SerialError) => {
-      const display = formatExampleSerialError(e);
+      const display = formatExampleSerialErrorDetail(e);
       errorMessage.set(display.message);
       errorType.set(display.type);
+      errorCode.set(display.code);
+      errorContext.set(display.contextSummary);
     }),
   );
   errorSub.add(
@@ -73,8 +87,7 @@ export function useSerialSession(
         next.status === SerialSessionStatus.Connected ||
         next.status === SerialSessionStatus.Idle
       ) {
-        errorMessage.set(null);
-        errorType.set(null);
+        clearError();
       }
     }),
   );
@@ -108,9 +121,12 @@ export function useSerialSession(
     receivedData,
     errorMessage,
     errorType,
+    errorCode,
+    errorContext,
     connect$,
     disconnect$,
     send$,
     clearReceivedData,
+    clearError,
   };
 }

--- a/apps/example-svelte/src/styles.css
+++ b/apps/example-svelte/src/styles.css
@@ -110,6 +110,39 @@ main {
   margin-top: 0.5rem;
 }
 
+.session-state-list {
+  margin: 0 0 12px;
+  padding: 0;
+}
+
+.session-state-list > div {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 8px 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.95rem;
+}
+
+.session-state-list dt {
+  margin: 0;
+  font-weight: 600;
+  color: #555;
+}
+
+.session-state-list dd {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  color: #2c3e50;
+  word-break: break-word;
+}
+
+.session-empty {
+  margin: 0 0 12px;
+  color: #7f8c8d;
+  font-size: 0.95rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-vanilla-js/index.html
+++ b/apps/example-vanilla-js/index.html
@@ -34,6 +34,66 @@
             </button>
           </div>
           <div id="connection-status" class="status-message"></div>
+          <h3 class="subsection-title">セッション状態</h3>
+          <dl class="session-state-list">
+            <div>
+              <dt>status</dt>
+              <dd id="session-status" data-testid="session-status"></dd>
+            </div>
+            <div>
+              <dt>進行中</dt>
+              <dd
+                id="session-in-progress"
+                data-testid="session-in-progress"
+              ></dd>
+            </div>
+            <div id="session-port-info-row" hidden>
+              <dt>ポート情報</dt>
+              <dd id="session-port-info" data-testid="session-port-info"></dd>
+            </div>
+          </dl>
+          <h3 class="subsection-title">最新エラー</h3>
+          <dl id="session-error-panel" class="session-state-list" hidden>
+            <div>
+              <dt>message</dt>
+              <dd
+                id="session-error-message"
+                data-testid="session-error-message"
+              ></dd>
+            </div>
+            <div>
+              <dt>code</dt>
+              <dd
+                id="session-error-code"
+                data-testid="session-error-code"
+              ></dd>
+            </div>
+            <div id="session-error-context-row" hidden>
+              <dt>context</dt>
+              <dd
+                id="session-error-context"
+                data-testid="session-error-context"
+              ></dd>
+            </div>
+          </dl>
+          <p
+            id="session-error-empty"
+            class="session-empty"
+            data-testid="session-error-empty"
+          >
+            エラーはありません。
+          </p>
+          <div class="button-group">
+            <button
+              type="button"
+              id="clear-error-btn"
+              class="btn btn-outline"
+              data-testid="clear-error"
+              hidden
+            >
+              エラークリア
+            </button>
+          </div>
         </section>
 
         <!-- Configuration Section -->

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,11 +1,17 @@
 import {
   createSerialSessionController,
-  formatExampleSerialError,
+  formatExamplePortInfo,
+  formatExampleSerialErrorDetail,
+  formatExampleSessionStatus,
+  getExampleControlsEnabled,
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
 } from '@gurezo/examples-shared';
-import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import {
+  isConnectedSessionState,
+  SerialSessionStatus,
+} from '@gurezo/web-serial-rxjs';
 import { fromEvent } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -100,7 +106,20 @@ export class App {
     const sendInput = $('send-input');
     const sendBtn = $('send-btn');
     const receiveOutput = $('receive-output');
+    const sessionStatusEl = $('session-status');
+    const sessionInProgressEl = $('session-in-progress');
+    const portInfoRow = $('session-port-info-row');
+    const portInfoEl = $('session-port-info');
+    const errorPanel = $('session-error-panel');
+    const errorEmpty = $('session-error-empty');
+    const errorMessageEl = $('session-error-message');
+    const errorCodeEl = $('session-error-code');
+    const errorContextRow = $('session-error-context-row');
+    const errorContextEl = $('session-error-context');
+    const clearErrorBtn = $('clear-error-btn');
     this.controller = createSerialSessionController({ initialBaudRate: 9600 });
+    this.latestError = null;
+    let lastState = { status: SerialSessionStatus.Idle };
 
     const STATUS = {
       idle: ['info', 'シリアルポートから切断しました。'],
@@ -112,16 +131,71 @@ export class App {
       disposed: ['info', 'セッションは破棄されました。'],
     };
 
-    this.controller.state$.subscribe((state) => {
-      const connected = state.status === SerialSessionStatus.Connected;
-      const busy =
+    const renderErrorPanel = () => {
+      if (!this.latestError) {
+        errorPanel.hidden = true;
+        errorEmpty.hidden = false;
+        clearErrorBtn.hidden = true;
+        return;
+      }
+      errorPanel.hidden = false;
+      errorEmpty.hidden = true;
+      clearErrorBtn.hidden = false;
+      errorMessageEl.textContent = this.latestError.message;
+      errorCodeEl.textContent = this.latestError.code;
+      if (this.latestError.contextSummary) {
+        errorContextRow.hidden = false;
+        errorContextEl.textContent = this.latestError.contextSummary;
+      } else {
+        errorContextRow.hidden = true;
+        errorContextEl.textContent = '';
+      }
+    };
+
+    const clearError = () => {
+      this.latestError = null;
+      renderErrorPanel();
+      setStatus(status, ...STATUS[lastState.status]);
+    };
+
+    const renderSessionState = (state) => {
+      const session = formatExampleSessionStatus(state);
+      sessionStatusEl.textContent = session.display;
+      sessionInProgressEl.textContent = session.inProgress ? 'はい' : 'いいえ';
+      if (isConnectedSessionState(state)) {
+        portInfoRow.hidden = false;
+        portInfoEl.textContent = formatExamplePortInfo(state.portInfo).display;
+      } else {
+        portInfoRow.hidden = true;
+        portInfoEl.textContent = '';
+      }
+    };
+
+    const applyControls = (state) => {
+      const controls = getExampleControlsEnabled(state, supportStatus.canConnect);
+      connectBtn.disabled = !controls.connect;
+      disconnectBtn.disabled = !controls.disconnect;
+      sendInput.disabled = sendBtn.disabled = !controls.send;
+      baudRateSelect.disabled =
+        state.status === SerialSessionStatus.Connected ||
         state.status === SerialSessionStatus.Connecting ||
         state.status === SerialSessionStatus.Disconnecting;
-      connectBtn.disabled = !supportStatus.canConnect || connected || busy;
-      baudRateSelect.disabled = connected || busy;
-      disconnectBtn.disabled = !connected;
-      sendInput.disabled = sendBtn.disabled = !connected;
-      setStatus(status, ...STATUS[state.status]);
+    };
+
+    this.controller.state$.subscribe((state) => {
+      lastState = state;
+      applyControls(state);
+      renderSessionState(state);
+      if (
+        state.status === SerialSessionStatus.Connected ||
+        state.status === SerialSessionStatus.Idle
+      ) {
+        this.latestError = null;
+        renderErrorPanel();
+      }
+      if (!this.latestError) {
+        setStatus(status, ...STATUS[state.status]);
+      }
     });
 
     this.controller.terminalText$.subscribe((text) => {
@@ -130,7 +204,9 @@ export class App {
     });
 
     this.controller.errors$.subscribe((error) => {
-      const display = formatExampleSerialError(error);
+      const display = formatExampleSerialErrorDetail(error);
+      this.latestError = display;
+      renderErrorPanel();
       setStatus(
         status,
         display.type,
@@ -138,6 +214,8 @@ export class App {
       );
       console.error('Serial port error:', error);
     });
+
+    fromEvent(clearErrorBtn, 'click').subscribe(() => clearError());
 
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
@@ -170,5 +248,7 @@ export class App {
       this.controller.resetTerminalBuffer();
       receiveOutput.value = '';
     });
+
+    renderErrorPanel();
   }
 }

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -53,6 +53,20 @@ describe('App', () => {
       <button id="connect-btn"></button>
       <button id="disconnect-btn"></button>
       <div id="connection-status"></div>
+      <dd id="session-status"></dd>
+      <dd id="session-in-progress"></dd>
+      <div id="session-port-info-row" hidden>
+        <dd id="session-port-info"></dd>
+      </div>
+      <dl id="session-error-panel" hidden>
+        <dd id="session-error-message"></dd>
+        <dd id="session-error-code"></dd>
+        <div id="session-error-context-row" hidden>
+          <dd id="session-error-context"></dd>
+        </div>
+      </dl>
+      <p id="session-error-empty"></p>
+      <button id="clear-error-btn" hidden></button>
       <select id="baud-rate">
         <option value="9600">9600</option>
         <option value="115200" selected>115200</option>
@@ -120,5 +134,13 @@ describe('App', () => {
     expect(webSerialRxjs.createSerialSession).toHaveBeenLastCalledWith({
       baudRate: 115200,
     });
+  });
+
+  it('should render session status panel', () => {
+    app = new App();
+    expect(document.getElementById('session-status').textContent).toContain(
+      'idle',
+    );
+    expect(document.getElementById('session-error-empty').hidden).toBe(false);
   });
 });

--- a/apps/example-vanilla-js/src/styles.css
+++ b/apps/example-vanilla-js/src/styles.css
@@ -110,6 +110,39 @@ main {
   margin-top: 0.5rem;
 }
 
+.session-state-list {
+  margin: 0 0 12px;
+  padding: 0;
+}
+
+.session-state-list > div {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 8px 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.95rem;
+}
+
+.session-state-list dt {
+  margin: 0;
+  font-weight: 600;
+  color: #555;
+}
+
+.session-state-list dd {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  color: #2c3e50;
+  word-break: break-word;
+}
+
+.session-empty {
+  margin: 0 0 12px;
+  color: #7f8c8d;
+  font-size: 0.95rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-vanilla-ts/index.html
+++ b/apps/example-vanilla-ts/index.html
@@ -34,6 +34,66 @@
             </button>
           </div>
           <div id="connection-status" class="status-message"></div>
+          <h3 class="subsection-title">セッション状態</h3>
+          <dl class="session-state-list">
+            <div>
+              <dt>status</dt>
+              <dd id="session-status" data-testid="session-status"></dd>
+            </div>
+            <div>
+              <dt>進行中</dt>
+              <dd
+                id="session-in-progress"
+                data-testid="session-in-progress"
+              ></dd>
+            </div>
+            <div id="session-port-info-row" hidden>
+              <dt>ポート情報</dt>
+              <dd id="session-port-info" data-testid="session-port-info"></dd>
+            </div>
+          </dl>
+          <h3 class="subsection-title">最新エラー</h3>
+          <dl id="session-error-panel" class="session-state-list" hidden>
+            <div>
+              <dt>message</dt>
+              <dd
+                id="session-error-message"
+                data-testid="session-error-message"
+              ></dd>
+            </div>
+            <div>
+              <dt>code</dt>
+              <dd
+                id="session-error-code"
+                data-testid="session-error-code"
+              ></dd>
+            </div>
+            <div id="session-error-context-row" hidden>
+              <dt>context</dt>
+              <dd
+                id="session-error-context"
+                data-testid="session-error-context"
+              ></dd>
+            </div>
+          </dl>
+          <p
+            id="session-error-empty"
+            class="session-empty"
+            data-testid="session-error-empty"
+          >
+            エラーはありません。
+          </p>
+          <div class="button-group">
+            <button
+              type="button"
+              id="clear-error-btn"
+              class="btn btn-outline"
+              data-testid="clear-error"
+              hidden
+            >
+              エラークリア
+            </button>
+          </div>
         </section>
 
         <!-- Configuration Section -->

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -66,6 +66,20 @@ describe('App', () => {
       <button id="connect-btn"></button>
       <button id="disconnect-btn"></button>
       <div id="connection-status"></div>
+      <dd id="session-status"></dd>
+      <dd id="session-in-progress"></dd>
+      <div id="session-port-info-row" hidden>
+        <dd id="session-port-info"></dd>
+      </div>
+      <dl id="session-error-panel" hidden>
+        <dd id="session-error-message"></dd>
+        <dd id="session-error-code"></dd>
+        <div id="session-error-context-row" hidden>
+          <dd id="session-error-context"></dd>
+        </div>
+      </dl>
+      <p id="session-error-empty"></p>
+      <button id="clear-error-btn" hidden></button>
       <select id="baud-rate">
         <option value="9600">9600</option>
         <option value="115200" selected>115200</option>
@@ -133,5 +147,15 @@ describe('App', () => {
     expect(webSerialRxjs.createSerialSession).toHaveBeenLastCalledWith({
       baudRate: 115200,
     });
+  });
+
+  it('should render session status panel', () => {
+    app = new App();
+    expect(document.getElementById('session-status')?.textContent).toContain(
+      'idle',
+    );
+    expect(
+      document.getElementById('session-error-empty')?.hidden,
+    ).toBe(false);
   });
 });

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,14 +1,20 @@
 import {
   createSerialSessionController,
-  formatExampleSerialError,
+  formatExamplePortInfo,
+  formatExampleSerialErrorDetail,
+  formatExampleSessionStatus,
+  getExampleControlsEnabled,
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
   type ExampleNavLink,
   type ExampleSlug,
+  type ExampleSerialErrorDetail,
 } from '@gurezo/examples-shared';
 import {
+  isConnectedSessionState,
   SerialSessionStatus,
+  type SerialSessionState,
   type SerialSessionStatus as SerialSessionStatusType,
 } from '@gurezo/web-serial-rxjs';
 import { fromEvent } from 'rxjs';
@@ -102,6 +108,8 @@ export class App {
     initialBaudRate: 9600,
   });
 
+  private latestError: ExampleSerialErrorDetail | null = null;
+
   constructor() {
     mountExampleNav('vanilla-ts');
     const supportStatus = mountRequirements();
@@ -113,6 +121,17 @@ export class App {
     const sendInput = $<HTMLInputElement>('send-input');
     const sendBtn = $<HTMLButtonElement>('send-btn');
     const receiveOutput = $<HTMLTextAreaElement>('receive-output');
+    const sessionStatusEl = $<HTMLElement>('session-status');
+    const sessionInProgressEl = $<HTMLElement>('session-in-progress');
+    const portInfoRow = $<HTMLElement>('session-port-info-row');
+    const portInfoEl = $<HTMLElement>('session-port-info');
+    const errorPanel = $<HTMLElement>('session-error-panel');
+    const errorEmpty = $<HTMLElement>('session-error-empty');
+    const errorMessageEl = $<HTMLElement>('session-error-message');
+    const errorCodeEl = $<HTMLElement>('session-error-code');
+    const errorContextRow = $<HTMLElement>('session-error-context-row');
+    const errorContextEl = $<HTMLElement>('session-error-context');
+    const clearErrorBtn = $<HTMLButtonElement>('clear-error-btn');
 
     const STATUS: Record<SerialSessionStatusType, [StatusType, string]> = {
       [S.Idle]: ['info', 'シリアルポートから切断しました。'],
@@ -124,14 +143,70 @@ export class App {
       [S.Disposed]: ['info', 'セッションは破棄されました。'],
     };
 
+    let lastState: SerialSessionState = { status: S.Idle };
+
+    const renderErrorPanel = (): void => {
+      if (!this.latestError) {
+        errorPanel.hidden = true;
+        errorEmpty.hidden = false;
+        clearErrorBtn.hidden = true;
+        return;
+      }
+      errorPanel.hidden = false;
+      errorEmpty.hidden = true;
+      clearErrorBtn.hidden = false;
+      errorMessageEl.textContent = this.latestError.message;
+      errorCodeEl.textContent = this.latestError.code;
+      if (this.latestError.contextSummary) {
+        errorContextRow.hidden = false;
+        errorContextEl.textContent = this.latestError.contextSummary;
+      } else {
+        errorContextRow.hidden = true;
+        errorContextEl.textContent = '';
+      }
+    };
+
+    const clearError = (): void => {
+      this.latestError = null;
+      renderErrorPanel();
+      setStatus(status, ...STATUS[lastState.status]);
+    };
+
+    const renderSessionState = (state: SerialSessionState): void => {
+      const session = formatExampleSessionStatus(state);
+      sessionStatusEl.textContent = session.display;
+      sessionInProgressEl.textContent = session.inProgress ? 'はい' : 'いいえ';
+      if (isConnectedSessionState(state)) {
+        portInfoRow.hidden = false;
+        portInfoEl.textContent = formatExamplePortInfo(state.portInfo).display;
+      } else {
+        portInfoRow.hidden = true;
+        portInfoEl.textContent = '';
+      }
+    };
+
+    const applyControls = (state: SerialSessionState): void => {
+      const controls = getExampleControlsEnabled(state, supportStatus.canConnect);
+      connectBtn.disabled = !controls.connect;
+      disconnectBtn.disabled = !controls.disconnect;
+      sendInput.disabled = sendBtn.disabled = !controls.send;
+      baudRateSelect.disabled =
+        state.status === S.Connected ||
+        state.status === S.Connecting ||
+        state.status === S.Disconnecting;
+    };
+
     this.controller.state$.subscribe((state) => {
-      const connected = state.status === S.Connected;
-      const busy = state.status === S.Connecting || state.status === S.Disconnecting;
-      connectBtn.disabled = !supportStatus.canConnect || connected || busy;
-      baudRateSelect.disabled = connected || busy;
-      disconnectBtn.disabled = !connected;
-      sendInput.disabled = sendBtn.disabled = !connected;
-      setStatus(status, ...STATUS[state.status]);
+      lastState = state;
+      applyControls(state);
+      renderSessionState(state);
+      if (state.status === S.Connected || state.status === S.Idle) {
+        this.latestError = null;
+        renderErrorPanel();
+      }
+      if (!this.latestError) {
+        setStatus(status, ...STATUS[state.status]);
+      }
     });
 
     this.controller.terminalText$.subscribe((text) => {
@@ -140,7 +215,9 @@ export class App {
     });
 
     this.controller.errors$.subscribe((error) => {
-      const display = formatExampleSerialError(error);
+      const display = formatExampleSerialErrorDetail(error);
+      this.latestError = display;
+      renderErrorPanel();
       setStatus(
         status,
         display.type,
@@ -148,6 +225,8 @@ export class App {
       );
       console.error('Serial port error:', error);
     });
+
+    fromEvent(clearErrorBtn, 'click').subscribe(() => clearError());
 
     fromEvent(connectBtn, 'click').subscribe(() => {
       const baudRate = parseInt(baudRateSelect.value, 10);
@@ -180,5 +259,7 @@ export class App {
       this.controller.resetTerminalBuffer();
       receiveOutput.value = '';
     });
+
+    renderErrorPanel();
   }
 }

--- a/apps/example-vanilla-ts/src/styles.css
+++ b/apps/example-vanilla-ts/src/styles.css
@@ -110,6 +110,39 @@ main {
   margin-top: 0.5rem;
 }
 
+.session-state-list {
+  margin: 0 0 12px;
+  padding: 0;
+}
+
+.session-state-list > div {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 8px 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.95rem;
+}
+
+.session-state-list dt {
+  margin: 0;
+  font-weight: 600;
+  color: #555;
+}
+
+.session-state-list dd {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  color: #2c3e50;
+  word-break: break-word;
+}
+
+.session-empty {
+  margin: 0 0 12px;
+  color: #7f8c8d;
+  font-size: 0.95rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/apps/example-vue/src/app/App.test.ts
+++ b/apps/example-vue/src/app/App.test.ts
@@ -211,5 +211,27 @@ describe('App', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.text()).toContain('エラー: write failed');
+    expect(wrapper.find('[data-testid="session-error-code"]').text()).toBe(
+      'WRITE_FAILED',
+    );
+  });
+
+  it('should show session status and port info when connected', async () => {
+    const wrapper = mount(App);
+
+    expect(wrapper.find('[data-testid="session-status"]').text()).toContain(
+      'idle',
+    );
+
+    const connectButton = wrapper.findAll('.btn-primary')[0];
+    await connectButton.trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.find('[data-testid="session-status"]').text()).toContain(
+      'connected',
+    );
+    expect(wrapper.find('[data-testid="session-port-info"]').exists()).toBe(
+      true,
+    );
   });
 });

--- a/apps/example-vue/src/app/App.vue
+++ b/apps/example-vue/src/app/App.vue
@@ -1,10 +1,13 @@
 <script setup lang="ts">
 import {
+  formatExamplePortInfo,
+  formatExampleSessionStatus,
+  getExampleControlsEnabled,
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
 } from '@gurezo/examples-shared';
-import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
 import { computed, ref } from 'vue';
 import { useSerialClient } from '../composables/useSerialClient';
 
@@ -25,17 +28,23 @@ const {
   receivedData,
   errorMessage,
   errorType,
+  errorCode,
+  errorContext,
   connect$,
   disconnect$,
   send$,
   clearReceivedData,
+  clearError,
 } = useSerialClient(baudRate.value);
 
-const connecting = computed(
-  () => state.value.status === SerialSessionStatus.Connecting,
+const sessionStatus = computed(() => formatExampleSessionStatus(state.value));
+const controls = computed(() =>
+  getExampleControlsEnabled(state.value, canConnect.value),
 );
-const disconnecting = computed(
-  () => state.value.status === SerialSessionStatus.Disconnecting,
+const portInfoDisplay = computed(() =>
+  isConnectedSessionState(state.value)
+    ? formatExamplePortInfo(state.value.portInfo)
+    : null,
 );
 
 const status = computed<{ type: StatusType; message: string }>(() => {
@@ -48,23 +57,26 @@ const status = computed<{ type: StatusType; message: string }>(() => {
           : `エラー: ${errorMessage.value}`,
     };
   }
-  switch (state.value.status) {
-    case SerialSessionStatus.Connecting:
-      return { type: 'info', message: '接続中...' };
-    case SerialSessionStatus.Disconnecting:
-      return { type: 'info', message: '切断中...' };
-    case SerialSessionStatus.Connected:
-      return { type: 'success', message: 'シリアルポートに接続しました。' };
-    case SerialSessionStatus.Unsupported:
-      return {
-        type: 'error',
-        message: supportStatus.statusMessage,
-      };
-    case SerialSessionStatus.Error:
-      return { type: 'error', message: 'エラーが発生しました。' };
-    default:
-      return { type: 'info', message: 'シリアルポートに接続していません。' };
+  if (sessionStatus.value.inProgress) {
+    return {
+      type: 'info',
+      message:
+        sessionStatus.value.status === 'connecting' ? '接続中...' : '切断中...',
+    };
   }
+  if (isConnected.value) {
+    return { type: 'success', message: 'シリアルポートに接続しました。' };
+  }
+  if (state.value.status === 'unsupported') {
+    return {
+      type: 'error',
+      message: supportStatus.statusMessage,
+    };
+  }
+  if (state.value.status === 'error') {
+    return { type: 'error', message: 'エラーが発生しました。' };
+  }
+  return { type: 'info', message: 'シリアルポートに接続していません。' };
 });
 
 const handleConnect = () => {
@@ -222,14 +234,14 @@ const handleKeyDown = (e: KeyboardEvent) => {
           <button
             class="btn btn-primary"
             @click="handleConnect"
-            :disabled="!canConnect || isConnected || connecting"
+            :disabled="!controls.connect"
           >
             接続
           </button>
           <button
             class="btn btn-secondary"
             @click="handleDisconnect"
-            :disabled="!isConnected || disconnecting"
+            :disabled="!controls.disconnect"
           >
             切断
           </button>
@@ -237,6 +249,53 @@ const handleKeyDown = (e: KeyboardEvent) => {
         <div :class="['status-message', status.type]">
           {{ status.message }}
         </div>
+        <h3 class="subsection-title">セッション状態</h3>
+        <dl class="session-state-list">
+          <div>
+            <dt>status</dt>
+            <dd data-testid="session-status">{{ sessionStatus.display }}</dd>
+          </div>
+          <div>
+            <dt>進行中</dt>
+            <dd data-testid="session-in-progress">
+              {{ sessionStatus.inProgress ? 'はい' : 'いいえ' }}
+            </dd>
+          </div>
+          <div v-if="portInfoDisplay">
+            <dt>ポート情報</dt>
+            <dd data-testid="session-port-info">{{ portInfoDisplay.display }}</dd>
+          </div>
+        </dl>
+        <h3 class="subsection-title">最新エラー</h3>
+        <template v-if="errorMessage">
+          <dl class="session-state-list">
+            <div>
+              <dt>message</dt>
+              <dd data-testid="session-error-message">{{ errorMessage }}</dd>
+            </div>
+            <div>
+              <dt>code</dt>
+              <dd data-testid="session-error-code">{{ errorCode }}</dd>
+            </div>
+            <div v-if="errorContext">
+              <dt>context</dt>
+              <dd data-testid="session-error-context">{{ errorContext }}</dd>
+            </div>
+          </dl>
+          <div class="button-group">
+            <button
+              type="button"
+              class="btn btn-outline"
+              data-testid="clear-error"
+              @click="clearError"
+            >
+              エラークリア
+            </button>
+          </div>
+        </template>
+        <p v-else class="session-empty" data-testid="session-error-empty">
+          エラーはありません。
+        </p>
       </section>
 
       <!-- データ送信 -->
@@ -251,13 +310,13 @@ const handleKeyDown = (e: KeyboardEvent) => {
               class="form-control"
               v-model="sendInput"
               @keydown="handleKeyDown"
-              :disabled="!isConnected"
+              :disabled="!controls.send"
               placeholder="送信するテキストを入力..."
             />
             <button
               class="btn btn-primary"
               @click="handleSend"
-              :disabled="!isConnected || !sendInput.trim()"
+              :disabled="!controls.send || !sendInput.trim()"
             >
               送信
             </button>

--- a/apps/example-vue/src/composables/useSerialClient.test.ts
+++ b/apps/example-vue/src/composables/useSerialClient.test.ts
@@ -227,7 +227,7 @@ describe('useSerialClient', () => {
     expect(api.receivedData.value).toBe('chunk-1chunk-2');
   });
 
-  it('should set errorMessage from errors$ emissions', () => {
+  it('should set errorMessage and errorCode from errors$ emissions', () => {
     const { api } = mountHarness();
     const mock = latestMock();
 
@@ -239,6 +239,25 @@ describe('useSerialClient', () => {
     );
     expect(api.errorMessage.value).toBe('write failed');
     expect(api.errorType.value).toBe('error');
+    expect(api.errorCode.value).toBe(
+      webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+    );
+  });
+
+  it('should clear errors via clearError', () => {
+    const { api } = mountHarness();
+    const mock = latestMock();
+
+    mock.errorsSubject.next(
+      new webSerialRxjs.SerialError(
+        webSerialRxjs.SerialErrorCode.WRITE_FAILED,
+        'write failed',
+      ),
+    );
+    api.clearError();
+    expect(api.errorMessage.value).toBe(null);
+    expect(api.errorCode.value).toBe(null);
+    expect(api.errorContext.value).toBe(null);
   });
 
   it('should propagate connect$ errors to subscribers', () => {

--- a/apps/example-vue/src/composables/useSerialClient.ts
+++ b/apps/example-vue/src/composables/useSerialClient.ts
@@ -1,6 +1,6 @@
 import {
   createSerialSessionController,
-  formatExampleSerialError,
+  formatExampleSerialErrorDetail,
   getExampleSupportStatus,
 } from '@gurezo/examples-shared';
 import {
@@ -20,10 +20,13 @@ export interface UseSerialClientReturn {
   receivedData: Ref<string>;
   errorMessage: Ref<string | null>;
   errorType: Ref<'info' | 'error' | null>;
+  errorCode: Ref<string | null>;
+  errorContext: Ref<string | null>;
   connect$: (baudRate?: number) => Observable<void>;
   disconnect$: () => Observable<void>;
   send$: (data: string | Uint8Array) => Observable<void>;
   clearReceivedData: () => void;
+  clearError: () => void;
 }
 
 export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
@@ -39,10 +42,14 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
   const receivedData = ref('');
   const errorMessage = ref<string | null>(null);
   const errorType = ref<'info' | 'error' | null>(null);
+  const errorCode = ref<string | null>(null);
+  const errorContext = ref<string | null>(null);
 
   const clearError = () => {
     errorMessage.value = null;
     errorType.value = null;
+    errorCode.value = null;
+    errorContext.value = null;
   };
 
   const stateSub = controller.state$.subscribe((next) => {
@@ -59,9 +66,11 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     receivedData.value = text;
   });
   const errorsSub = controller.errors$.subscribe((error: SerialError) => {
-    const display = formatExampleSerialError(error);
+    const display = formatExampleSerialErrorDetail(error);
     errorMessage.value = display.message;
     errorType.value = display.type;
+    errorCode.value = display.code;
+    errorContext.value = display.contextSummary;
   });
 
   const connect$ = (baudRate?: number): Observable<void> => {
@@ -91,9 +100,12 @@ export function useSerialClient(initialBaudRate = 9600): UseSerialClientReturn {
     receivedData,
     errorMessage,
     errorType,
+    errorCode,
+    errorContext,
     connect$,
     disconnect$,
     send$,
     clearReceivedData,
+    clearError,
   };
 }

--- a/apps/example-vue/src/styles.css
+++ b/apps/example-vue/src/styles.css
@@ -110,6 +110,39 @@ main {
   margin-top: 0.5rem;
 }
 
+.session-state-list {
+  margin: 0 0 12px;
+  padding: 0;
+}
+
+.session-state-list > div {
+  display: grid;
+  grid-template-columns: 7rem 1fr;
+  gap: 8px 12px;
+  padding: 6px 0;
+  border-bottom: 1px solid #eee;
+  font-size: 0.95rem;
+}
+
+.session-state-list dt {
+  margin: 0;
+  font-weight: 600;
+  color: #555;
+}
+
+.session-state-list dd {
+  margin: 0;
+  font-family: 'Courier New', monospace;
+  color: #2c3e50;
+  word-break: break-word;
+}
+
+.session-empty {
+  margin: 0 0 12px;
+  color: #7f8c8d;
+  font-size: 0.95rem;
+}
+
 .form-group {
   margin-bottom: 16px;
 }

--- a/libs/examples-shared/src/example-session-display.spec.ts
+++ b/libs/examples-shared/src/example-session-display.spec.ts
@@ -1,0 +1,155 @@
+import {
+  SerialError,
+  SerialErrorCode,
+  SerialSessionStatus,
+  type SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+import { describe, expect, it } from 'vitest';
+import {
+  formatExamplePortInfo,
+  formatExampleSerialErrorDetail,
+  formatExampleSessionStatus,
+  getExampleControlsEnabled,
+} from './example-session-display';
+
+describe('formatExampleSessionStatus', () => {
+  it('formats idle with Japanese label', () => {
+    const display = formatExampleSessionStatus({
+      status: SerialSessionStatus.Idle,
+    });
+
+    expect(display).toEqual({
+      status: 'idle',
+      label: 'アイドル',
+      display: 'idle（アイドル）',
+      inProgress: false,
+    });
+  });
+
+  it('marks connecting and disconnecting as in progress', () => {
+    expect(
+      formatExampleSessionStatus({ status: SerialSessionStatus.Connecting })
+        .inProgress,
+    ).toBe(true);
+    expect(
+      formatExampleSessionStatus({ status: SerialSessionStatus.Disconnecting })
+        .inProgress,
+    ).toBe(true);
+    expect(
+      formatExampleSessionStatus({
+        status: SerialSessionStatus.Connected,
+        portInfo: {},
+      }).inProgress,
+    ).toBe(false);
+  });
+});
+
+describe('formatExamplePortInfo', () => {
+  it('formats vendor and product ids as hex', () => {
+    expect(
+      formatExamplePortInfo({ usbVendorId: 0x2341, usbProductId: 0x0043 }),
+    ).toEqual({
+      vendorId: '0x2341',
+      productId: '0x0043',
+      display: 'Vendor ID: 0x2341 / Product ID: 0x0043',
+    });
+  });
+
+  it('uses 不明 when ids are missing', () => {
+    expect(formatExamplePortInfo({})).toEqual({
+      vendorId: '不明',
+      productId: '不明',
+      display: 'Vendor ID: 不明 / Product ID: 不明',
+    });
+  });
+});
+
+describe('formatExampleSerialErrorDetail', () => {
+  it('includes code and maps cancel to info', () => {
+    const error = new SerialError(
+      SerialErrorCode.OPERATION_CANCELLED,
+      'cancelled',
+      { cause: undefined },
+    );
+
+    const detail = formatExampleSerialErrorDetail(error);
+
+    expect(detail.type).toBe('info');
+    expect(detail.code).toBe(SerialErrorCode.OPERATION_CANCELLED);
+    expect(detail.message).toContain('キャンセル');
+  });
+
+  it('summarizes cause and structured context', () => {
+    const error = new SerialError(
+      SerialErrorCode.WRITE_FAILED,
+      'write failed',
+      new Error('device busy'),
+    );
+
+    const detail = formatExampleSerialErrorDetail(error);
+
+    expect(detail).toMatchObject({
+      type: 'error',
+      message: 'write failed',
+      code: SerialErrorCode.WRITE_FAILED,
+    });
+    expect(detail.contextSummary).toContain('cause: Error: device busy');
+  });
+
+  it('summarizes maxChars for line buffer overflow', () => {
+    const error = new SerialError(
+      SerialErrorCode.LINE_BUFFER_OVERFLOW,
+      'overflow',
+      undefined,
+      { maxChars: 4096 },
+    );
+
+    expect(formatExampleSerialErrorDetail(error).contextSummary).toBe(
+      'maxChars: 4096',
+    );
+  });
+});
+
+describe('getExampleControlsEnabled', () => {
+  const idle: SerialSessionState = { status: SerialSessionStatus.Idle };
+  const connected: SerialSessionState = {
+    status: SerialSessionStatus.Connected,
+    portInfo: { usbVendorId: 1, usbProductId: 2 },
+  };
+  const connecting: SerialSessionState = {
+    status: SerialSessionStatus.Connecting,
+  };
+  const disconnecting: SerialSessionState = {
+    status: SerialSessionStatus.Disconnecting,
+  };
+
+  it('enables connect only when idle and canConnect', () => {
+    expect(getExampleControlsEnabled(idle, true)).toEqual({
+      connect: true,
+      disconnect: false,
+      send: false,
+    });
+    expect(getExampleControlsEnabled(idle, false).connect).toBe(false);
+  });
+
+  it('enables disconnect and send when connected', () => {
+    expect(getExampleControlsEnabled(connected, true)).toEqual({
+      connect: false,
+      disconnect: true,
+      send: true,
+    });
+  });
+
+  it('disables all actions while connecting or disconnecting', () => {
+    expect(getExampleControlsEnabled(connecting, true)).toEqual({
+      connect: false,
+      disconnect: false,
+      send: false,
+    });
+    expect(getExampleControlsEnabled(disconnecting, true)).toEqual({
+      connect: false,
+      disconnect: false,
+      send: false,
+    });
+  });
+});

--- a/libs/examples-shared/src/example-session-display.ts
+++ b/libs/examples-shared/src/example-session-display.ts
@@ -1,5 +1,6 @@
 import {
   SerialSessionStatus,
+  type ConnectedSessionState,
   type SerialError,
   type SerialSessionState,
 } from '@gurezo/web-serial-rxjs';
@@ -74,10 +75,10 @@ function formatUsbId(value: number | undefined): string {
 }
 
 /**
- * Formats USB Vendor / Product IDs from {@link SerialPortInfo}.
+ * Formats USB Vendor / Product IDs from connected session `portInfo`.
  */
 export function formatExamplePortInfo(
-  portInfo: SerialPortInfo,
+  portInfo: ConnectedSessionState['portInfo'],
 ): ExamplePortInfoDisplay {
   const vendorId = formatUsbId(portInfo.usbVendorId);
   const productId = formatUsbId(portInfo.usbProductId);

--- a/libs/examples-shared/src/example-session-display.ts
+++ b/libs/examples-shared/src/example-session-display.ts
@@ -1,0 +1,185 @@
+import {
+  SerialSessionStatus,
+  type SerialError,
+  type SerialSessionState,
+} from '@gurezo/web-serial-rxjs';
+import {
+  formatExampleSerialError,
+  type ExampleErrorDisplay,
+} from './example-requirements';
+
+export interface ExampleSessionStatusDisplay {
+  /** Raw `state.status` value. */
+  readonly status: SerialSessionState['status'];
+  /** Japanese label for the status. */
+  readonly label: string;
+  /** Combined display like `idle（アイドル）`. */
+  readonly display: string;
+  /** True while connect or disconnect is in progress. */
+  readonly inProgress: boolean;
+}
+
+export interface ExamplePortInfoDisplay {
+  readonly vendorId: string;
+  readonly productId: string;
+  readonly display: string;
+}
+
+export interface ExampleSerialErrorDetail extends ExampleErrorDisplay {
+  readonly code: string;
+  readonly contextSummary: string | null;
+}
+
+export interface ExampleControlsEnabled {
+  readonly connect: boolean;
+  readonly disconnect: boolean;
+  readonly send: boolean;
+}
+
+const STATUS_LABELS: Record<SerialSessionState['status'], string> = {
+  [SerialSessionStatus.Idle]: 'アイドル',
+  [SerialSessionStatus.Connecting]: '接続中',
+  [SerialSessionStatus.Connected]: '接続済み',
+  [SerialSessionStatus.Disconnecting]: '切断中',
+  [SerialSessionStatus.Unsupported]: '非対応',
+  [SerialSessionStatus.Error]: 'エラー',
+  [SerialSessionStatus.Disposed]: '破棄済み',
+};
+
+/**
+ * Formats a {@link SerialSessionState} for Example UI status panels.
+ */
+export function formatExampleSessionStatus(
+  state: SerialSessionState,
+): ExampleSessionStatusDisplay {
+  const status = state.status;
+  const label = STATUS_LABELS[status];
+  const inProgress =
+    status === SerialSessionStatus.Connecting ||
+    status === SerialSessionStatus.Disconnecting;
+
+  return {
+    status,
+    label,
+    display: `${status}（${label}）`,
+    inProgress,
+  };
+}
+
+function formatUsbId(value: number | undefined): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return '不明';
+  }
+  return `0x${value.toString(16).toUpperCase().padStart(4, '0')}`;
+}
+
+/**
+ * Formats USB Vendor / Product IDs from {@link SerialPortInfo}.
+ */
+export function formatExamplePortInfo(
+  portInfo: SerialPortInfo,
+): ExamplePortInfoDisplay {
+  const vendorId = formatUsbId(portInfo.usbVendorId);
+  const productId = formatUsbId(portInfo.usbProductId);
+
+  return {
+    vendorId,
+    productId,
+    display: `Vendor ID: ${vendorId} / Product ID: ${productId}`,
+  };
+}
+
+function summarizeContext(context: unknown): string | null {
+  if (context === undefined || context === null) {
+    return null;
+  }
+
+  if (typeof context !== 'object') {
+    return String(context);
+  }
+
+  const record = context as Record<string, unknown>;
+  const parts: string[] = [];
+
+  if ('cause' in record) {
+    const cause = record.cause;
+    if (cause instanceof Error) {
+      parts.push(`cause: ${cause.name}: ${cause.message}`);
+    } else if (cause !== undefined && cause !== null) {
+      parts.push(`cause: ${String(cause)}`);
+    }
+  }
+
+  if (typeof record.maxChars === 'number') {
+    parts.push(`maxChars: ${record.maxChars}`);
+  }
+
+  if (typeof record.field === 'string') {
+    parts.push(`field: ${record.field}`);
+  }
+  if ('value' in record) {
+    parts.push(`value: ${String(record.value)}`);
+  }
+  if (typeof record.constraint === 'string') {
+    parts.push(`constraint: ${record.constraint}`);
+  }
+  if (typeof record.filterIndex === 'number') {
+    parts.push(`filterIndex: ${record.filterIndex}`);
+  }
+
+  if (parts.length === 0) {
+    try {
+      return JSON.stringify(context);
+    } catch {
+      return String(context);
+    }
+  }
+
+  return parts.join(', ');
+}
+
+/**
+ * Maps a {@link SerialError} to Example detail fields (message, code, context).
+ * Port-selection cancel remains an info tone via {@link formatExampleSerialError}.
+ */
+export function formatExampleSerialErrorDetail(
+  error: SerialError,
+): ExampleSerialErrorDetail {
+  const base = formatExampleSerialError(error);
+  const code =
+    typeof error.code === 'string' ? error.code : String(error.code ?? 'UNKNOWN');
+
+  return {
+    ...base,
+    code,
+    contextSummary: summarizeContext(error.context),
+  };
+}
+
+/**
+ * Derives Connect / Disconnect / Send enabled flags from session state
+ * and browser support (`canConnect` from {@link getExampleSupportStatus}).
+ */
+export function getExampleControlsEnabled(
+  state: SerialSessionState,
+  canConnect: boolean,
+): ExampleControlsEnabled {
+  const status = state.status;
+  const connected = status === SerialSessionStatus.Connected;
+  const connecting = status === SerialSessionStatus.Connecting;
+  const disconnecting = status === SerialSessionStatus.Disconnecting;
+  const disposed = status === SerialSessionStatus.Disposed;
+  const unsupported = status === SerialSessionStatus.Unsupported;
+
+  return {
+    connect:
+      canConnect &&
+      !connected &&
+      !connecting &&
+      !disconnecting &&
+      !disposed &&
+      !unsupported,
+    disconnect: connected && !disconnecting,
+    send: connected && !disconnecting,
+  };
+}

--- a/libs/examples-shared/src/example-session-display.ts
+++ b/libs/examples-shared/src/example-session-display.ts
@@ -102,7 +102,7 @@ function summarizeContext(context: unknown): string | null {
   const parts: string[] = [];
 
   if ('cause' in record) {
-    const cause = record.cause;
+    const cause = record['cause'];
     if (cause instanceof Error) {
       parts.push(`cause: ${cause.name}: ${cause.message}`);
     } else if (cause !== undefined && cause !== null) {
@@ -110,21 +110,21 @@ function summarizeContext(context: unknown): string | null {
     }
   }
 
-  if (typeof record.maxChars === 'number') {
-    parts.push(`maxChars: ${record.maxChars}`);
+  if (typeof record['maxChars'] === 'number') {
+    parts.push(`maxChars: ${record['maxChars']}`);
   }
 
-  if (typeof record.field === 'string') {
-    parts.push(`field: ${record.field}`);
+  if (typeof record['field'] === 'string') {
+    parts.push(`field: ${record['field']}`);
   }
   if ('value' in record) {
-    parts.push(`value: ${String(record.value)}`);
+    parts.push(`value: ${String(record['value'])}`);
   }
-  if (typeof record.constraint === 'string') {
-    parts.push(`constraint: ${record.constraint}`);
+  if (typeof record['constraint'] === 'string') {
+    parts.push(`constraint: ${record['constraint']}`);
   }
-  if (typeof record.filterIndex === 'number') {
-    parts.push(`filterIndex: ${record.filterIndex}`);
+  if (typeof record['filterIndex'] === 'number') {
+    parts.push(`filterIndex: ${record['filterIndex']}`);
   }
 
   if (parts.length === 0) {

--- a/libs/examples-shared/src/index.ts
+++ b/libs/examples-shared/src/index.ts
@@ -19,3 +19,13 @@ export {
   type ExampleSupportStatus,
   type ExampleUnsupportedReason,
 } from './example-requirements';
+export {
+  formatExamplePortInfo,
+  formatExampleSerialErrorDetail,
+  formatExampleSessionStatus,
+  getExampleControlsEnabled,
+  type ExampleControlsEnabled,
+  type ExamplePortInfoDisplay,
+  type ExampleSerialErrorDetail,
+  type ExampleSessionStatusDisplay,
+} from './example-session-display';


### PR DESCRIPTION
## Summary
各 Example で `SerialSession` の `state$` / `errors$` を可視化し、状態駆動の Connect/Disconnect/Send 制御とエラー詳細（code / context）・Connected 時の VID/PID を画面上で確認できるようにしました（#521 / 親 #516）。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #521
- Parent: #516

## What changed?
- `examples-shared` にセッション状態・ポート情報・エラー詳細・コントロール可否の表示ヘルパーを追加
- 6 つの Example（React / Angular / Vue / Svelte / Vanilla TS / Vanilla JS）に「セッション状態」「最新エラー」パネルを配線
- Connect / Disconnect / Send の disabled 判定を共有ヘルパーに統一
- エラーの手動クリア（エラークリア）を追加
- Connected 時に Vendor ID / Product ID を表示

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `npx nx test examples-shared` および各 `example-*` のテストが通ることを確認
2. Chromium 系ブラウザで任意の Example を開き、「セッション状態」に `status`（例: idle）が表示されること
3. 接続後に status が `connected` になり、Vendor ID / Product ID が表示されること
4. エラー発生時に message / code / context が表示され、「エラークリア」で消えること
5. 接続中・切断中は対応ボタンが無効になること

## Environment (if relevant)
- Browser: Chrome / Edge / Opera / Firefox (desktop)
- OS: macOS / Windows / Linux
- web-serial-rxjs version (for verification): workspace main
- RxJS version: ^7.8.0

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)