### PR TITLE
docs(web-serial-rxjs): add request-response recipe

### DIFF
--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -8,10 +8,11 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 
 1. **[Overview](./overview.md)** — `SerialSession` public surface, role of `state$` / `errors$`, minimal sample
 2. **[Quick Start](./quick-start.md)** — installation, connect, receive/send, disconnect/dispose, error handling
-3. **[Advanced Usage](./advanced-usage.md)** — line framing, request/response-style flows, recovery
-4. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
-5. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
-6. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
+3. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
+4. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
+5. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
+6. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
+7. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
 
 When migrating existing code:
 
@@ -26,6 +27,7 @@ When migrating existing code:
 | **[Overview](./overview.md)** | Public surface quick reference, feature summary, minimal sample |
 | **[Quick Start](./quick-start.md)** | Basic flow from installation through disconnect |
 | **[Advanced Usage](./advanced-usage.md)** | Application patterns and RxJS recipes |
+| **[Request / Response](./request-response.md)** | Command + matching reply on `lines$` / `receive$` (no core `request$`) |
 | **[API concepts and design notes](./concepts.md)** | Options, error codes, type tables, swappable `SerialSession` contract, [supported data](./concepts.md#supported-data-text--binary--charset) |
 | **[Hardware-free testing](./testing.md)** | Controllable Fake `SerialSession`, Vitest / Angular / React examples (npm: not bundled) |
 | **[Troubleshooting](./troubleshooting.md)** | Common problems, check steps, and what to report |

--- a/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md
+++ b/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md
@@ -1,6 +1,6 @@
 # Advanced Usage
 
-`SerialSession` intentionally exposes a small surface. Most "advanced" workflows are expressed by composing plain RxJS operators over `receive$` and `send$`. If you are new to the API, read [SerialSession overview](./overview.md#serialsession-at-a-glance) and [Quick Start](./quick-start.md) first; this page focuses on **recipes** (line framing, derived streams, and recovery) that the overview defers on purpose. For lifecycle and error patterns, prefer `state$` with `state.status` narrowing and `errors$` with `error.is()` — see [Migrating to v3](./migration-v3.md). For swapping the concrete session via DI or test fakes, see [Swappable public contract](./concepts.md#swappable-public-contract-decision-536) and [Hardware-free testing with a Fake SerialSession](./testing.md).
+`SerialSession` intentionally exposes a small surface. Most "advanced" workflows are expressed by composing plain RxJS operators over `receive$` and `send$`. If you are new to the API, read [SerialSession overview](./overview.md#serialsession-at-a-glance) and [Quick Start](./quick-start.md) first; this page focuses on **recipes** (line framing, derived streams, and recovery) that the overview defers on purpose. For **command + matching reply** flows (`lines$` / `receive$`, wait-then-send, `concatMap` serialization), see the dedicated [Request / Response recipes](./request-response.md). For lifecycle and error patterns, prefer `state$` with `state.status` narrowing and `errors$` with `error.is()` — see [Migrating to v3](./migration-v3.md). For swapping the concrete session via DI or test fakes, see [Swappable public contract](./concepts.md#swappable-public-contract-decision-536) and [Hardware-free testing with a Fake SerialSession](./testing.md).
 
 This page maps directly to [issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228): built-in **`lines$`** and the imperative methods cover common cases. Prefer **`state$`** narrowing for connection UI. Patterns such as **`sendLine`**, **`readUntil`**, and **`waitForState`** are still things you build on the core API (no extra exports for those). For a real-world serial-console style app, see [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) (Web Serial over USB OTG); the same recipes apply when you reimplement its read/write loop with `SerialSession`.
 
@@ -102,6 +102,8 @@ from(commands)
 ```
 
 ## readUntil pattern (`readUntil$` / prompt-style reads)
+
+For the full Request / Response recipe (line waits, send-vs-timeout errors, `concatMap` serialization), see **[Request / Response recipes](./request-response.md)**. The snippets below are a short `receive$` prompt-style primer.
 
 `receive$` delivers **chunks**, not logical messages. A **read-until** pattern accumulates text until a predicate (delimiter, regex, prompt) matches. Because `receive$` is hot and does not replay past chunks to late subscribers, **start waiting on `receive$` before you `send$`** if the device may respond immediately.
 

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -126,7 +126,8 @@ In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscr
 | **[日本語 Guide 索引](../ja/README.md)** | Getting Started の読み順と一覧。 |
 | **Repository [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md)** | Monorepo overview, examples index, and contribution links. |
 | **[Quick Start](./quick-start.md)** | Shortest path to a working open port and subscriptions. |
-| **[Advanced Usage](./advanced-usage.md)** | Line framing, request/response-style flows, and recovery. |
+| **[Advanced Usage](./advanced-usage.md)** | Line framing, derived streams, and recovery. |
+| **[Request / Response](./request-response.md)** | Command + matching reply on `lines$` / `receive$`. |
 | **[Troubleshooting](./troubleshooting.md)** | Common Web Serial / session problems and self-help checks. |
 | **[API Reference (TypeDoc)](modules.html)** | Options, `SerialSessionState`, and `SerialError` details; narrative tables also in [concepts](./concepts.md). |
 | **[v2 → v3 Migration Guide](./migration-v3.md)** ([日本語](../ja/migration-v3.md)) | `state$` discriminated union, `SerialSessionStatus`, and `context.cause`. |

--- a/packages/web-serial-rxjs/docs/guide/en/request-response.md
+++ b/packages/web-serial-rxjs/docs/guide/en/request-response.md
@@ -1,0 +1,217 @@
+# Request / Response recipes
+
+Serial devices often expect a **command**, then a **matching reply** (a line, a prompt, or a terminator). This recipe shows how to build that flow with plain RxJS on top of `SerialSession` — **without** adding a core `request$()` API.
+
+Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#538](https://github.com/gurezo/web-serial-rxjs/issues/538) · Related: [Hardware-free testing](./testing.md) · Follow-up: timeout / cancel / retry ([#539](https://github.com/gurezo/web-serial-rxjs/issues/539))
+
+## Scope decision
+
+| Item | Decision |
+| --- | --- |
+| Core API | **No** dedicated `request$()` (compose RxJS yourself) |
+| npm package | Helpers below are **not** published exports |
+| How to use | Copy the patterns into your app, or keep a local helper |
+| Repo reference | [`tests/helpers/request-response-recipes.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/request-response-recipes.ts) (CI examples only) |
+
+RxJS composition is enough for common command/reply protocols. A future core helper would only be justified if many apps need the same correlation / framing rules.
+
+## Choose `lines$` or `receive$`
+
+| Stream | Use when |
+| --- | --- |
+| `lines$` | Newline-delimited replies (`OK`, status lines, parsers) |
+| `receive$` | Prompts / terminators **without** a trailing newline, terminals, `\r` redraws |
+
+## Critical ordering: wait, then send
+
+`lines$` and `receive$` are **hot** and do not replay past emissions. If the device replies immediately, **start the wait subscription before `send$`**.
+
+```typescript
+import { filter, firstValueFrom, take, timeout } from 'rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+
+async function requestOk(session: SerialSession, cmd: string): Promise<string> {
+  const waitForOk$ = session.lines$.pipe(
+    filter((line) => line === 'OK'),
+    take(1),
+    timeout({ first: 3000 }),
+  );
+
+  // 1) Start waiting (subscription via firstValueFrom)
+  const replyPromise = firstValueFrom(waitForOk$);
+  // 2) Then send
+  await firstValueFrom(session.send$(cmd));
+  return replyPromise;
+}
+```
+
+Sending first and waiting afterward can miss a fast reply.
+
+## Line-oriented patterns (`lines$`)
+
+### Exact line, substring, RegExp
+
+```typescript
+import { filter, take, timeout } from 'rxjs';
+
+// Exact
+const waitExact$ = session.lines$.pipe(
+  filter((line) => line === 'OK'),
+  take(1),
+  timeout({ first: 3000 }),
+);
+
+// Substring
+const waitContains$ = session.lines$.pipe(
+  filter((line) => line.includes('ready')),
+  take(1),
+  timeout({ first: 3000 }),
+);
+
+// RegExp
+const waitRegex$ = session.lines$.pipe(
+  filter((line) => /^VERSION=\d+$/.test(line)),
+  take(1),
+  timeout({ first: 3000 }),
+);
+```
+
+`take(1)` completes the subscription after the first match — no leftover listeners.
+
+### Copy-paste helper: `requestLine$`
+
+```typescript
+import {
+  Observable,
+  filter,
+  take,
+  timeout,
+} from 'rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+import type { SerialPayload } from '@gurezo/web-serial-rxjs';
+
+type LineMatcher = string | RegExp | ((line: string) => boolean);
+
+function matchesLine(matcher: LineMatcher, line: string): boolean {
+  if (typeof matcher === 'function') return matcher(line);
+  if (typeof matcher === 'string') return line === matcher;
+  return matcher.test(line);
+}
+
+function waitForLine$(
+  session: SerialSession,
+  matcher: LineMatcher,
+  timeoutMs = 3000,
+): Observable<string> {
+  return session.lines$.pipe(
+    filter((line) => matchesLine(matcher, line)),
+    take(1),
+    timeout({ first: timeoutMs }),
+  );
+}
+
+function requestLine$(
+  session: SerialSession,
+  payload: SerialPayload,
+  matcher: LineMatcher,
+  timeoutMs = 3000,
+): Observable<string> {
+  return new Observable<string>((subscriber) => {
+    const waitSub = waitForLine$(session, matcher, timeoutMs).subscribe({
+      next: (value) => {
+        subscriber.next(value);
+        subscriber.complete();
+      },
+      error: (error) => subscriber.error(error),
+    });
+
+    const sendSub = session.send$(payload).subscribe({
+      error: (error) => {
+        waitSub.unsubscribe();
+        subscriber.error(error);
+      },
+    });
+
+    return () => {
+      waitSub.unsubscribe();
+      sendSub.unsubscribe();
+    };
+  });
+}
+```
+
+## Chunk / prompt patterns (`receive$`)
+
+Accumulate chunks until a prompt or terminator appears:
+
+```typescript
+import { filter, scan, take, timeout } from 'rxjs';
+
+const waitPrompt$ = session.receive$.pipe(
+  scan((buffer, chunk) => buffer + chunk, ''),
+  filter((buffer) => /device>\s*$/.test(buffer)),
+  take(1),
+  timeout({ first: 5000 }),
+);
+```
+
+Same wait-then-send rule as `lines$`. See also [Advanced Usage – readUntil](./advanced-usage.md#readuntil-pattern-readuntil--prompt-style-reads).
+
+## Send failure vs response timeout
+
+| Failure | Type | Typical cause |
+| --- | --- | --- |
+| Write / `send$` | `SerialError` | Port closed, write failed |
+| No matching reply | RxJS `TimeoutError` | Device silent or matcher wrong |
+
+```typescript
+import { TimeoutError, firstValueFrom } from 'rxjs';
+import { SerialError } from '@gurezo/web-serial-rxjs';
+
+try {
+  await firstValueFrom(requestLine$(session, 'AT\r\n', 'OK'));
+} catch (error) {
+  if (error instanceof SerialError) {
+    // send failed — do not treat as "device did not answer"
+  } else if (error instanceof TimeoutError) {
+    // waited, but no matching line
+  } else {
+    throw error;
+  }
+}
+```
+
+Cancel / retry / backoff policies belong in [#539](https://github.com/gurezo/web-serial-rxjs/issues/539).
+
+## Serialize multiple commands: `concatMap` vs `switchMap`
+
+Protocols **without** correlation IDs should run requests **one at a time**. Prefer `concatMap`. `switchMap` cancels the previous wait when a new command starts and can lose replies.
+
+```typescript
+import { concatMap, from } from 'rxjs';
+
+from([
+  { payload: 'CMD1\r\n', matcher: 'R1' },
+  { payload: 'CMD2\r\n', matcher: 'R2' },
+]).pipe(
+  concatMap(({ payload, matcher }) =>
+    requestLine$(session, payload, matcher),
+  ),
+);
+```
+
+If the same reply string can arrive as an unsolicited event, decide correlation in your app (sequence numbers, exclusive ownership of the port, etc.).
+
+## Vitest coverage (no hardware)
+
+```bash
+pnpm --filter @gurezo/web-serial-rxjs exec vitest run tests/session/request-response-recipes.test.ts
+```
+
+Drive replies with the Fake from [Hardware-free testing](./testing.md) (`emitLine` / `emitReceive` / `failNextSend`).
+
+## Related
+
+- [Advanced Usage](./advanced-usage.md) — line framing, `readUntil`, ordered writes
+- [Hardware-free testing](./testing.md) — Fake `SerialSession`
+- Follow-up: [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) timeout / cancel / retry

--- a/packages/web-serial-rxjs/docs/guide/en/testing.md
+++ b/packages/web-serial-rxjs/docs/guide/en/testing.md
@@ -14,7 +14,7 @@ Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [
 | How to use | Copy the helper below into your test tree, or keep an equivalent local Fake |
 | Repo reference | [`tests/helpers/fake-serial-session.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/fake-serial-session.ts) (CI examples only; not published) |
 
-A future `@gurezo/web-serial-rxjs/testing` entry may be considered if Request/Response (#538) and timeout recipes (#539) prove a shared helper is worth maintaining. Until then, keep the public surface small.
+A future `@gurezo/web-serial-rxjs/testing` entry may be considered if shared helpers across [Request / Response](./request-response.md) and timeout recipes (#539) prove worth maintaining. Until then, keep the public surface small.
 
 ## Dependency injection pattern
 
@@ -345,4 +345,5 @@ it('reads connected state from Fake', async () => {
 
 - [Swappable public contract](./concepts.md#swappable-public-contract-decision-536)
 - [Advanced Usage](./advanced-usage.md) — compose RxJS on top of `receive$` / `send$`
-- Follow-ups: Request/Response (#538), timeout / cancel / retry (#539)
+- [Request / Response recipes](./request-response.md) — command + matching reply (#538)
+- Follow-up: timeout / cancel / retry (#539)

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -8,10 +8,11 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 
 1. **[概要](./overview.md)** — `SerialSession` の公開面、`state$` / `errors$` の位置付け、最小サンプル
 2. **[クイックスタート](./quick-start.md)** — インストール、接続、受信・送信、切断・破棄、エラーハンドリング
-3. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、擬似リクエスト／レスポンス、リカバリ
-4. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
-5. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
-6. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
+3. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
+4. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
+5. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
+6. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
+7. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
 
 既存コードから移行する場合:
 
@@ -26,6 +27,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | **[概要](./overview.md)** | 公開面の早見表、機能概要、最小サンプル |
 | **[クイックスタート](./quick-start.md)** | インストールから切断までの基本フロー |
 | **[高度な使用方法](./advanced-usage.md)** | 応用パターンと RxJS レシピ |
+| **[Request / Response](./request-response.md)** | コマンド送信後の応答待ち（コア `request$` なし） |
 | **[API の概念と設計メモ](./concepts.md)** | オプション・エラーコード・型の表形式補足、差し替え可能な `SerialSession` 契約、[対応範囲](./concepts.md#対応範囲テキスト--バイナリ--文字コード) |
 | **[実機なしテスト](./testing.md)** | 制御可能な Fake `SerialSession`、Vitest / Angular / React 例（npm 非同梱） |
 | **[トラブルシューティング](./troubleshooting.md)** | よくある問題の確認手順と報告時の情報 |

--- a/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md
@@ -1,6 +1,6 @@
 # 高度な使用方法
 
-`SerialSession` は意図的に小さな公開面に絞られています。応用パターンの大半は、`receive$` と `send$` の上に普通の RxJS オペレータを組み合わせることで表現できます。API の全体像は先に[SerialSession の概要](./overview.md#serialsessionの全体像)と[クイックスタート](./quick-start.md)を読み、本ページは概要で省いた**行フレーミング・派生ストリーム・リカバリ**のレシピに絞ります。ライフサイクルとエラーは `state$` の `state.status` narrowing と `errors$` の `error.is()` を優先してください — [v3 への移行](./migration-v3.md) を参照。DI やテスト用 Fake で具象実装を差し替える場合は、[差し替え可能な公開契約](./concepts.md#差し替え可能な公開契約decision-536)と [Fake SerialSession による実機なしテスト](./testing.md) を参照してください。
+`SerialSession` は意図的に小さな公開面に絞られています。応用パターンの大半は、`receive$` と `send$` の上に普通の RxJS オペレータを組み合わせることで表現できます。API の全体像は先に[SerialSession の概要](./overview.md#serialsessionの全体像)と[クイックスタート](./quick-start.md)を読み、本ページは概要で省いた**行フレーミング・派生ストリーム・リカバリ**のレシピに絞ります。**コマンド送信後の応答待ち**（`lines$` / `receive$`、待ち→送信、`concatMap` 直列化）は専用の [Request / Response レシピ](./request-response.md) を参照してください。ライフサイクルとエラーは `state$` の `state.status` narrowing と `errors$` の `error.is()` を優先してください — [v3 への移行](./migration-v3.md) を参照。DI やテスト用 Fake で具象実装を差し替える場合は、[差し替え可能な公開契約](./concepts.md#差し替え可能な公開契約decision-536)と [Fake SerialSession による実機なしテスト](./testing.md) を参照してください。
 
 本ページは [Issue #228](https://github.com/gurezo/web-serial-rxjs/issues/228) で列挙したパターンに対応します。**`lines$`** は `SerialSession` の組み込みとして用意されています。接続 UI には **`state$`** narrowing を優先してください。**`sendLine`・`readUntil`・`waitForState`** などは、引き続きコア API の上に組み立てるパターンです（専用の追加 export はありません）。USB OTG シリアルコンソールの実例として [CHIRIMEN PiZeroWebSerialConsole](https://github.com/chirimen-oh/PiZeroWebSerialConsole) があります。同アプリの読み書きループを `SerialSession` で書き直すときも、ここでのレシピがそのまま使えます。
 
@@ -100,6 +100,8 @@ from(commands)
 ```
 
 ## readUntil パターン（`readUntil$` / プロンプト待ち）
+
+行待ち・送信エラーとタイムアウトの区別・`concatMap` 直列化を含む正式な Request / Response Recipe は **[Request / Response レシピ](./request-response.md)** を参照してください。以下は `receive$` のプロンプト待ちの短い入門です。
 
 `receive$` は**チャンク**単位であり、メッセージ単位ではありません。**readUntil** はバッファに蓄積したテキストが述語（区切り・正規表現・プロンプト）を満たすまで待ちます。`receive$` はホットで過去チャンクを後から購読しただけでは再現されないため、相手がすぐ応答するなら **`send$` する前に `receive$` 側の待ち受けを開始**してください。
 

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -120,7 +120,8 @@ session.send$('hello\r\n').subscribe();
 | **[English Guide 索引](../en/README.md)** | Getting Started reading order and full index. |
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ全体の目次、サンプル索引、貢献の導線。 |
 | **[クイックスタート](./quick-start.md)** | 最短でポートを開いて購読するところまで。 |
-| **[高度な使用方法](./advanced-usage.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
+| **[高度な使用方法](./advanced-usage.md)** | 行フレーミング、派生ストリーム、リカバリ。 |
+| **[Request / Response](./request-response.md)** | `lines$` / `receive$` でのコマンド送信後の応答待ち。 |
 | **[トラブルシューティング](./troubleshooting.md)** | Web Serial / セッションのよくある問題と自己解決手順。 |
 | **[API Reference（TypeDoc）](../../api/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細。表・図は [概念と設計メモ](./concepts.md) も参照。 |
 | **[v2 → v3 マイグレーション](./migration-v3.md)**（[English](../en/migration-v3.md)） | `state$` discriminated union、`SerialSessionStatus`、`context.cause`。 |

--- a/packages/web-serial-rxjs/docs/guide/ja/request-response.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/request-response.md
@@ -1,0 +1,217 @@
+# Request / Response レシピ
+
+シリアル機器では、**コマンド送信後に条件に合う応答を待つ**流れがよくあります。本 Recipe は、コア API に `request$()` を追加せず、`SerialSession` 上の RxJS 組み合わせでその流れを組み立てる方法を示します。
+
+Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#538](https://github.com/gurezo/web-serial-rxjs/issues/538) · 関連: [実機なしテスト](./testing.md) · 後続: タイムアウト・キャンセル・再試行（[#539](https://github.com/gurezo/web-serial-rxjs/issues/539)）
+
+## スコープの判断
+
+| 項目 | 判断 |
+| --- | --- |
+| コア API | **`request$()` は追加しない**（利用側で RxJS を組み立てる） |
+| npm パッケージ | 下記ヘルパーは **公開 export ではない** |
+| 使い方 | パターンをアプリへコピーするか、同等のローカルヘルパーを置く |
+| リポジトリ参照 | [`tests/helpers/request-response-recipes.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/request-response-recipes.ts)（CI 用の例） |
+
+一般的なコマンド／応答プロトコルには RxJS の組み合わせで足ります。多数のアプリが同じ相関・フレーミング規則を必要とした場合に限り、将来のコアヘルパーを検討します。
+
+## `lines$` と `receive$` の使い分け
+
+| ストリーム | 向いている用途 |
+| --- | --- |
+| `lines$` | 改行区切りの応答（`OK`、ステータス行、パーサ） |
+| `receive$` | **改行なし**のプロンプト／終端、ターミナル、`\r` による再描画 |
+
+## 重要な順序: 先に待ち、その後に送信
+
+`lines$` / `receive$` は **ホット**で、過去の emit を再生しません。機器がすぐに返す場合は、**`send$` の前に待ち受け購読を開始**してください。
+
+```typescript
+import { filter, firstValueFrom, take, timeout } from 'rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+
+async function requestOk(session: SerialSession, cmd: string): Promise<string> {
+  const waitForOk$ = session.lines$.pipe(
+    filter((line) => line === 'OK'),
+    take(1),
+    timeout({ first: 3000 }),
+  );
+
+  // 1) 先に待ち受け開始（firstValueFrom で購読）
+  const replyPromise = firstValueFrom(waitForOk$);
+  // 2) その後に送信
+  await firstValueFrom(session.send$(cmd));
+  return replyPromise;
+}
+```
+
+送信してから待ち始めると、速い応答を取りこぼすことがあります。
+
+## 行指向パターン（`lines$`）
+
+### 完全一致・部分一致・正規表現
+
+```typescript
+import { filter, take, timeout } from 'rxjs';
+
+// 完全一致
+const waitExact$ = session.lines$.pipe(
+  filter((line) => line === 'OK'),
+  take(1),
+  timeout({ first: 3000 }),
+);
+
+// 部分一致
+const waitContains$ = session.lines$.pipe(
+  filter((line) => line.includes('ready')),
+  take(1),
+  timeout({ first: 3000 }),
+);
+
+// 正規表現
+const waitRegex$ = session.lines$.pipe(
+  filter((line) => /^VERSION=\d+$/.test(line)),
+  take(1),
+  timeout({ first: 3000 }),
+);
+```
+
+`take(1)` により、最初の一致で購読が完了します。
+
+### コピー用ヘルパー: `requestLine$`
+
+```typescript
+import {
+  Observable,
+  filter,
+  take,
+  timeout,
+} from 'rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+import type { SerialPayload } from '@gurezo/web-serial-rxjs';
+
+type LineMatcher = string | RegExp | ((line: string) => boolean);
+
+function matchesLine(matcher: LineMatcher, line: string): boolean {
+  if (typeof matcher === 'function') return matcher(line);
+  if (typeof matcher === 'string') return line === matcher;
+  return matcher.test(line);
+}
+
+function waitForLine$(
+  session: SerialSession,
+  matcher: LineMatcher,
+  timeoutMs = 3000,
+): Observable<string> {
+  return session.lines$.pipe(
+    filter((line) => matchesLine(matcher, line)),
+    take(1),
+    timeout({ first: timeoutMs }),
+  );
+}
+
+function requestLine$(
+  session: SerialSession,
+  payload: SerialPayload,
+  matcher: LineMatcher,
+  timeoutMs = 3000,
+): Observable<string> {
+  return new Observable<string>((subscriber) => {
+    const waitSub = waitForLine$(session, matcher, timeoutMs).subscribe({
+      next: (value) => {
+        subscriber.next(value);
+        subscriber.complete();
+      },
+      error: (error) => subscriber.error(error),
+    });
+
+    const sendSub = session.send$(payload).subscribe({
+      error: (error) => {
+        waitSub.unsubscribe();
+        subscriber.error(error);
+      },
+    });
+
+    return () => {
+      waitSub.unsubscribe();
+      sendSub.unsubscribe();
+    };
+  });
+}
+```
+
+## チャンク／プロンプトパターン（`receive$`）
+
+チャンクを蓄積し、プロンプトや終端文字列が現れるまで待ちます。
+
+```typescript
+import { filter, scan, take, timeout } from 'rxjs';
+
+const waitPrompt$ = session.receive$.pipe(
+  scan((buffer, chunk) => buffer + chunk, ''),
+  filter((buffer) => /device>\s*$/.test(buffer)),
+  take(1),
+  timeout({ first: 5000 }),
+);
+```
+
+待ち → 送信の順序は `lines$` と同じです。詳細は [高度な使用方法 – readUntil](./advanced-usage.md#readuntil-パターンreaduntil--プロンプト待ち) も参照してください。
+
+## 送信エラーと応答タイムアウトの区別
+
+| 失敗 | 型 | 典型的な原因 |
+| --- | --- | --- |
+| 書き込み / `send$` | `SerialError` | ポート閉鎖、書き込み失敗 |
+| 一致する応答なし | RxJS `TimeoutError` | 無応答、matcher の誤り |
+
+```typescript
+import { TimeoutError, firstValueFrom } from 'rxjs';
+import { SerialError } from '@gurezo/web-serial-rxjs';
+
+try {
+  await firstValueFrom(requestLine$(session, 'AT\r\n', 'OK'));
+} catch (error) {
+  if (error instanceof SerialError) {
+    // 送信失敗 — 「応答が来なかった」とは別扱い
+  } else if (error instanceof TimeoutError) {
+    // 待ち続けたが一致する行がなかった
+  } else {
+    throw error;
+  }
+}
+```
+
+キャンセル・再試行・バックオフの方針は [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) を参照してください。
+
+## 複数コマンドの直列化: `concatMap` と `switchMap`
+
+**相関 ID のない**プロトコルでは、要求を **1 つずつ** 実行します。`concatMap` を推奨します。`switchMap` は新しいコマンド開始時に直前の待ちをキャンセルするため、応答を取りこぼし得ます。
+
+```typescript
+import { concatMap, from } from 'rxjs';
+
+from([
+  { payload: 'CMD1\r\n', matcher: 'R1' },
+  { payload: 'CMD2\r\n', matcher: 'R2' },
+]).pipe(
+  concatMap(({ payload, matcher }) =>
+    requestLine$(session, payload, matcher),
+  ),
+);
+```
+
+同じ応答文字列が非同期イベントとしても流れる機器では、相関方法（シーケンス番号、ポートの排他など）を利用側で決めてください。
+
+## Vitest カバレッジ（実機なし）
+
+```bash
+pnpm --filter @gurezo/web-serial-rxjs exec vitest run tests/session/request-response-recipes.test.ts
+```
+
+応答の投入には [実機なしテスト](./testing.md) の Fake（`emitLine` / `emitReceive` / `failNextSend`）を使います。
+
+## 関連
+
+- [高度な使用方法](./advanced-usage.md) — 行フレーミング、`readUntil`、順序付き送信
+- [実機なしテスト](./testing.md) — Fake `SerialSession`
+- 後続: [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) タイムアウト・キャンセル・再試行

--- a/packages/web-serial-rxjs/docs/guide/ja/testing.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/testing.md
@@ -14,7 +14,7 @@ Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [
 | 使い方 | 下のヘルパーをテストツリーへコピーするか、同等の Fake をアプリ側で定義する |
 | リポジトリ参照 | [`tests/helpers/fake-serial-session.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/fake-serial-session.ts)（CI 用の例。公開物ではない） |
 
-Request/Response（#538）やタイムアウト Recipe（#539）で共有ヘルパーの必要性が固まった場合に、将来 `@gurezo/web-serial-rxjs/testing` などを検討します。それまでは公開面を小さく保ちます。
+[Request / Response](./request-response.md) やタイムアウト Recipe（#539）で共有ヘルパーの必要性が固まった場合に、将来 `@gurezo/web-serial-rxjs/testing` などを検討します。それまでは公開面を小さく保ちます。
 
 ## 依存の差し替えパターン
 
@@ -345,4 +345,5 @@ it('reads connected state from Fake', async () => {
 
 - [差し替え可能な公開契約](./concepts.md#差し替え可能な公開契約decision-536)
 - [高度な使用方法](./advanced-usage.md) — `receive$` / `send$` 上の RxJS 組み立て
-- 後続: Request/Response（#538）、タイムアウト・キャンセル・再試行（#539）
+- [Request / Response レシピ](./request-response.md) — コマンド送信後の応答待ち（#538）
+- 後続: タイムアウト・キャンセル・再試行（#539）

--- a/packages/web-serial-rxjs/tests/helpers/request-response-recipes.ts
+++ b/packages/web-serial-rxjs/tests/helpers/request-response-recipes.ts
@@ -1,0 +1,179 @@
+import {
+  Observable,
+  TimeoutError,
+  concatMap,
+  filter,
+  from,
+  scan,
+  take,
+  timeout,
+} from 'rxjs';
+import { SerialError } from '../../src/errors/serial-error';
+import type { SerialSession } from '../../src/session/serial-session';
+import type { SerialPayload } from '../../src/types';
+
+/**
+ * Request / Response recipe helpers built on `SerialSession` (Issue #538).
+ *
+ * These helpers are **not** published on npm. Copy the pattern into application
+ * code. They compose plain RxJS over `lines$` / `receive$` / `send$` and do
+ * **not** extend the core public API.
+ *
+ * Critical ordering: start waiting on `lines$` / `receive$` **before**
+ * subscribing to `send$`, because those streams are hot and do not replay.
+ *
+ * @see https://github.com/gurezo/web-serial-rxjs/issues/538
+ */
+
+export type LineMatcher = string | RegExp | ((line: string) => boolean);
+
+export type RequestResponseOptions = {
+  /** First-emission timeout in ms (RxJS `timeout({ first })`). Default: 3000. */
+  timeoutMs?: number;
+};
+
+const DEFAULT_TIMEOUT_MS = 3000;
+
+function matchesLine(matcher: LineMatcher, line: string): boolean {
+  if (typeof matcher === 'function') {
+    return matcher(line);
+  }
+  if (typeof matcher === 'string') {
+    return line === matcher;
+  }
+  return matcher.test(line);
+}
+
+/**
+ * Wait for the next line that matches `matcher` on `session.lines$`.
+ * Completes after one match (`take(1)`).
+ */
+export function waitForLine$(
+  session: SerialSession,
+  matcher: LineMatcher,
+  options: RequestResponseOptions = {},
+): Observable<string> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return session.lines$.pipe(
+    filter((line) => matchesLine(matcher, line)),
+    take(1),
+    timeout({ first: timeoutMs }),
+  );
+}
+
+/**
+ * Accumulate `receive$` chunks until `predicate` matches the buffer, then
+ * emit the buffer and complete.
+ */
+export function waitUntilBuffer$(
+  session: SerialSession,
+  predicate: (buffer: string) => boolean,
+  options: RequestResponseOptions = {},
+): Observable<string> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  return session.receive$.pipe(
+    scan((buffer, chunk) => buffer + chunk, ''),
+    filter(predicate),
+    take(1),
+    timeout({ first: timeoutMs }),
+  );
+}
+
+/**
+ * True when `error` is a write/send failure (`SerialError`).
+ */
+export function isSendFailure(error: unknown): error is SerialError {
+  return error instanceof SerialError;
+}
+
+/**
+ * True when `error` is a response-wait timeout (`TimeoutError`).
+ */
+export function isResponseTimeout(error: unknown): error is TimeoutError {
+  return error instanceof TimeoutError;
+}
+
+/**
+ * Subscribe to a wait pipeline first, then `send$`.
+ * On send failure, unsubscribes the wait so it does not hang until timeout.
+ */
+function sendThenWait$(
+  session: SerialSession,
+  payload: SerialPayload,
+  wait$: Observable<string>,
+): Observable<string> {
+  return new Observable<string>((subscriber) => {
+    const waitSub = wait$.subscribe({
+      next: (value) => {
+        subscriber.next(value);
+        subscriber.complete();
+      },
+      error: (error: unknown) => {
+        subscriber.error(error);
+      },
+    });
+
+    const sendSub = session.send$(payload).subscribe({
+      error: (error: unknown) => {
+        waitSub.unsubscribe();
+        subscriber.error(error);
+      },
+    });
+
+    return () => {
+      waitSub.unsubscribe();
+      sendSub.unsubscribe();
+    };
+  });
+}
+
+/**
+ * Send `payload`, then wait for a matching line.
+ *
+ * Subscribes to the wait pipeline **before** `send$` so a fast device reply
+ * is not missed.
+ */
+export function requestLine$(
+  session: SerialSession,
+  payload: SerialPayload,
+  matcher: LineMatcher,
+  options: RequestResponseOptions = {},
+): Observable<string> {
+  return sendThenWait$(session, payload, waitForLine$(session, matcher, options));
+}
+
+/**
+ * Send `payload`, then wait until the accumulated `receive$` buffer matches
+ * `predicate` (prompt / terminator style).
+ */
+export function requestUntil$(
+  session: SerialSession,
+  payload: SerialPayload,
+  predicate: (buffer: string) => boolean,
+  options: RequestResponseOptions = {},
+): Observable<string> {
+  return sendThenWait$(
+    session,
+    payload,
+    waitUntilBuffer$(session, predicate, options),
+  );
+}
+
+/**
+ * Run multiple request/response pairs **serially** with `concatMap`.
+ * Prefer this over `switchMap` when the protocol has no correlation IDs.
+ */
+export function requestLinesInOrder$(
+  session: SerialSession,
+  commands: ReadonlyArray<{
+    payload: SerialPayload;
+    matcher: LineMatcher;
+  }>,
+  options: RequestResponseOptions = {},
+): Observable<string> {
+  return from(commands).pipe(
+    concatMap(({ payload, matcher }) =>
+      requestLine$(session, payload, matcher, options),
+    ),
+  );
+}

--- a/packages/web-serial-rxjs/tests/session/request-response-recipes.test.ts
+++ b/packages/web-serial-rxjs/tests/session/request-response-recipes.test.ts
@@ -1,0 +1,249 @@
+import {
+  TimeoutError,
+  firstValueFrom,
+  from,
+  switchMap,
+  take,
+  toArray,
+} from 'rxjs';
+import { describe, expect, it } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { createFakeSerialSession } from '../helpers/fake-serial-session';
+import {
+  isResponseTimeout,
+  isSendFailure,
+  requestLine$,
+  requestLinesInOrder$,
+  requestUntil$,
+  waitForLine$,
+  waitUntilBuffer$,
+} from '../helpers/request-response-recipes';
+
+/**
+ * Request / Response recipe scenarios (Issue #538).
+ *
+ * Uses the Fake SerialSession from #537 — no USB hardware required.
+ */
+
+describe('request-response recipes (Issue #538)', () => {
+  it('waits for the next exact line on lines$', async () => {
+    const fake = createFakeSerialSession();
+    const linePromise = firstValueFrom(waitForLine$(fake.session, 'OK'));
+
+    fake.emitLine('BUSY');
+    fake.emitLine('OK');
+
+    await expect(linePromise).resolves.toBe('OK');
+  });
+
+  it('matches lines by substring predicate and RegExp', async () => {
+    const fake = createFakeSerialSession();
+
+    const containsPromise = firstValueFrom(
+      waitForLine$(fake.session, (line) => line.includes('ready')),
+    );
+    fake.emitLine('not yet');
+    fake.emitLine('device ready');
+    await expect(containsPromise).resolves.toBe('device ready');
+
+    const regexPromise = firstValueFrom(
+      waitForLine$(fake.session, /^VERSION=\d+$/),
+    );
+    fake.emitLine('VERSION=x');
+    fake.emitLine('VERSION=42');
+    await expect(regexPromise).resolves.toBe('VERSION=42');
+  });
+
+  it('completes the wait subscription after take(1)', async () => {
+    const fake = createFakeSerialSession();
+    const emissions: string[] = [];
+    let completed = false;
+
+    const sub = waitForLine$(fake.session, 'OK').subscribe({
+      next: (line) => emissions.push(line),
+      complete: () => {
+        completed = true;
+      },
+    });
+
+    fake.emitLine('OK');
+    fake.emitLine('OK');
+
+    expect(emissions).toEqual(['OK']);
+    expect(completed).toBe(true);
+    expect(sub.closed).toBe(true);
+  });
+
+  it('times out when no matching line arrives', async () => {
+    const fake = createFakeSerialSession();
+
+    await expect(
+      firstValueFrom(waitForLine$(fake.session, 'OK', { timeoutMs: 50 })),
+    ).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it('misses a fast reply when send happens before wait (hot stream)', async () => {
+    const fake = createFakeSerialSession();
+
+    await firstValueFrom(fake.session.send$('AT\r\n'));
+    fake.emitLine('OK');
+
+    await expect(
+      firstValueFrom(waitForLine$(fake.session, 'OK', { timeoutMs: 50 })),
+    ).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it('requestLine$ subscribes first then send$ and captures the reply', async () => {
+    const fake = createFakeSerialSession();
+
+    const responsePromise = firstValueFrom(
+      requestLine$(fake.session, 'AT\r\n', 'OK'),
+    );
+
+    queueMicrotask(() => {
+      expect(fake.sent).toEqual(['AT\r\n']);
+      fake.emitLine('OK');
+    });
+
+    await expect(responsePromise).resolves.toBe('OK');
+  });
+
+  it('distinguishes send failure (SerialError) from response timeout', async () => {
+    const fake = createFakeSerialSession();
+    const writeError = new SerialError(
+      SerialErrorCode.WRITE_FAILED,
+      'port closed',
+    );
+    fake.failNextSend(writeError);
+
+    try {
+      await firstValueFrom(requestLine$(fake.session, 'AT\r\n', 'OK'));
+      expect.unreachable('expected send failure');
+    } catch (error) {
+      expect(isSendFailure(error)).toBe(true);
+      expect(isResponseTimeout(error)).toBe(false);
+      expect(error).toBe(writeError);
+    }
+
+    try {
+      await firstValueFrom(
+        requestLine$(fake.session, 'AT\r\n', 'OK', { timeoutMs: 50 }),
+      );
+      expect.unreachable('expected timeout');
+    } catch (error) {
+      expect(isResponseTimeout(error)).toBe(true);
+      expect(isSendFailure(error)).toBe(false);
+    }
+  });
+
+  it('buffers receive$ chunks until a prompt / terminator appears', async () => {
+    const fake = createFakeSerialSession();
+    const bufferPromise = firstValueFrom(
+      waitUntilBuffer$(fake.session, (buf) => /device>\s*$/.test(buf)),
+    );
+
+    fake.emitReceive('hel');
+    fake.emitReceive('lo\r\n');
+    fake.emitReceive('device> ');
+
+    await expect(bufferPromise).resolves.toBe('hello\r\ndevice> ');
+  });
+
+  it('requestUntil$ waits for a terminator after send', async () => {
+    const fake = createFakeSerialSession();
+    const responsePromise = firstValueFrom(
+      requestUntil$(
+        fake.session,
+        'status\r\n',
+        (buf) => buf.includes('END'),
+        { timeoutMs: 500 },
+      ),
+    );
+
+    queueMicrotask(() => {
+      fake.emitReceive('sta');
+      fake.emitReceive('tus\r\nEND');
+    });
+
+    await expect(responsePromise).resolves.toBe('status\r\nEND');
+  });
+
+  it('serializes multiple requests with concatMap (not switchMap)', async () => {
+    const fake = createFakeSerialSession();
+    const replies: string[] = [];
+
+    const run = firstValueFrom(
+      requestLinesInOrder$(
+        fake.session,
+        [
+          { payload: 'CMD1\r\n', matcher: 'R1' },
+          { payload: 'CMD2\r\n', matcher: 'R2' },
+          { payload: 'CMD3\r\n', matcher: 'R3' },
+        ],
+        { timeoutMs: 500 },
+      ).pipe(take(3), toArray()),
+    );
+
+    // Drive replies as each command is recorded
+    const drive = async () => {
+      for (const expected of ['CMD1\r\n', 'CMD2\r\n', 'CMD3\r\n'] as const) {
+        await viWaitUntil(() => fake.sent.includes(expected));
+        const reply =
+          expected === 'CMD1\r\n'
+            ? 'R1'
+            : expected === 'CMD2\r\n'
+              ? 'R2'
+              : 'R3';
+        fake.emitLine(reply);
+        replies.push(reply);
+      }
+    };
+
+    void drive();
+
+    await expect(run).resolves.toEqual(['R1', 'R2', 'R3']);
+    expect(fake.sent).toEqual(['CMD1\r\n', 'CMD2\r\n', 'CMD3\r\n']);
+    expect(replies).toEqual(['R1', 'R2', 'R3']);
+  });
+
+  it('documents why switchMap is unsafe without correlation ids', async () => {
+    const fake = createFakeSerialSession();
+
+    // switchMap cancels the previous wait when a new command starts
+    const lastOnly = firstValueFrom(
+      from([
+        { payload: 'A\r\n', matcher: 'RA' as const },
+        { payload: 'B\r\n', matcher: 'RB' as const },
+      ]).pipe(
+        switchMap(({ payload, matcher }) =>
+          requestLine$(fake.session, payload, matcher, { timeoutMs: 200 }),
+        ),
+        take(1),
+      ),
+    );
+
+    queueMicrotask(() => {
+      fake.emitLine('RA');
+      fake.emitLine('RB');
+    });
+
+    // Only the last in-flight request can win under switchMap
+    await expect(lastOnly).resolves.toBe('RB');
+    expect(fake.sent).toEqual(['A\r\n', 'B\r\n']);
+  });
+});
+
+/** Tiny poll helper to avoid pulling Vitest fake timers into recipe tests. */
+async function viWaitUntil(
+  predicate: () => boolean,
+  timeoutMs = 1000,
+): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('viWaitUntil timed out');
+    }
+    await new Promise((r) => setTimeout(r, 0));
+  }
+}


### PR DESCRIPTION
## Summary
- コマンド送信後に応答を待つ Request / Response の公式 Recipe を日英 Guide に追加しました（#538）
- コア API は拡張せず、`lines$` / `receive$` + RxJS の組み合わせと Fake 利用の Vitest で完了条件を満たします

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #538
- Parent: #535
- Depends on: #537
- Follow-up: #539

## What changed?
- `tests/helpers/request-response-recipes.ts` に行待ち / プロンプト待ち / 直列化ヘルパーを追加（npm 非公開）
- Issue シナリオをカバーする Vitest（`request-response-recipes.test.ts`）を追加
- 日英 Guide `request-response.md` を追加（待ち→送信、送信エラーとタイムアウトの区別、`concatMap` vs `switchMap`）
- Guide README / advanced-usage / testing / overview から導線を更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: なし。ヘルパーは `tests/helpers` と Guide のみ（npm export なし）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm --filter @gurezo/web-serial-rxjs exec vitest run tests/session/request-response-recipes.test.ts`
2. Guide を確認: `packages/web-serial-rxjs/docs/guide/en/request-response.md` / `ja/request-response.md`
3. Guide README / advanced-usage から新ページへのリンクが有効であること

## Environment (if relevant)
- Browser: N/A（実機なし Recipe）
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: workspace

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)