### PR TITLE
feat(examples-shared): add line ending select on example send ui

### DIFF
--- a/apps/example-angular/src/app/app.html
+++ b/apps/example-angular/src/app/app.html
@@ -189,6 +189,18 @@
     <section class="section">
       <h2>データ送信</h2>
       <div class="form-group">
+        <label for="line-ending">改行コード</label>
+        <select
+          id="line-ending"
+          class="form-control"
+          [(ngModel)]="lineEnding"
+        >
+          @for (opt of lineEndingOptions; track opt.value) {
+            <option [value]="opt.value">{{ opt.label }}</option>
+          }
+        </select>
+      </div>
+      <div class="form-group">
         <label for="send-input">送信データ</label>
         <div class="input-group">
           <input

--- a/apps/example-angular/src/app/app.ts
+++ b/apps/example-angular/src/app/app.ts
@@ -10,6 +10,9 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import {
+  appendExampleLineEnding,
+  DEFAULT_EXAMPLE_LINE_ENDING,
+  EXAMPLE_LINE_ENDING_OPTIONS,
   formatExamplePortInfo,
   formatExampleSerialErrorDetail,
   formatExampleSessionStatus,
@@ -17,6 +20,7 @@ import {
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
+  type ExampleLineEnding,
   type ExampleSerialErrorDetail,
 } from '@gurezo/examples-shared';
 import {
@@ -38,6 +42,8 @@ type StatusType = 'info' | 'success' | 'error';
 export class App {
   baudRate = 9600;
   sendInput = '';
+  lineEnding: ExampleLineEnding = DEFAULT_EXAMPLE_LINE_ENDING;
+  readonly lineEndingOptions = EXAMPLE_LINE_ENDING_OPTIONS;
   readonly navLinks = getExampleNavLinks('angular');
   readonly requirements = getExampleRequirementsCopy();
   readonly supportStatus = getExampleSupportStatus();
@@ -160,14 +166,16 @@ export class App {
     if (!text) {
       return;
     }
-    this.serialService.send$(`${text}\n`).subscribe({
-      next: () => {
-        this.sendInput = '';
-      },
-      error: (error: unknown) => {
-        console.error('送信エラー:', error);
-      },
-    });
+    this.serialService
+      .send$(appendExampleLineEnding(text, this.lineEnding))
+      .subscribe({
+        next: () => {
+          this.sendInput = '';
+        },
+        error: (error: unknown) => {
+          console.error('送信エラー:', error);
+        },
+      });
   }
 
   handleKeyDown(event: KeyboardEvent): void {

--- a/apps/example-react/src/App.tsx
+++ b/apps/example-react/src/App.tsx
@@ -1,10 +1,14 @@
 import {
+  appendExampleLineEnding,
+  DEFAULT_EXAMPLE_LINE_ENDING,
+  EXAMPLE_LINE_ENDING_OPTIONS,
   formatExamplePortInfo,
   formatExampleSessionStatus,
   getExampleControlsEnabled,
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
+  type ExampleLineEnding,
 } from '@gurezo/examples-shared';
 import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
 import { useMemo, useState } from 'react';
@@ -22,6 +26,9 @@ const externalLinkProps = {
 export function App() {
   const [baudRate, setBaudRate] = useState(9600);
   const [sendInput, setSendInput] = useState('');
+  const [lineEnding, setLineEnding] = useState<ExampleLineEnding>(
+    DEFAULT_EXAMPLE_LINE_ENDING,
+  );
   const supportStatus = useMemo(() => getExampleSupportStatus(), []);
   const {
     canConnect,
@@ -74,7 +81,7 @@ export function App() {
   const handleSend = () => {
     const text = sendInput.trim();
     if (!text) return;
-    send$(`${text}\n`).subscribe({
+    send$(appendExampleLineEnding(text, lineEnding)).subscribe({
       next: () => setSendInput(''),
       error: (e: unknown) => console.error('送信エラー:', e),
     });
@@ -248,6 +255,23 @@ export function App() {
         </section>
         <section className="section">
           <h2>データ送信</h2>
+          <div className="form-group">
+            <label htmlFor="line-ending">改行コード</label>
+            <select
+              id="line-ending"
+              className="form-control"
+              value={lineEnding}
+              onChange={(e) =>
+                setLineEnding(e.target.value as ExampleLineEnding)
+              }
+            >
+              {EXAMPLE_LINE_ENDING_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
           <div className="form-group">
             <label htmlFor="send-input">送信データ</label>
             <div className="input-group">

--- a/apps/example-svelte/src/App.svelte
+++ b/apps/example-svelte/src/App.svelte
@@ -1,11 +1,15 @@
 <script lang="ts">
   import {
+    appendExampleLineEnding,
+    DEFAULT_EXAMPLE_LINE_ENDING,
+    EXAMPLE_LINE_ENDING_OPTIONS,
     formatExamplePortInfo,
     formatExampleSessionStatus,
     getExampleControlsEnabled,
     getExampleNavLinks,
     getExampleRequirementsCopy,
     getExampleSupportStatus,
+    type ExampleLineEnding,
   } from '@gurezo/examples-shared';
   import {
     isConnectedSessionState,
@@ -17,9 +21,11 @@
   const requirements = getExampleRequirementsCopy();
   const supportStatus = getExampleSupportStatus();
   const externalLinkRel = 'noopener noreferrer';
+  const lineEndingOptions = EXAMPLE_LINE_ENDING_OPTIONS;
 
   let baudRate = 9600;
   let sendInput = '';
+  let lineEnding: ExampleLineEnding = DEFAULT_EXAMPLE_LINE_ENDING;
 
   const {
     canConnect,
@@ -97,7 +103,7 @@
     if (!text) {
       return;
     }
-    send$(`${text}\n`).subscribe({
+    send$(appendExampleLineEnding(text, lineEnding)).subscribe({
       next: () => {
         sendInput = '';
       },
@@ -300,6 +306,14 @@
     <!-- データ送信 -->
     <section class="section">
       <h2>データ送信</h2>
+      <div class="form-group">
+        <label for="line-ending">改行コード</label>
+        <select id="line-ending" class="form-control" bind:value={lineEnding}>
+          {#each lineEndingOptions as opt}
+            <option value={opt.value}>{opt.label}</option>
+          {/each}
+        </select>
+      </div>
       <div class="form-group">
         <label for="send-input">送信データ</label>
         <div class="input-group">

--- a/apps/example-vanilla-js/index.html
+++ b/apps/example-vanilla-js/index.html
@@ -115,6 +115,10 @@
         <section id="send-section" class="section">
           <h2>データ送信</h2>
           <div class="form-group">
+            <label for="line-ending">改行コード:</label>
+            <select id="line-ending" class="form-control"></select>
+          </div>
+          <div class="form-group">
             <label for="send-input">送信データ:</label>
             <div class="input-group">
               <input

--- a/apps/example-vanilla-js/src/app.js
+++ b/apps/example-vanilla-js/src/app.js
@@ -1,5 +1,8 @@
 import {
+  appendExampleLineEnding,
   createSerialSessionController,
+  DEFAULT_EXAMPLE_LINE_ENDING,
+  EXAMPLE_LINE_ENDING_OPTIONS,
   formatExamplePortInfo,
   formatExampleSerialErrorDetail,
   formatExampleSessionStatus,
@@ -103,6 +106,7 @@ export class App {
     const disconnectBtn = $('disconnect-btn');
     const status = $('connection-status');
     const baudRateSelect = $('baud-rate');
+    const lineEndingSelect = $('line-ending');
     const sendInput = $('send-input');
     const sendBtn = $('send-btn');
     const receiveOutput = $('receive-output');
@@ -120,6 +124,16 @@ export class App {
     this.controller = createSerialSessionController({ initialBaudRate: 9600 });
     this.latestError = null;
     let lastState = { status: SerialSessionStatus.Idle };
+
+    for (const opt of EXAMPLE_LINE_ENDING_OPTIONS) {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (opt.value === DEFAULT_EXAMPLE_LINE_ENDING) {
+        option.selected = true;
+      }
+      lineEndingSelect.appendChild(option);
+    }
 
     const STATUS = {
       idle: ['info', 'シリアルポートから切断しました。'],
@@ -230,10 +244,12 @@ export class App {
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
-      this.controller.send$(`${text}\n`).subscribe({
-        next: () => (sendInput.value = ''),
-        error: () => void 0,
-      });
+      this.controller
+        .send$(appendExampleLineEnding(text, lineEndingSelect.value))
+        .subscribe({
+          next: () => (sendInput.value = ''),
+          error: () => void 0,
+        });
     };
 
     fromEvent(sendBtn, 'click').subscribe(send);

--- a/apps/example-vanilla-js/src/app.test.js
+++ b/apps/example-vanilla-js/src/app.test.js
@@ -71,6 +71,7 @@ describe('App', () => {
         <option value="9600">9600</option>
         <option value="115200" selected>115200</option>
       </select>
+      <select id="line-ending"></select>
       <input id="send-input" />
       <button id="send-btn"></button>
       <textarea id="receive-output"></textarea>

--- a/apps/example-vanilla-ts/index.html
+++ b/apps/example-vanilla-ts/index.html
@@ -115,6 +115,10 @@
         <section id="send-section" class="section">
           <h2>データ送信</h2>
           <div class="form-group">
+            <label for="line-ending">改行コード:</label>
+            <select id="line-ending" class="form-control"></select>
+          </div>
+          <div class="form-group">
             <label for="send-input">送信データ:</label>
             <div class="input-group">
               <input

--- a/apps/example-vanilla-ts/src/app.test.ts
+++ b/apps/example-vanilla-ts/src/app.test.ts
@@ -84,6 +84,7 @@ describe('App', () => {
         <option value="9600">9600</option>
         <option value="115200" selected>115200</option>
       </select>
+      <select id="line-ending"></select>
       <input id="send-input" />
       <button id="send-btn"></button>
       <textarea id="receive-output"></textarea>

--- a/apps/example-vanilla-ts/src/app.ts
+++ b/apps/example-vanilla-ts/src/app.ts
@@ -1,5 +1,8 @@
 import {
+  appendExampleLineEnding,
   createSerialSessionController,
+  DEFAULT_EXAMPLE_LINE_ENDING,
+  EXAMPLE_LINE_ENDING_OPTIONS,
   formatExamplePortInfo,
   formatExampleSerialErrorDetail,
   formatExampleSessionStatus,
@@ -7,6 +10,7 @@ import {
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
+  type ExampleLineEnding,
   type ExampleNavLink,
   type ExampleSlug,
   type ExampleSerialErrorDetail,
@@ -118,6 +122,7 @@ export class App {
     const disconnectBtn = $<HTMLButtonElement>('disconnect-btn');
     const status = $<HTMLElement>('connection-status');
     const baudRateSelect = $<HTMLSelectElement>('baud-rate');
+    const lineEndingSelect = $<HTMLSelectElement>('line-ending');
     const sendInput = $<HTMLInputElement>('send-input');
     const sendBtn = $<HTMLButtonElement>('send-btn');
     const receiveOutput = $<HTMLTextAreaElement>('receive-output');
@@ -132,6 +137,16 @@ export class App {
     const errorContextRow = $<HTMLElement>('session-error-context-row');
     const errorContextEl = $<HTMLElement>('session-error-context');
     const clearErrorBtn = $<HTMLButtonElement>('clear-error-btn');
+
+    for (const opt of EXAMPLE_LINE_ENDING_OPTIONS) {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.label;
+      if (opt.value === DEFAULT_EXAMPLE_LINE_ENDING) {
+        option.selected = true;
+      }
+      lineEndingSelect.appendChild(option);
+    }
 
     const STATUS: Record<SerialSessionStatusType, [StatusType, string]> = {
       [S.Idle]: ['info', 'シリアルポートから切断しました。'],
@@ -241,7 +256,8 @@ export class App {
     const send = () => {
       const text = sendInput.value.trim();
       if (!text) return;
-      this.controller.send$(`${text}\n`).subscribe({
+      const ending = lineEndingSelect.value as ExampleLineEnding;
+      this.controller.send$(appendExampleLineEnding(text, ending)).subscribe({
         next: () => (sendInput.value = ''),
         error: () => void 0,
       });

--- a/apps/example-vue/src/app/App.vue
+++ b/apps/example-vue/src/app/App.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import {
+  appendExampleLineEnding,
+  DEFAULT_EXAMPLE_LINE_ENDING,
+  EXAMPLE_LINE_ENDING_OPTIONS,
   formatExamplePortInfo,
   formatExampleSessionStatus,
   getExampleControlsEnabled,
   getExampleNavLinks,
   getExampleRequirementsCopy,
   getExampleSupportStatus,
+  type ExampleLineEnding,
 } from '@gurezo/examples-shared';
 import { isConnectedSessionState } from '@gurezo/web-serial-rxjs';
 import { computed, ref } from 'vue';
@@ -17,9 +21,11 @@ const navLinks = getExampleNavLinks('vue');
 const requirements = getExampleRequirementsCopy();
 const supportStatus = getExampleSupportStatus();
 const externalLinkRel = 'noopener noreferrer';
+const lineEndingOptions = EXAMPLE_LINE_ENDING_OPTIONS;
 
 const baudRate = ref(9600);
 const sendInput = ref('');
+const lineEnding = ref<ExampleLineEnding>(DEFAULT_EXAMPLE_LINE_ENDING);
 
 const {
   canConnect,
@@ -101,7 +107,7 @@ const handleSend = () => {
   if (!text) {
     return;
   }
-  send$(`${text}\n`).subscribe({
+  send$(appendExampleLineEnding(text, lineEnding.value)).subscribe({
     next: () => {
       sendInput.value = '';
     },
@@ -301,6 +307,22 @@ const handleKeyDown = (e: KeyboardEvent) => {
       <!-- データ送信 -->
       <section class="section">
         <h2>データ送信</h2>
+        <div class="form-group">
+          <label for="line-ending">改行コード</label>
+          <select
+            id="line-ending"
+            class="form-control"
+            v-model="lineEnding"
+          >
+            <option
+              v-for="opt in lineEndingOptions"
+              :key="opt.value"
+              :value="opt.value"
+            >
+              {{ opt.label }}
+            </option>
+          </select>
+        </div>
         <div class="form-group">
           <label for="send-input">送信データ</label>
           <div class="input-group">

--- a/libs/examples-shared/src/example-line-ending.spec.ts
+++ b/libs/examples-shared/src/example-line-ending.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import {
+  appendExampleLineEnding,
+  DEFAULT_EXAMPLE_LINE_ENDING,
+  EXAMPLE_LINE_ENDING_OPTIONS,
+  getExampleLineEndingSuffix,
+  type ExampleLineEnding,
+} from './example-line-ending';
+
+describe('DEFAULT_EXAMPLE_LINE_ENDING', () => {
+  it('defaults to lf for backward compatibility', () => {
+    expect(DEFAULT_EXAMPLE_LINE_ENDING).toBe('lf');
+  });
+});
+
+describe('EXAMPLE_LINE_ENDING_OPTIONS', () => {
+  it('exposes four options with escape-visible labels', () => {
+    expect(EXAMPLE_LINE_ENDING_OPTIONS.map((o) => o.value)).toEqual([
+      'none',
+      'lf',
+      'cr',
+      'crlf',
+    ]);
+    expect(EXAMPLE_LINE_ENDING_OPTIONS.map((o) => o.label)).toEqual([
+      'None',
+      'LF (\\n)',
+      'CR (\\r)',
+      'CRLF (\\r\\n)',
+    ]);
+  });
+});
+
+describe('getExampleLineEndingSuffix', () => {
+  it.each<[ExampleLineEnding, string]>([
+    ['none', ''],
+    ['lf', '\n'],
+    ['cr', '\r'],
+    ['crlf', '\r\n'],
+  ])('%s → %j', (ending, expected) => {
+    expect(getExampleLineEndingSuffix(ending)).toBe(expected);
+  });
+});
+
+describe('appendExampleLineEnding', () => {
+  it.each<[ExampleLineEnding, string]>([
+    ['none', 'hello'],
+    ['lf', 'hello\n'],
+    ['cr', 'hello\r'],
+    ['crlf', 'hello\r\n'],
+  ])('appends %s', (ending, expected) => {
+    expect(appendExampleLineEnding('hello', ending)).toBe(expected);
+  });
+});

--- a/libs/examples-shared/src/example-line-ending.ts
+++ b/libs/examples-shared/src/example-line-ending.ts
@@ -1,0 +1,47 @@
+/**
+ * Line ending choices for Example send UI.
+ */
+export type ExampleLineEnding = 'none' | 'lf' | 'cr' | 'crlf';
+
+/** Default matches the previous hard-coded `\n` append behavior. */
+export const DEFAULT_EXAMPLE_LINE_ENDING: ExampleLineEnding = 'lf';
+
+export interface ExampleLineEndingOption {
+  readonly value: ExampleLineEnding;
+  readonly label: string;
+}
+
+/**
+ * Options for Example send-UI `<select>` labels.
+ * Escape sequences are shown so invisible characters are visible.
+ */
+export const EXAMPLE_LINE_ENDING_OPTIONS: readonly ExampleLineEndingOption[] = [
+  { value: 'none', label: 'None' },
+  { value: 'lf', label: 'LF (\\n)' },
+  { value: 'cr', label: 'CR (\\r)' },
+  { value: 'crlf', label: 'CRLF (\\r\\n)' },
+] as const;
+
+const SUFFIX_BY_ENDING: Record<ExampleLineEnding, string> = {
+  none: '',
+  lf: '\n',
+  cr: '\r',
+  crlf: '\r\n',
+};
+
+/**
+ * Returns the byte suffix for the selected line ending.
+ */
+export function getExampleLineEndingSuffix(ending: ExampleLineEnding): string {
+  return SUFFIX_BY_ENDING[ending];
+}
+
+/**
+ * Appends the selected line ending to `text` for Example send handlers.
+ */
+export function appendExampleLineEnding(
+  text: string,
+  ending: ExampleLineEnding,
+): string {
+  return text + getExampleLineEndingSuffix(ending);
+}

--- a/libs/examples-shared/src/index.ts
+++ b/libs/examples-shared/src/index.ts
@@ -29,3 +29,11 @@ export {
   type ExampleSerialErrorDetail,
   type ExampleSessionStatusDisplay,
 } from './example-session-display';
+export {
+  appendExampleLineEnding,
+  DEFAULT_EXAMPLE_LINE_ENDING,
+  EXAMPLE_LINE_ENDING_OPTIONS,
+  getExampleLineEndingSuffix,
+  type ExampleLineEnding,
+  type ExampleLineEndingOption,
+} from './example-line-ending';


### PR DESCRIPTION
## PR Title (Conventional Commits)
feat(examples-shared): add line ending select on example send ui

## Summary
Example 送信 UI に改行コード（None / LF / CR / CRLF）選択を追加し、6 Example で仕様を統一しました。シリアルデバイスごとの行末差を Example 上で検証しやすくするためです。

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #522
- Parent: #516

## What changed?
- `examples-shared` に `appendExampleLineEnding` / `EXAMPLE_LINE_ENDING_OPTIONS` などの改行コードヘルパーと Vitest を追加
- React / Angular / Vue / Svelte / Vanilla TS / Vanilla JS の送信 UI に改行コード `<select>` を追加
- 送信時の固定 `\n` 付与を、選択値に応じた末尾付加へ置き換え（既定は従来どおり `lf`）

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `nx test examples-shared` で改行コードヘルパーのテストが通ることを確認する
2. `nx test example-react` / `example-vue` など関連 Example のテストが通ることを確認する
3. 任意の Example をブラウザで開き、改行コードを None / LF / CR / CRLF に切り替えて送信し、末尾が変わることを確認する（既定は LF）

## Environment (if relevant)
- Browser: Chrome / Edge（Web Serial API）
- OS: macOS
- web-serial-rxjs version (for verification): workspace main
- RxJS version: workspace 依存どおり

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)