### PR TITLE
docs(web-serial-rxjs): audit urls and add docs seo metadata

### DIFF
--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
@@ -225,7 +225,9 @@ gh api -X PATCH repos/gurezo/web-serial-rxjs -f homepage='https://gurezo.net/web
 gh api -X DELETE repos/gurezo/web-serial-rxjs/pages
 ```
 
-旧 GitHub Pages ホストからの HTTP redirect（必要な場合）は GitHub Pages / DNS / portal 側の設定であり、本リポジトリの静的 fragment の責務ではない。
+Pages 無効化後（`has_pages: false`）も、`https://gurezo.github.io/web-serial-rxjs/` はしばらくキャッシュ応答を返すことがある。当該ホストは非公式として扱い、依存しない。旧 GitHub Pages ホストからの HTTP redirect（必要な場合）は GitHub Pages / DNS / portal 側の設定であり、本リポジトリの静的 fragment の責務ではない。
+
+**#524 検証メモ（2026-08-05）:** GitHub Website URL は `https://gurezo.net/web-serial-rxjs/`、Pages は無効化済み。主要な `gurezo.net` docs / examples URL は 200。`guide/*/troubleshooting.html` は `gurezo/portal` が最新 artifact を再取り込むまで 404（#523 の内容は `main` 済み）。ドメインルートの `robots.txt` / `sitemap.xml` は portal follow-up（現状 404）。
 
 ### SEO 責務分担（#524）
 

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
@@ -197,14 +197,45 @@ web-serial-rxjs-static/
 
 `gurezo/portal` は artifact をダウンロードし、`web-serial-rxjs/` を `firebase-public/web-serial-rxjs/` へ配置する。ビルド失敗時は upload ステップに到達しないため、失敗時に artifact は公開されない。
 
-## 公開 Hosting（#151 / #361）
+## 公開 Hosting（#151 / #361 / #524）
 
 | 項目 | 値 |
 | --- | --- |
-| canonical 公開 URL | `https://gurezo.net/web-serial-rxjs/` |
+| canonical 公開 URL | `https://gurezo.net/web-serial-rxjs/` のみ |
 | Hosting | `gurezo/portal` 経由の Firebase Hosting |
 | 本リポジトリ | 静的 artifact の生成と upload のみ（`portal-static-artifact.yml`） |
-| GitHub Pages | 廃止（#361）。本ドキュメントサイト向けに Pages deploy を再有効化しない |
+| GitHub Pages | 廃止（#361 / #524）。本ドキュメントサイト向けに Pages deploy を再有効化しない |
+| 旧 GitHub Pages URL | `https://gurezo.github.io/web-serial-rxjs/` — 非公式・廃止済み。廃止の説明以外ではリンクしない |
+
+### 公開後の URL・メタデータ方針（#524）
+
+`gurezo.net` 公開後も公式導線を次に揃える:
+
+| 対象 | 期待値 |
+| --- | --- |
+| リポジトリ Website URL（GitHub Settings → General → Website） | `https://gurezo.net/web-serial-rxjs/` |
+| GitHub Pages | 無効（Settings → Pages → None）。`main` の `/docs` から公開しない |
+| `package.json` / README / Guide / Examples / issue forms | `https://gurezo.net/web-serial-rxjs/` |
+| Pages deploy workflow | 再追加しない（#361） |
+
+Pages 無効化と Website URL 更新は必要に応じて `gh` で行う:
+
+```bash
+gh api -X PATCH repos/gurezo/web-serial-rxjs -f homepage='https://gurezo.net/web-serial-rxjs/'
+gh api -X DELETE repos/gurezo/web-serial-rxjs/pages
+```
+
+旧 GitHub Pages ホストからの HTTP redirect（必要な場合）は GitHub Pages / DNS / portal 側の設定であり、本リポジトリの静的 fragment の責務ではない。
+
+### SEO 責務分担（#524）
+
+| 関心事 | 責務 | 備考 |
+| --- | --- | --- |
+| docs fragment HTML の `rel=canonical` と Open Graph（`og:title` / `og:url` / `og:description` / `og:type`） | 本リポジトリ | `pnpm run docs` で注入（サイト index、examples index、Guide、API Reference） |
+| ドメインルートの `robots.txt` / `sitemap.xml` | `gurezo/portal` | `web-serial-rxjs` portal fragment には含めない。portal 側 follow-up として追跡する |
+| 旧 Pages → `gurezo.net` の redirect | GitHub Pages / portal / DNS | 方針のみここに記載。実装は fragment 外 |
+
+`troubleshooting.html` などが `main` に存在するのに `gurezo.net` で 404 の場合は、`gurezo/portal` で最新の `web-serial-rxjs-static` artifact を再取り込みする（本リポジトリは artifact upload まで）。
 
 ## Issue 間の責務境界
 
@@ -226,6 +257,7 @@ web-serial-rxjs-static/
 | **#151** | Firebase Hosting 移行の親（レイアウトは本リポ、最終 deploy は portal） |
 | **#360** | docs + examples の静的 artifact 集約 workflow |
 | **#361** | URL 更新と GitHub Pages 停止 |
+| **#524** | 公開後の URL / メタデータ監査、docs HTML の canonical + OGP、Pages / Website 設定 |
 
 ## 後続 Issue 向けチェックリスト
 
@@ -243,6 +275,7 @@ web-serial-rxjs-static/
 - [x] **#359** — Vue example を `dist/portal/web-serial-rxjs/examples/vue/` に出力
 - [x] **#360** — GitHub Actions で `web-serial-rxjs-static` artifact を upload
 - [x] **#361** — 公式 URL を `gurezo.net` に更新し、GitHub Pages deploy workflow を削除
+- [ ] **#524** — URL / メタデータ監査、docs canonical + OGP、Pages 無効化、portal SEO follow-up の文書化
 - [ ] **#151** — `gurezo/portal` 経由で公開（内部パスは再定義しない）
 
 ## 参照
@@ -258,7 +291,9 @@ web-serial-rxjs-static/
 - [Portal Vue example #359](https://github.com/gurezo/web-serial-rxjs/issues/359)
 - [Portal static artifact CI #360](https://github.com/gurezo/web-serial-rxjs/issues/360)
 - [URL 更新と GitHub Pages 停止 #361](https://github.com/gurezo/web-serial-rxjs/issues/361)
+- [公開後の URL / メタデータ監査 #524](https://github.com/gurezo/web-serial-rxjs/issues/524)
 - [Firebase 移行親 #151](https://github.com/gurezo/web-serial-rxjs/issues/151)
+- [ユーザビリティ親 #516](https://github.com/gurezo/web-serial-rxjs/issues/516)
 - [TypeDoc 設定](../typedoc.json)
 - [Portal static artifact workflow](../../../.github/workflows/portal-static-artifact.yml)
 - [English version](./ARCHITECTURE.md)

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.md
@@ -197,14 +197,45 @@ web-serial-rxjs-static/
 
 `gurezo/portal` downloads the artifact and places `web-serial-rxjs/` under `firebase-public/web-serial-rxjs/`. Build failure skips the upload step, so no artifact is published on failure.
 
-## Public hosting (#151 / #361)
+## Public hosting (#151 / #361 / #524)
 
 | Item | Value |
 | --- | --- |
-| Canonical public URL | `https://gurezo.net/web-serial-rxjs/` |
+| Canonical public URL | `https://gurezo.net/web-serial-rxjs/` only |
 | Hosting | Firebase Hosting via `gurezo/portal` |
 | This repo | Builds and uploads static artifact only (`portal-static-artifact.yml`) |
-| GitHub Pages | Retired (#361). Do not re-enable Pages deploy for this documentation site. |
+| GitHub Pages | Retired (#361 / #524). Do not re-enable Pages deploy for this documentation site. |
+| Former GitHub Pages URL | `https://gurezo.github.io/web-serial-rxjs/` — unofficial / retired. Do not link to it except when documenting retirement. |
+
+### Post-publish URL and metadata policy (#524)
+
+After publishing on `gurezo.net`, keep official entry points aligned:
+
+| Surface | Expected value |
+| --- | --- |
+| Repository Website URL (GitHub Settings → General → Website) | `https://gurezo.net/web-serial-rxjs/` |
+| GitHub Pages | Disabled (Settings → Pages → None). Do not publish from `main` `/docs`. |
+| `package.json` / README / Guide / Examples / issue forms | `https://gurezo.net/web-serial-rxjs/` |
+| Pages deploy workflow | Must not be re-added (#361) |
+
+Disable Pages and update the Website URL with `gh` when needed:
+
+```bash
+gh api -X PATCH repos/gurezo/web-serial-rxjs -f homepage='https://gurezo.net/web-serial-rxjs/'
+gh api -X DELETE repos/gurezo/web-serial-rxjs/pages
+```
+
+HTTP redirects from the former GitHub Pages host (if any) are owned by GitHub Pages / DNS / portal configuration, not by this repository's static fragment.
+
+### SEO responsibility split (#524)
+
+| Concern | Owner | Notes |
+| --- | --- | --- |
+| `rel=canonical` and Open Graph (`og:title`, `og:url`, `og:description`, `og:type`) on docs fragment HTML | This repository | Injected during `pnpm run docs` (site index, examples index, Guide, API Reference) |
+| Domain-root `robots.txt` / `sitemap.xml` | `gurezo/portal` | Not part of the `web-serial-rxjs` portal fragment. Track as a portal follow-up. |
+| Former Pages → `gurezo.net` redirect | GitHub Pages / portal / DNS | Documented here; implementation is outside this fragment |
+
+When Guide pages such as `troubleshooting.html` exist on `main` but return 404 on `gurezo.net`, re-import the latest `web-serial-rxjs-static` artifact in `gurezo/portal` (this repository only uploads the artifact).
 
 ## Issue boundaries
 
@@ -226,6 +257,7 @@ web-serial-rxjs-static/
 | **#151** | Firebase Hosting migration parent (layout here; final deploy via portal) |
 | **#360** | Aggregate static artifact workflow (docs + examples) |
 | **#361** | URL updates and GitHub Pages shutdown |
+| **#524** | Post-publish URL / metadata audit; docs HTML canonical + OGP; Pages / Website settings |
 
 ## Checklist for downstream issues
 
@@ -243,6 +275,7 @@ web-serial-rxjs-static/
 - [x] **#359** — Emit Vue example at `dist/portal/web-serial-rxjs/examples/vue/`
 - [x] **#360** — Upload `web-serial-rxjs-static` artifact via GitHub Actions
 - [x] **#361** — Point official URLs at `gurezo.net`; remove GitHub Pages deploy workflow
+- [ ] **#524** — Audit URLs / metadata; add docs canonical + OGP; disable Pages; document portal SEO follow-up
 - [ ] **#151** — Publish via `gurezo/portal` without redefining internal paths
 
 ## References
@@ -258,7 +291,9 @@ web-serial-rxjs-static/
 - [Portal Vue example #359](https://github.com/gurezo/web-serial-rxjs/issues/359)
 - [Portal static artifact CI #360](https://github.com/gurezo/web-serial-rxjs/issues/360)
 - [URL updates and GitHub Pages shutdown #361](https://github.com/gurezo/web-serial-rxjs/issues/361)
+- [Post-publish URL / metadata audit #524](https://github.com/gurezo/web-serial-rxjs/issues/524)
 - [Firebase migration parent #151](https://github.com/gurezo/web-serial-rxjs/issues/151)
+- [Usability parent #516](https://github.com/gurezo/web-serial-rxjs/issues/516)
 - [TypeDoc configuration](../typedoc.json)
 - [Portal static artifact workflow](../../../.github/workflows/portal-static-artifact.yml)
 - [日本語版](./ARCHITECTURE.ja.md)

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.md
@@ -225,7 +225,9 @@ gh api -X PATCH repos/gurezo/web-serial-rxjs -f homepage='https://gurezo.net/web
 gh api -X DELETE repos/gurezo/web-serial-rxjs/pages
 ```
 
-HTTP redirects from the former GitHub Pages host (if any) are owned by GitHub Pages / DNS / portal configuration, not by this repository's static fragment.
+After Pages is disabled (`has_pages: false`), `https://gurezo.github.io/web-serial-rxjs/` may still return cached responses for a while. Treat that host as unofficial; do not rely on it. HTTP redirects from the former GitHub Pages host (if any) are owned by GitHub Pages / DNS / portal configuration, not by this repository's static fragment.
+
+**#524 verification notes (2026-08-05):** GitHub Website URL points at `https://gurezo.net/web-serial-rxjs/`; Pages is disabled. Primary `gurezo.net` docs / examples URLs return 200. `guide/*/troubleshooting.html` still 404 until `gurezo/portal` re-imports the latest artifact (#523 content is on `main`). Domain-root `robots.txt` / `sitemap.xml` remain portal follow-ups (currently 404).
 
 ### SEO responsibility split (#524)
 

--- a/packages/web-serial-rxjs/scripts/build-docs-index.mjs
+++ b/packages/web-serial-rxjs/scripts/build-docs-index.mjs
@@ -103,7 +103,12 @@ session.lines$.subscribe((line) => console.log(line));
 </div>
 </div>`;
 
-const html = `${buildTypeDocHead({ title, assetBase, dataBase })}
+const html = `${buildTypeDocHead({
+  title,
+  assetBase,
+  dataBase,
+  canonicalPath: 'index.html',
+})}
 ${buildTypeDocBodyStart({
   title,
   titleHref: 'index.html',

--- a/packages/web-serial-rxjs/scripts/build-examples-index.mjs
+++ b/packages/web-serial-rxjs/scripts/build-examples-index.mjs
@@ -67,7 +67,12 @@ ${cards}
 </div>
 </div>`;
 
-const html = `${buildTypeDocHead({ title, assetBase, dataBase })}
+const html = `${buildTypeDocHead({
+  title,
+  assetBase,
+  dataBase,
+  canonicalPath: 'examples/',
+})}
 ${buildTypeDocBodyStart({
   title,
   titleHref: '../index.html',

--- a/packages/web-serial-rxjs/scripts/docs-theme.mjs
+++ b/packages/web-serial-rxjs/scripts/docs-theme.mjs
@@ -13,6 +13,75 @@ const PAGE_LABELS = {
   },
 };
 
+/** Canonical public origin for the documentation site (#524). */
+export const PUBLIC_DOCS_ORIGIN = 'https://gurezo.net/web-serial-rxjs';
+
+export const DEFAULT_DOCS_DESCRIPTION = 'Documentation for web-serial-rxjs';
+
+export function escapeHtmlAttr(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+/**
+ * Build an absolute public URL from a path relative to the docs site root.
+ * @param {string} canonicalPath e.g. '' | 'index.html' | 'guide/en/README.html' | 'examples/' | 'api/modules.html'
+ */
+export function publicDocsUrl(canonicalPath = '') {
+  const normalized = String(canonicalPath).replace(/^\//, '');
+  if (!normalized || normalized === 'index.html') {
+    return `${PUBLIC_DOCS_ORIGIN}/`;
+  }
+  return `${PUBLIC_DOCS_ORIGIN}/${normalized}`;
+}
+
+/**
+ * Canonical + Open Graph tags for docs fragment HTML (#524).
+ */
+export function buildSeoMetaTags({
+  title,
+  canonicalPath,
+  description = DEFAULT_DOCS_DESCRIPTION,
+}) {
+  const canonicalUrl = publicDocsUrl(canonicalPath);
+  const safeTitle = escapeHtmlAttr(title);
+  const safeDescription = escapeHtmlAttr(description);
+  const safeUrl = escapeHtmlAttr(canonicalUrl);
+
+  return [
+    `<link rel="canonical" href="${safeUrl}"/>`,
+    `<meta property="og:title" content="${safeTitle}"/>`,
+    `<meta property="og:description" content="${safeDescription}"/>`,
+    `<meta property="og:url" content="${safeUrl}"/>`,
+    `<meta property="og:type" content="website"/>`,
+  ].join('');
+}
+
+/**
+ * Inject SEO meta before `</head>`. Skips when canonical is already present.
+ */
+export function injectSeoMetaTags(html, options) {
+  if (/rel=["']canonical["']/i.test(html)) {
+    return html;
+  }
+  if (!/<\/head>/i.test(html)) {
+    return html;
+  }
+  return html.replace(/<\/head>/i, `${buildSeoMetaTags(options)}</head>`);
+}
+
+export function extractHtmlTitle(html, fallback = 'web-serial-rxjs') {
+  const match = html.match(/<title>([^<]*)<\/title>/i);
+  if (!match) {
+    return fallback;
+  }
+  const title = match[1].trim();
+  return title || fallback;
+}
+
 export function buildToolbarLinks({
   locale,
   guideIndexHref,
@@ -25,8 +94,19 @@ export function buildToolbarLinks({
   return `<div id="tsd-toolbar-links"><a href="${guideIndexHref}">${labels.guideIndex}</a><a href="${otherLocaleHref}">${labels.otherLocale}</a><a href="${apiHref}">${labels.apiReference}</a><a href="${siteIndexHref}">${labels.siteTop}</a></div>`;
 }
 
-export function buildTypeDocHead({ title, assetBase, dataBase = assetBase }) {
-  return `<!DOCTYPE html><html class="default" lang="en" data-base="${dataBase}"><head><meta charset="utf-8"/><meta http-equiv="x-ua-compatible" content="IE=edge"/><title>${title}</title><meta name="description" content="Documentation for web-serial-rxjs"/><meta name="viewport" content="width=device-width, initial-scale=1"/><link rel="stylesheet" href="${assetBase}assets/style.css"/><link rel="stylesheet" href="${assetBase}assets/highlight.css"/><script defer src="${assetBase}assets/main.js"></script><script async src="${assetBase}assets/icons.js" id="tsd-icons-script"></script><script async src="${assetBase}assets/search.js" id="tsd-search-script"></script><script async src="${assetBase}assets/navigation.js" id="tsd-nav-script"></script><script async src="${assetBase}assets/hierarchy.js" id="tsd-hierarchy-script"></script><link rel="stylesheet" href="${assetBase}assets/rhineai-style.css"/></head>`;
+export function buildTypeDocHead({
+  title,
+  assetBase,
+  dataBase = assetBase,
+  canonicalPath,
+  description = DEFAULT_DOCS_DESCRIPTION,
+}) {
+  const seo =
+    canonicalPath !== undefined
+      ? buildSeoMetaTags({ title, canonicalPath, description })
+      : '';
+
+  return `<!DOCTYPE html><html class="default" lang="en" data-base="${dataBase}"><head><meta charset="utf-8"/><meta http-equiv="x-ua-compatible" content="IE=edge"/><title>${escapeHtmlAttr(title)}</title><meta name="description" content="${escapeHtmlAttr(description)}"/><meta name="viewport" content="width=device-width, initial-scale=1"/>${seo}<link rel="stylesheet" href="${assetBase}assets/style.css"/><link rel="stylesheet" href="${assetBase}assets/highlight.css"/><script defer src="${assetBase}assets/main.js"></script><script async src="${assetBase}assets/icons.js" id="tsd-icons-script"></script><script async src="${assetBase}assets/search.js" id="tsd-search-script"></script><script async src="${assetBase}assets/navigation.js" id="tsd-nav-script"></script><script async src="${assetBase}assets/hierarchy.js" id="tsd-hierarchy-script"></script><link rel="stylesheet" href="${assetBase}assets/rhineai-style.css"/></head>`;
 }
 
 export function buildTypeDocBodyStart({ title, titleHref, toolbarLinks, assetBase }) {

--- a/packages/web-serial-rxjs/scripts/patch-docs-assets.mjs
+++ b/packages/web-serial-rxjs/scripts/patch-docs-assets.mjs
@@ -1,13 +1,15 @@
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
+import { join, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import zlib from 'node:zlib';
 import { buildDocumentUrlMap } from './docs-paths.mjs';
+import { extractHtmlTitle, injectSeoMetaTags } from './docs-theme.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const apiAssetsRoot = join(__dirname, '../../../docs/api/assets');
 const apiRoot = join(__dirname, '../../../docs/api');
+const docsRoot = join(__dirname, '../../../docs');
 
 const urlMap = buildDocumentUrlMap();
 
@@ -63,12 +65,23 @@ patchCompressedAsset(join(apiAssetsRoot, 'search.js'), 'searchData');
 patchCompressedAsset(join(apiAssetsRoot, 'navigation.js'), 'navigationData');
 
 let htmlUpdated = 0;
+let seoUpdated = 0;
 for (const htmlFile of collectHtmlFiles(apiRoot)) {
   const original = readFileSync(htmlFile, 'utf8');
   let next = original;
 
   for (const [from, to] of urlMap.entries()) {
     next = next.replaceAll(from, to);
+  }
+
+  const docsRelPath = relative(docsRoot, htmlFile).split('\\').join('/');
+  const withSeo = injectSeoMetaTags(next, {
+    title: extractHtmlTitle(next),
+    canonicalPath: docsRelPath,
+  });
+  if (withSeo !== next) {
+    seoUpdated += 1;
+    next = withSeo;
   }
 
   if (next !== original) {
@@ -78,3 +91,4 @@ for (const htmlFile of collectHtmlFiles(apiRoot)) {
 }
 
 console.log(`Updated document links in ${htmlUpdated} API HTML files.`);
+console.log(`Injected canonical/OGP meta in ${seoUpdated} API HTML files.`);

--- a/packages/web-serial-rxjs/scripts/relocate-typedoc-guide.mjs
+++ b/packages/web-serial-rxjs/scripts/relocate-typedoc-guide.mjs
@@ -12,7 +12,12 @@ import {
   rewriteTypedocDocumentHref,
   typedocFilenameToGuideRelPath,
 } from './docs-paths.mjs';
-import { buildToolbarLinks } from './docs-theme.mjs';
+import {
+  buildSeoMetaTags,
+  buildToolbarLinks,
+  extractHtmlTitle,
+  injectSeoMetaTags,
+} from './docs-theme.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -41,13 +46,18 @@ function buildDocumentRedirectHtml({ locale, guideRelPath }) {
     locale === 'ja'
       ? 'ガイドページへ移動しています…'
       : 'Redirecting to the guide page…';
+  const seo = buildSeoMetaTags({
+    title: 'Redirecting…',
+    canonicalPath: guideRelPath,
+    description: 'Redirecting to the guide page.',
+  });
 
   return `<!DOCTYPE html>
 <html lang="${lang}">
 <head>
   <meta charset="utf-8">
   <meta http-equiv="refresh" content="0; url=${href}">
-  <link rel="canonical" href="${href}">
+  ${seo}
   <title>Redirecting…</title>
 </head>
 <body>
@@ -110,6 +120,11 @@ function rewriteGuideHtml(html, { locale, pagePath, guideRelPath }) {
 
   const lang = locale === 'ja' ? 'ja' : 'en';
   next = next.replace(/<html class="default" lang="en"/, `<html class="default" lang="${lang}"`);
+
+  next = injectSeoMetaTags(next, {
+    title: extractHtmlTitle(next),
+    canonicalPath: guideRelPath,
+  });
 
   return next;
 }


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): audit urls and add docs seo metadata

## Summary
`gurezo.net` 公開後の URL・メタデータ・旧 GitHub Pages 導線を監査し、docs 生成 HTML に canonical / OGP を追加しました。robots/sitemap は portal 責務として ARCHITECTURE に明文化しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #524
- Parent: #516

## What changed?
- ARCHITECTURE（en/ja）に旧 Pages 方針、SEO 責務分担、#524 検証メモを追記
- docs 生成 HTML（サイト index / examples index / Guide / API）へ `rel=canonical` と OGP（`og:title` / `og:url` / `og:description` / `og:type`）を注入
- GitHub リポジトリ Website URL を `https://gurezo.net/web-serial-rxjs/` に更新し、GitHub Pages を無効化

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs` を実行し、`docs/index.html` / `docs/examples/index.html` / `docs/guide/en/README.html` / `docs/api/index.html` に canonical と og タグが含まれることを確認する
2. `pnpm run docs:check-links`（`pnpm run docs` 内）が成功することを確認する
3. GitHub リポジトリ Settings で Website が `https://gurezo.net/web-serial-rxjs/`、Pages が Disabled であることを確認する
4. 主要公開 URL（docs / examples / 各 example）が 200 であることを確認する
5. `guide/*/troubleshooting.html` が 404 の場合は `gurezo/portal` での artifact 再取り込みが必要なこと（#523 は main 済み）を認識する
6. `https://gurezo.net/robots.txt` / `sitemap.xml` は portal follow-up（現状 404）であることを認識する

## Environment (if relevant)
- Browser: N/A（静的 docs / リポジトリ設定）
- OS: macOS
- web-serial-rxjs version (for verification): main
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)