### PR TITLE
docs(web-serial-rxjs): add timeout cancel retry recipe

### DIFF
--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -10,9 +10,10 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 2. **[Quick Start](./quick-start.md)** — installation, connect, receive/send, disconnect/dispose, error handling
 3. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
 4. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
-5. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
-6. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
-7. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
+5. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
+6. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
+7. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
+8. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
 
 When migrating existing code:
 
@@ -28,6 +29,7 @@ When migrating existing code:
 | **[Quick Start](./quick-start.md)** | Basic flow from installation through disconnect |
 | **[Advanced Usage](./advanced-usage.md)** | Application patterns and RxJS recipes |
 | **[Request / Response](./request-response.md)** | Command + matching reply on `lines$` / `receive$` (no core `request$`) |
+| **[Timeout / cancel / retry](./timeout-cancel-retry.md)** | Timeouts, cancel on teardown, limited retry (no core auto-retry) |
 | **[API concepts and design notes](./concepts.md)** | Options, error codes, type tables, swappable `SerialSession` contract, [supported data](./concepts.md#supported-data-text--binary--charset) |
 | **[Hardware-free testing](./testing.md)** | Controllable Fake `SerialSession`, Vitest / Angular / React examples (npm: not bundled) |
 | **[Troubleshooting](./troubleshooting.md)** | Common problems, check steps, and what to report |

--- a/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md
+++ b/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md
@@ -226,7 +226,7 @@ session.errors$.subscribe((error) => {
 
 ## Reconnect On Fatal Error
 
-Because fatal failures drive `state$` to `{ status: 'error', error }`, a reconnect policy is straightforward:
+Because fatal failures drive `state$` to `{ status: 'error', error }`, a reconnect policy is straightforward. Prefer a **limited** retry and never reconnect after `dispose$` — see [Timeout / cancel / retry](./timeout-cancel-retry.md). The snippet below is a minimal sketch; add `retry({ count })`, skip `OPERATION_CANCELLED`, and stop when `status === 'disposed'`.
 
 ```typescript
 import { filter, concatMap } from 'rxjs';

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -128,6 +128,7 @@ In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscr
 | **[Quick Start](./quick-start.md)** | Shortest path to a working open port and subscriptions. |
 | **[Advanced Usage](./advanced-usage.md)** | Line framing, derived streams, and recovery. |
 | **[Request / Response](./request-response.md)** | Command + matching reply on `lines$` / `receive$`. |
+| **[Timeout / cancel / retry](./timeout-cancel-retry.md)** | Timeouts, teardown cancel, bounded retry. |
 | **[Troubleshooting](./troubleshooting.md)** | Common Web Serial / session problems and self-help checks. |
 | **[API Reference (TypeDoc)](modules.html)** | Options, `SerialSessionState`, and `SerialError` details; narrative tables also in [concepts](./concepts.md). |
 | **[v2 → v3 Migration Guide](./migration-v3.md)** ([日本語](../ja/migration-v3.md)) | `state$` discriminated union, `SerialSessionStatus`, and `context.cause`. |

--- a/packages/web-serial-rxjs/docs/guide/en/request-response.md
+++ b/packages/web-serial-rxjs/docs/guide/en/request-response.md
@@ -2,7 +2,7 @@
 
 Serial devices often expect a **command**, then a **matching reply** (a line, a prompt, or a terminator). This recipe shows how to build that flow with plain RxJS on top of `SerialSession` — **without** adding a core `request$()` API.
 
-Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#538](https://github.com/gurezo/web-serial-rxjs/issues/538) · Related: [Hardware-free testing](./testing.md) · Follow-up: timeout / cancel / retry ([#539](https://github.com/gurezo/web-serial-rxjs/issues/539))
+Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#538](https://github.com/gurezo/web-serial-rxjs/issues/538) · Related: [Hardware-free testing](./testing.md) · [Timeout / cancel / retry](./timeout-cancel-retry.md)
 
 ## Scope decision
 
@@ -181,7 +181,7 @@ try {
 }
 ```
 
-Cancel / retry / backoff policies belong in [#539](https://github.com/gurezo/web-serial-rxjs/issues/539).
+Cancel / retry / backoff policies belong in [Timeout / cancel / retry](./timeout-cancel-retry.md).
 
 ## Serialize multiple commands: `concatMap` vs `switchMap`
 
@@ -214,4 +214,4 @@ Drive replies with the Fake from [Hardware-free testing](./testing.md) (`emitLin
 
 - [Advanced Usage](./advanced-usage.md) — line framing, `readUntil`, ordered writes
 - [Hardware-free testing](./testing.md) — Fake `SerialSession`
-- Follow-up: [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) timeout / cancel / retry
+- [Timeout / cancel / retry](./timeout-cancel-retry.md) — deadlines, teardown cancel, bounded retry

--- a/packages/web-serial-rxjs/docs/guide/en/testing.md
+++ b/packages/web-serial-rxjs/docs/guide/en/testing.md
@@ -14,7 +14,7 @@ Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [
 | How to use | Copy the helper below into your test tree, or keep an equivalent local Fake |
 | Repo reference | [`tests/helpers/fake-serial-session.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/fake-serial-session.ts) (CI examples only; not published) |
 
-A future `@gurezo/web-serial-rxjs/testing` entry may be considered if shared helpers across [Request / Response](./request-response.md) and timeout recipes (#539) prove worth maintaining. Until then, keep the public surface small.
+A future `@gurezo/web-serial-rxjs/testing` entry may be considered if shared helpers across [Request / Response](./request-response.md) and [Timeout / cancel / retry](./timeout-cancel-retry.md) prove worth maintaining. Until then, keep the public surface small.
 
 ## Dependency injection pattern
 
@@ -346,4 +346,4 @@ it('reads connected state from Fake', async () => {
 - [Swappable public contract](./concepts.md#swappable-public-contract-decision-536)
 - [Advanced Usage](./advanced-usage.md) — compose RxJS on top of `receive$` / `send$`
 - [Request / Response recipes](./request-response.md) — command + matching reply (#538)
-- Follow-up: timeout / cancel / retry (#539)
+- [Timeout / cancel / retry](./timeout-cancel-retry.md) — deadlines, teardown cancel, bounded retry (#539)

--- a/packages/web-serial-rxjs/docs/guide/en/timeout-cancel-retry.md
+++ b/packages/web-serial-rxjs/docs/guide/en/timeout-cancel-retry.md
@@ -1,0 +1,275 @@
+# Timeout, cancel, and retry recipes
+
+`connect$()`, `send$()`, and response waits often need **timeouts**, **cancellation**, and **bounded retries**. This recipe shows how to place those policies in **application code** with plain RxJS — **without** a core auto-reconnect or auto-retry API.
+
+Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) · Related: [Request / Response](./request-response.md) · [Hardware-free testing](./testing.md)
+
+## Scope decision
+
+| Item | Decision |
+| --- | --- |
+| Core API | **No** built-in auto-reconnect / auto-retry |
+| npm package | Helpers below are **not** published exports |
+| How to use | Copy the patterns into your app, or keep a local helper |
+| Repo reference | [`tests/helpers/timeout-cancel-retry-recipes.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/timeout-cancel-retry-recipes.ts) (CI examples only) |
+
+Unconditional retry can re-open the port picker, treat user cancel as a failure worth looping, duplicate commands, run non-idempotent device actions more than once, or spin forever while USB is unplugged. Keep the policy in the app so you can decide per operation.
+
+## Separate responsibilities
+
+| Concern | Meaning | Typical RxJS tools |
+| --- | --- | --- |
+| **Timeout** | Stop waiting after a deadline | `timeout({ first })` |
+| **Cancel** | Stop because the user or UI tore down work | `takeUntil(destroy$)`, unsubscribe |
+| **Retry** | Attempt again after a failure — only when safe | `retry({ count, delay })` |
+
+Do not collapse these into one “keep trying” loop. A cancelled port picker is not a transient network blip.
+
+## Recommended policy by operation
+
+| Operation | Recommended policy |
+| --- | --- |
+| Port picker | Start from a user gesture; do **not** auto-reopen on cancel |
+| Connect failure | Manual retry or a **limited** count, depending on the cause |
+| Read stopped | Distinguish device unplug from app teardown |
+| Response timeout | Retry only after confirming the command is **idempotent** |
+| Send failure | Decide in the app whether the same payload may be resent |
+| After `dispose$` | **Do not** retry — create a new `SerialSession` |
+
+## Connect timeout
+
+```typescript
+import { firstValueFrom, timeout } from 'rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+
+async function connectWithTimeout(
+  session: SerialSession,
+  timeoutMs = 10_000,
+): Promise<void> {
+  await firstValueFrom(session.connect$().pipe(timeout({ first: timeoutMs })));
+}
+```
+
+`timeout` here bounds how long you wait for `connect$` to complete (including the browser port picker). It is **not** a library-level connection lease.
+
+## Response-wait timeout
+
+Prefer the wait-then-send patterns in [Request / Response](./request-response.md). Distinguish write failures (`SerialError`) from wait timeouts (RxJS `TimeoutError`):
+
+```typescript
+import { TimeoutError, firstValueFrom, filter, take, timeout } from 'rxjs';
+import { SerialError } from '@gurezo/web-serial-rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+
+async function requestOk(session: SerialSession, cmd: string): Promise<string> {
+  const wait$ = session.lines$.pipe(
+    filter((line) => line === 'OK'),
+    take(1),
+    timeout({ first: 3000 }),
+  );
+  const replyPromise = firstValueFrom(wait$);
+  await firstValueFrom(session.send$(cmd));
+  return replyPromise;
+}
+
+try {
+  await requestOk(session, 'AT\r\n');
+} catch (error) {
+  if (error instanceof SerialError) {
+    // send failed
+  } else if (error instanceof TimeoutError) {
+    // no matching reply in time
+  } else {
+    throw error;
+  }
+}
+```
+
+## Cancel with `takeUntil`
+
+```typescript
+import { Subject, takeUntil } from 'rxjs';
+
+const destroy$ = new Subject<void>();
+
+const sub = session.lines$
+  .pipe(takeUntil(destroy$))
+  .subscribe((line) => console.log(line));
+
+// Later: user navigates away or presses Cancel
+destroy$.next();
+destroy$.complete();
+// sub completes; no further lines are delivered
+```
+
+Cancellation should **complete** the pipeline (or unsubscribe), not feed into an infinite `retry`.
+
+## Cancel on Component / Hook teardown
+
+Framework-agnostic pattern: own a `destroy$` Subject and complete it in cleanup.
+
+**React**
+
+```typescript
+import { useEffect, useRef } from 'react';
+import { Subject, takeUntil } from 'rxjs';
+
+function useSerialLines(session: SerialSession, onLine: (line: string) => void) {
+  const destroyRef = useRef(new Subject<void>());
+
+  useEffect(() => {
+    const destroy$ = destroyRef.current;
+    const sub = session.lines$.pipe(takeUntil(destroy$)).subscribe(onLine);
+    return () => {
+      destroy$.next();
+      destroy$.complete();
+      sub.unsubscribe();
+    };
+  }, [session, onLine]);
+}
+```
+
+**Angular** (`DestroyRef` / `takeUntilDestroyed`)
+
+```typescript
+import { DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+const destroyRef = inject(DestroyRef);
+session.lines$
+  .pipe(takeUntilDestroyed(destroyRef))
+  .subscribe((line) => console.log(line));
+```
+
+## What to retry — and what to avoid
+
+| Safe to consider with a **limit** | Avoid automatic retry |
+| --- | --- |
+| Transient `PORT_OPEN_FAILED` after a previous disconnect | `OPERATION_CANCELLED` (user closed the picker) |
+| Idempotent read-only queries after a response timeout | Non-idempotent commands (`MOTOR_START`, `WRITE_FLASH`, …) |
+| Bounded reconnect after a fatal error (see below) | Anything after `dispose$` / `SESSION_DISPOSED` |
+| | Infinite reconnect while the cable is unplugged |
+
+```typescript
+import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
+
+function shouldRetryConnect(error: unknown): boolean {
+  if (
+    error instanceof SerialError &&
+    (error.is(SerialErrorCode.OPERATION_CANCELLED) ||
+      error.is(SerialErrorCode.SESSION_DISPOSED))
+  ) {
+    return false;
+  }
+  if (
+    error instanceof SerialError &&
+    (error.is(SerialErrorCode.PORT_OPEN_FAILED) ||
+      error.is(SerialErrorCode.CONNECTION_LOST))
+  ) {
+    return true;
+  }
+  return false;
+}
+```
+
+## Limited retry (no infinite loop)
+
+```typescript
+import { retry, throwError, timeout, timer } from 'rxjs';
+
+session
+  .connect$()
+  .pipe(
+    timeout({ first: 10_000 }),
+    retry({
+      count: 2, // two retries after the first failure → at most 3 attempts
+      delay: (error, retryCount) => {
+        if (!shouldRetryConnect(error)) {
+          return throwError(() => error);
+        }
+        return timer(200 * 2 ** (retryCount - 1)); // exponential backoff
+      },
+    }),
+  )
+  .subscribe({
+    error: (error) => console.error('connect failed after limited retries', error),
+  });
+```
+
+## Exponential backoff
+
+`retryCount` in RxJS `retry({ delay })` is **1-based** for the first retry:
+
+| Retry # | Delay with `base = 200` |
+| --- | --- |
+| 1 | 200 ms |
+| 2 | 400 ms |
+| 3 | 800 ms |
+
+```typescript
+const delayMs = baseDelayMs * 2 ** (retryCount - 1);
+```
+
+## Do not retry user cancel
+
+When the user dismisses the port picker, Chromium surfaces a `DOMException` that this library maps to `SerialErrorCode.OPERATION_CANCELLED`. Treat it as intentional UI, not a flaky device:
+
+```typescript
+import { SerialErrorCode } from '@gurezo/web-serial-rxjs';
+
+session.errors$.subscribe((error) => {
+  if (error.is(SerialErrorCode.OPERATION_CANCELLED)) {
+    // Show idle UI — do not call connect$() again automatically
+    return;
+  }
+});
+```
+
+## Do not reconnect after `disposed`
+
+After `dispose$()`, the session is terminal. `connect$` / `send$` fail with `SESSION_DISPOSED`. Create a **new** `SerialSession` if you need another connection (for example after a baud-rate change).
+
+```typescript
+import { firstValueFrom, take } from 'rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+async function reconnectIfAlive(session: SerialSession): Promise<void> {
+  const state = await firstValueFrom(session.state$.pipe(take(1)));
+  if (state.status === SerialSessionStatus.Disposed) {
+    throw new Error('Session disposed — create a new SerialSession');
+  }
+  await firstValueFrom(session.connect$());
+}
+```
+
+## Do not auto-resend non-idempotent commands
+
+A write may have reached the device even when your wait timed out. Resending `MOTOR_START` or a flash write can duplicate side effects.
+
+```typescript
+// Prefer a single attempt + operator decision
+session.send$('MOTOR_START\r\n').subscribe({
+  error: (error) => {
+    // Ask the user or inspect device state before sending again
+    console.error(error);
+  },
+});
+
+// Only retry when re-send is known-safe (read-only status, etc.)
+// and you pass an explicit idempotent: true style guard in your helper.
+```
+
+## Vitest coverage (no hardware)
+
+```bash
+pnpm --filter @gurezo/web-serial-rxjs exec vitest run tests/session/timeout-cancel-retry-recipes.test.ts
+```
+
+Drive failures with the Fake from [Hardware-free testing](./testing.md) (`failNextConnect`, `failConnectTimes`, `hangNextConnect`, `failNextSend`, `dispose$`).
+
+## Related
+
+- [Request / Response](./request-response.md) — wait-then-send, send vs timeout errors
+- [Advanced Usage](./advanced-usage.md) — recovery / reconnect (prefer **limited** retry from this page)
+- [Hardware-free testing](./testing.md) — Fake `SerialSession`
+- [Troubleshooting](./troubleshooting.md) — port picker cancel and common failures

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -10,9 +10,10 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 2. **[クイックスタート](./quick-start.md)** — インストール、接続、受信・送信、切断・破棄、エラーハンドリング
 3. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
 4. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
-5. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
-6. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
-7. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
+5. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
+6. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
+7. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
+8. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
 
 既存コードから移行する場合:
 
@@ -28,6 +29,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | **[クイックスタート](./quick-start.md)** | インストールから切断までの基本フロー |
 | **[高度な使用方法](./advanced-usage.md)** | 応用パターンと RxJS レシピ |
 | **[Request / Response](./request-response.md)** | コマンド送信後の応答待ち（コア `request$` なし） |
+| **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** | タイムアウト、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし） |
 | **[API の概念と設計メモ](./concepts.md)** | オプション・エラーコード・型の表形式補足、差し替え可能な `SerialSession` 契約、[対応範囲](./concepts.md#対応範囲テキスト--バイナリ--文字コード) |
 | **[実機なしテスト](./testing.md)** | 制御可能な Fake `SerialSession`、Vitest / Angular / React 例（npm 非同梱） |
 | **[トラブルシューティング](./troubleshooting.md)** | よくある問題の確認手順と報告時の情報 |

--- a/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md
@@ -224,7 +224,7 @@ session.errors$.subscribe((error) => {
 
 ## 致命的エラー時の再接続
 
-致命的エラーは `state$` を `{ status: 'error', error }` に遷移させるので、再接続ポリシーは素直に書けます。
+致命的エラーは `state$` を `{ status: 'error', error }` に遷移させるので、再接続ポリシーは素直に書けます。**回数制限**を付け、`dispose$` 後は再接続しない方針を優先してください — [タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md) を参照。以下は最小スケッチです。`retry({ count })`、`OPERATION_CANCELLED` の除外、`status === 'disposed'` での停止を加えてください。
 
 ```typescript
 import { filter, concatMap } from 'rxjs';

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -122,6 +122,7 @@ session.send$('hello\r\n').subscribe();
 | **[クイックスタート](./quick-start.md)** | 最短でポートを開いて購読するところまで。 |
 | **[高度な使用方法](./advanced-usage.md)** | 行フレーミング、派生ストリーム、リカバリ。 |
 | **[Request / Response](./request-response.md)** | `lines$` / `receive$` でのコマンド送信後の応答待ち。 |
+| **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** | タイムアウト、破棄時キャンセル、回数制限付き再試行。 |
 | **[トラブルシューティング](./troubleshooting.md)** | Web Serial / セッションのよくある問題と自己解決手順。 |
 | **[API Reference（TypeDoc）](../../api/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細。表・図は [概念と設計メモ](./concepts.md) も参照。 |
 | **[v2 → v3 マイグレーション](./migration-v3.md)**（[English](../en/migration-v3.md)） | `state$` discriminated union、`SerialSessionStatus`、`context.cause`。 |

--- a/packages/web-serial-rxjs/docs/guide/ja/request-response.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/request-response.md
@@ -2,7 +2,7 @@
 
 シリアル機器では、**コマンド送信後に条件に合う応答を待つ**流れがよくあります。本 Recipe は、コア API に `request$()` を追加せず、`SerialSession` 上の RxJS 組み合わせでその流れを組み立てる方法を示します。
 
-Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#538](https://github.com/gurezo/web-serial-rxjs/issues/538) · 関連: [実機なしテスト](./testing.md) · 後続: タイムアウト・キャンセル・再試行（[#539](https://github.com/gurezo/web-serial-rxjs/issues/539)）
+Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#538](https://github.com/gurezo/web-serial-rxjs/issues/538) · 関連: [実機なしテスト](./testing.md) · [タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)
 
 ## スコープの判断
 
@@ -181,7 +181,7 @@ try {
 }
 ```
 
-キャンセル・再試行・バックオフの方針は [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) を参照してください。
+キャンセル・再試行・バックオフの方針は [タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md) を参照してください。
 
 ## 複数コマンドの直列化: `concatMap` と `switchMap`
 
@@ -214,4 +214,4 @@ pnpm --filter @gurezo/web-serial-rxjs exec vitest run tests/session/request-resp
 
 - [高度な使用方法](./advanced-usage.md) — 行フレーミング、`readUntil`、順序付き送信
 - [実機なしテスト](./testing.md) — Fake `SerialSession`
-- 後続: [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) タイムアウト・キャンセル・再試行
+- [タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md) — 期限、破棄時キャンセル、回数制限付き再試行

--- a/packages/web-serial-rxjs/docs/guide/ja/testing.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/testing.md
@@ -14,7 +14,7 @@ Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [
 | 使い方 | 下のヘルパーをテストツリーへコピーするか、同等の Fake をアプリ側で定義する |
 | リポジトリ参照 | [`tests/helpers/fake-serial-session.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/fake-serial-session.ts)（CI 用の例。公開物ではない） |
 
-[Request / Response](./request-response.md) やタイムアウト Recipe（#539）で共有ヘルパーの必要性が固まった場合に、将来 `@gurezo/web-serial-rxjs/testing` などを検討します。それまでは公開面を小さく保ちます。
+[Request / Response](./request-response.md) や [タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md) で共有ヘルパーの必要性が固まった場合に、将来 `@gurezo/web-serial-rxjs/testing` などを検討します。それまでは公開面を小さく保ちます。
 
 ## 依存の差し替えパターン
 
@@ -346,4 +346,4 @@ it('reads connected state from Fake', async () => {
 - [差し替え可能な公開契約](./concepts.md#差し替え可能な公開契約decision-536)
 - [高度な使用方法](./advanced-usage.md) — `receive$` / `send$` 上の RxJS 組み立て
 - [Request / Response レシピ](./request-response.md) — コマンド送信後の応答待ち（#538）
-- 後続: タイムアウト・キャンセル・再試行（#539）
+- [タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md) — 期限、破棄時キャンセル、回数制限付き再試行（#539）

--- a/packages/web-serial-rxjs/docs/guide/ja/timeout-cancel-retry.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/timeout-cancel-retry.md
@@ -1,0 +1,275 @@
+# タイムアウト・キャンセル・再試行レシピ
+
+`connect$()`、`send$()`、応答待ちには、しばしば **タイムアウト**、**キャンセル**、**回数制限付き再試行** が必要です。本 Recipe は、コアの自動再接続・自動再試行 API を追加せず、利用側で plain RxJS によって方針を置く方法を示します。
+
+Parent: [#535](https://github.com/gurezo/web-serial-rxjs/issues/535) · Issue: [#539](https://github.com/gurezo/web-serial-rxjs/issues/539) · 関連: [Request / Response](./request-response.md) · [実機なしテスト](./testing.md)
+
+## スコープの判断
+
+| 項目 | 判断 |
+| --- | --- |
+| コア API | **自動再接続・自動再試行は追加しない** |
+| npm パッケージ | 下記ヘルパーは **公開 export ではない** |
+| 使い方 | パターンをアプリへコピーするか、同等のローカルヘルパーを置く |
+| リポジトリ参照 | [`tests/helpers/timeout-cancel-retry-recipes.ts`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/tests/helpers/timeout-cancel-retry-recipes.ts)（CI 用の例） |
+
+無条件の再試行は、ポート選択ダイアログの再表示、ユーザーキャンセルの障害扱い、コマンドの重複送信、非冪等な機器操作の複数回実行、USB 切断中の無限ループなどを招き得ます。操作ごとに判断できるよう、方針はアプリ側に置きます。
+
+## 責務の分離
+
+| 関心事 | 意味 | 典型的な RxJS |
+| --- | --- | --- |
+| **タイムアウト** | 期限までに終わらなければ打ち切る | `timeout({ first })` |
+| **キャンセル** | ユーザー操作や UI 破棄により打ち切る | `takeUntil(destroy$)`、unsubscribe |
+| **再試行** | 失敗後に再度試みる（安全な場合のみ） | `retry({ count, delay })` |
+
+これらを「とにかく続ける」1 本のループにまとめないでください。ポート選択のキャンセルは、一時的な通信障害ではありません。
+
+## 処理別の推奨方針
+
+| 処理 | 推奨方針 |
+| --- | --- |
+| ポート選択 | ユーザー操作から開始し、キャンセル時は自動再表示しない |
+| 接続失敗 | 原因に応じて手動再試行または回数制限 |
+| 読み取り停止 | デバイス切断とアプリ終了を区別する |
+| 応答タイムアウト | コマンドの冪等性を確認してから再試行する |
+| 送信失敗 | 同じデータを自動再送してよいか利用側で判断する |
+| `dispose$` 後 | 再試行しない（新しい `SerialSession` を作る） |
+
+## 接続のタイムアウト
+
+```typescript
+import { firstValueFrom, timeout } from 'rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+
+async function connectWithTimeout(
+  session: SerialSession,
+  timeoutMs = 10_000,
+): Promise<void> {
+  await firstValueFrom(session.connect$().pipe(timeout({ first: timeoutMs })));
+}
+```
+
+ここでの `timeout` は、`connect$`（ポート選択ダイアログを含む）の完了待ちに上限を付けるものです。ライブラリ全体の接続リースではありません。
+
+## 応答待機のタイムアウト
+
+待ち → 送信のパターンは [Request / Response](./request-response.md) を優先してください。書き込み失敗（`SerialError`）と待ちタイムアウト（RxJS `TimeoutError`）を区別します。
+
+```typescript
+import { TimeoutError, firstValueFrom, filter, take, timeout } from 'rxjs';
+import { SerialError } from '@gurezo/web-serial-rxjs';
+import type { SerialSession } from '@gurezo/web-serial-rxjs';
+
+async function requestOk(session: SerialSession, cmd: string): Promise<string> {
+  const wait$ = session.lines$.pipe(
+    filter((line) => line === 'OK'),
+    take(1),
+    timeout({ first: 3000 }),
+  );
+  const replyPromise = firstValueFrom(wait$);
+  await firstValueFrom(session.send$(cmd));
+  return replyPromise;
+}
+
+try {
+  await requestOk(session, 'AT\r\n');
+} catch (error) {
+  if (error instanceof SerialError) {
+    // 送信失敗
+  } else if (error instanceof TimeoutError) {
+    // 期限内に一致する応答がなかった
+  } else {
+    throw error;
+  }
+}
+```
+
+## `takeUntil` によるキャンセル
+
+```typescript
+import { Subject, takeUntil } from 'rxjs';
+
+const destroy$ = new Subject<void>();
+
+const sub = session.lines$
+  .pipe(takeUntil(destroy$))
+  .subscribe((line) => console.log(line));
+
+// 後で: 画面遷移や Cancel
+destroy$.next();
+destroy$.complete();
+// sub は complete。以降の行は届かない
+```
+
+キャンセルはパイプラインを **完了**（または unsubscribe）させ、無限の `retry` に流し込まないでください。
+
+## Component / Hook 破棄時のキャンセル
+
+フレームワーク非依存の型: `destroy$` Subject を持ち、cleanup で complete します。
+
+**React**
+
+```typescript
+import { useEffect, useRef } from 'react';
+import { Subject, takeUntil } from 'rxjs';
+
+function useSerialLines(session: SerialSession, onLine: (line: string) => void) {
+  const destroyRef = useRef(new Subject<void>());
+
+  useEffect(() => {
+    const destroy$ = destroyRef.current;
+    const sub = session.lines$.pipe(takeUntil(destroy$)).subscribe(onLine);
+    return () => {
+      destroy$.next();
+      destroy$.complete();
+      sub.unsubscribe();
+    };
+  }, [session, onLine]);
+}
+```
+
+**Angular**（`DestroyRef` / `takeUntilDestroyed`）
+
+```typescript
+import { DestroyRef, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+
+const destroyRef = inject(DestroyRef);
+session.lines$
+  .pipe(takeUntilDestroyed(destroyRef))
+  .subscribe((line) => console.log(line));
+```
+
+## `retry()` してよい処理 / 避けるべき処理
+
+| **回数制限付き**で検討してよい例 | 自動再試行を避ける例 |
+| --- | --- |
+| 切断後の一時的な `PORT_OPEN_FAILED` | `OPERATION_CANCELLED`（ユーザーがダイアログを閉じた） |
+| 応答タイムアウト後の冪等な読み取りクエリ | 非冪等コマンド（`MOTOR_START`、`WRITE_FLASH` など） |
+| fatal エラー後の **制限付き**再接続（後述） | `dispose$` / `SESSION_DISPOSED` の後 |
+| | ケーブル未接続のままの無限再接続 |
+
+```typescript
+import { SerialError, SerialErrorCode } from '@gurezo/web-serial-rxjs';
+
+function shouldRetryConnect(error: unknown): boolean {
+  if (
+    error instanceof SerialError &&
+    (error.is(SerialErrorCode.OPERATION_CANCELLED) ||
+      error.is(SerialErrorCode.SESSION_DISPOSED))
+  ) {
+    return false;
+  }
+  if (
+    error instanceof SerialError &&
+    (error.is(SerialErrorCode.PORT_OPEN_FAILED) ||
+      error.is(SerialErrorCode.CONNECTION_LOST))
+  ) {
+    return true;
+  }
+  return false;
+}
+```
+
+## 回数制限付き再試行（無限ループにしない）
+
+```typescript
+import { retry, throwError, timeout, timer } from 'rxjs';
+
+session
+  .connect$()
+  .pipe(
+    timeout({ first: 10_000 }),
+    retry({
+      count: 2, // 初回失敗のあと最大 2 回再試行 → 合計最大 3 回
+      delay: (error, retryCount) => {
+        if (!shouldRetryConnect(error)) {
+          return throwError(() => error);
+        }
+        return timer(200 * 2 ** (retryCount - 1)); // 指数バックオフ
+      },
+    }),
+  )
+  .subscribe({
+    error: (error) => console.error('回数制限内で接続に失敗', error),
+  });
+```
+
+## 指数バックオフ
+
+RxJS `retry({ delay })` の `retryCount` は、最初の再試行が **1** です。
+
+| 再試行 # | `base = 200` のときの遅延 |
+| --- | --- |
+| 1 | 200 ms |
+| 2 | 400 ms |
+| 3 | 800 ms |
+
+```typescript
+const delayMs = baseDelayMs * 2 ** (retryCount - 1);
+```
+
+## ユーザーキャンセルは再試行しない
+
+ユーザーがポート選択を閉じると、Chromium の `DOMException` が `SerialErrorCode.OPERATION_CANCELLED` に正規化されます。一時障害ではなく、意図的な UI 操作として扱います。
+
+```typescript
+import { SerialErrorCode } from '@gurezo/web-serial-rxjs';
+
+session.errors$.subscribe((error) => {
+  if (error.is(SerialErrorCode.OPERATION_CANCELLED)) {
+    // idle UI を表示 — connect$() を自動では呼び出さない
+    return;
+  }
+});
+```
+
+## `disposed` では再接続しない
+
+`dispose$()` のあと、セッションは終端です。`connect$` / `send$` は `SESSION_DISPOSED` で失敗します。再接続が必要なら **新しい** `SerialSession` を作成してください（ボーレート変更後など）。
+
+```typescript
+import { firstValueFrom, take } from 'rxjs';
+import { SerialSessionStatus } from '@gurezo/web-serial-rxjs';
+
+async function reconnectIfAlive(session: SerialSession): Promise<void> {
+  const state = await firstValueFrom(session.state$.pipe(take(1)));
+  if (state.status === SerialSessionStatus.Disposed) {
+    throw new Error('Session disposed — 新しい SerialSession を作成してください');
+  }
+  await firstValueFrom(session.connect$());
+}
+```
+
+## 非冪等コマンドを自動再送しない
+
+待ちがタイムアウトしても、書き込みは機器に届いている場合があります。`MOTOR_START` やフラッシュ書き込みの再送は副作用を重複させ得ます。
+
+```typescript
+// 1 回の試行 + 運用者判断を推奨
+session.send$('MOTOR_START\r\n').subscribe({
+  error: (error) => {
+    // 再送する前にユーザー確認や機器状態の確認を行う
+    console.error(error);
+  },
+});
+
+// 再送が安全と分かっている場合のみ（読み取り専用の status など）
+// ヘルパーでは idempotent: true のような明示的なガードを付ける
+```
+
+## Vitest カバレッジ（実機なし）
+
+```bash
+pnpm --filter @gurezo/web-serial-rxjs exec vitest run tests/session/timeout-cancel-retry-recipes.test.ts
+```
+
+失敗の投入には [実機なしテスト](./testing.md) の Fake（`failNextConnect` / `failConnectTimes` / `hangNextConnect` / `failNextSend` / `dispose$`）を使います。
+
+## 関連
+
+- [Request / Response](./request-response.md) — 待ち→送信、送信エラーとタイムアウトの区別
+- [高度な使用方法](./advanced-usage.md) — リカバリ／再接続（本ページの **制限付き**再試行を優先）
+- [実機なしテスト](./testing.md) — Fake `SerialSession`
+- [トラブルシューティング](./troubleshooting.md) — ポート選択キャンセルとよくある失敗

--- a/packages/web-serial-rxjs/tests/helpers/fake-serial-session.ts
+++ b/packages/web-serial-rxjs/tests/helpers/fake-serial-session.ts
@@ -56,6 +56,15 @@ export type FakeSerialSessionHandle = {
   emitLine(line: string): void;
   emitError(error: SerialError): void;
   failNextConnect(error?: SerialError): void;
+  /**
+   * Fail the next `times` `connect$` subscriptions with the same error.
+   * Useful for limited-retry recipe tests (#539).
+   */
+  failConnectTimes(times: number, error?: SerialError): void;
+  /**
+   * Make the next `connect$` hang (never emit). Pair with RxJS `timeout`.
+   */
+  hangNextConnect(): void;
   failNextSend(error?: SerialError): void;
   /**
    * Simulate an unexpected device unplug while connected.
@@ -77,8 +86,10 @@ export function createFakeSerialSession(): FakeSerialSessionHandle {
   const terminalTextSubject = new BehaviorSubject<string>('');
 
   const sent: SerialPayload[] = [];
+  let remainingConnectFailures = 0;
   let nextConnectError: SerialError | undefined;
   let nextSendError: SerialError | undefined;
+  let hangNextConnect = false;
 
   const session: SerialSession = {
     state$: stateSubject.asObservable(),
@@ -89,6 +100,25 @@ export function createFakeSerialSession(): FakeSerialSessionHandle {
 
     connect$: (): Observable<void> =>
       defer(() => {
+        if (hangNextConnect) {
+          hangNextConnect = false;
+          stateSubject.next({ status: SerialSessionStatus.Connecting });
+          // Never emits — use with RxJS timeout in recipe tests (#539).
+          return new Observable<void>(() => undefined);
+        }
+
+        if (remainingConnectFailures > 0) {
+          remainingConnectFailures -= 1;
+          const error = nextConnectError ?? defaultConnectError();
+          if (remainingConnectFailures === 0) {
+            nextConnectError = undefined;
+          }
+          stateSubject.next({ status: SerialSessionStatus.Connecting });
+          stateSubject.next({ status: SerialSessionStatus.Idle });
+          errorsSubject.next(error);
+          return throwError(() => error);
+        }
+
         if (nextConnectError !== undefined) {
           const error = nextConnectError;
           nextConnectError = undefined;
@@ -152,6 +182,17 @@ export function createFakeSerialSession(): FakeSerialSessionHandle {
     },
     failNextConnect(error: SerialError = defaultConnectError()): void {
       nextConnectError = error;
+      remainingConnectFailures = 0;
+    },
+    failConnectTimes(
+      times: number,
+      error: SerialError = defaultConnectError(),
+    ): void {
+      remainingConnectFailures = Math.max(0, times);
+      nextConnectError = error;
+    },
+    hangNextConnect(): void {
+      hangNextConnect = true;
     },
     failNextSend(error: SerialError = defaultSendError()): void {
       nextSendError = error;

--- a/packages/web-serial-rxjs/tests/helpers/timeout-cancel-retry-recipes.ts
+++ b/packages/web-serial-rxjs/tests/helpers/timeout-cancel-retry-recipes.ts
@@ -1,0 +1,279 @@
+import {
+  Observable,
+  TimeoutError,
+  defer,
+  map,
+  mergeMap,
+  retry,
+  take,
+  takeUntil,
+  throwError,
+  timeout,
+  timer,
+} from 'rxjs';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import type { SerialSession } from '../../src/session/serial-session';
+import { SerialSessionStatus } from '../../src/session/serial-session-state';
+import type { SerialPayload } from '../../src/types';
+import {
+  type LineMatcher,
+  type RequestResponseOptions,
+  requestLine$,
+} from './request-response-recipes';
+
+/**
+ * Timeout / cancel / retry recipe helpers built on `SerialSession` (Issue #539).
+ *
+ * These helpers are **not** published on npm. Copy the pattern into application
+ * code. They compose plain RxJS over `connect$` / `send$` / `lines$` and do
+ * **not** extend the core public API with automatic reconnect or retry.
+ *
+ * @see https://github.com/gurezo/web-serial-rxjs/issues/539
+ */
+
+export type TimeoutOptions = {
+  /** First-emission timeout in ms (RxJS `timeout({ first })`). Default: 10_000. */
+  timeoutMs?: number;
+};
+
+export type RetryOptions = {
+  /** Maximum number of retries after the first failure. Default: 2. */
+  count?: number;
+  /** Base delay in ms for exponential backoff. Default: 200. */
+  baseDelayMs?: number;
+};
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 10_000;
+const DEFAULT_RETRY_COUNT = 2;
+const DEFAULT_BASE_DELAY_MS = 200;
+
+/**
+ * True when `error` is a user-cancelled port picker (`OPERATION_CANCELLED`).
+ * Do **not** retry or re-open the picker automatically.
+ */
+export function isUserCancelled(error: unknown): error is SerialError {
+  return (
+    error instanceof SerialError &&
+    error.is(SerialErrorCode.OPERATION_CANCELLED)
+  );
+}
+
+/**
+ * True when `error` is `SESSION_DISPOSED`.
+ * Create a new session instead of retrying on a disposed instance.
+ */
+export function isSessionDisposedError(error: unknown): error is SerialError {
+  return (
+    error instanceof SerialError && error.is(SerialErrorCode.SESSION_DISPOSED)
+  );
+}
+
+/**
+ * Emit whether the session is currently in `disposed` status.
+ */
+export function isDisposedState(session: SerialSession): Observable<boolean> {
+  return session.state$.pipe(
+    map((state) => state.status === SerialSessionStatus.Disposed),
+    take(1),
+  );
+}
+
+/**
+ * Connect with a first-emission timeout.
+ * Does **not** retry on failure — compose with {@link connectWithLimitedRetry$}
+ * when a bounded retry policy is appropriate.
+ */
+export function connectWithTimeout$(
+  session: SerialSession,
+  options: TimeoutOptions = {},
+): Observable<void> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+  return session.connect$().pipe(timeout({ first: timeoutMs }));
+}
+
+/**
+ * Wait for a matching reply after send, with an explicit timeout.
+ * Thin wrapper around {@link requestLine$} for documentation / tests.
+ */
+export function requestWithTimeout$(
+  session: SerialSession,
+  payload: SerialPayload,
+  matcher: LineMatcher,
+  options: RequestResponseOptions = {},
+): Observable<string> {
+  return requestLine$(session, payload, matcher, options);
+}
+
+/**
+ * Run `source$` until `cancel$` emits, then complete without error.
+ * Typical use: Component / Hook teardown Subject.
+ */
+export function withCancel$<T>(
+  source$: Observable<T>,
+  cancel$: Observable<unknown>,
+): Observable<T> {
+  return source$.pipe(takeUntil(cancel$));
+}
+
+/**
+ * Whether this error is safe to retry for a **connect** attempt.
+ * User cancel and disposed sessions must never be retried.
+ */
+export function shouldRetryConnect(error: unknown): boolean {
+  if (isUserCancelled(error) || isSessionDisposedError(error)) {
+    return false;
+  }
+  if (error instanceof TimeoutError) {
+    return true;
+  }
+  if (error instanceof SerialError) {
+    return (
+      error.is(SerialErrorCode.PORT_OPEN_FAILED) ||
+      error.is(SerialErrorCode.CONNECTION_LOST)
+    );
+  }
+  return false;
+}
+
+/**
+ * Exponential backoff delay for retry attempt `retryCount` (1-based in RxJS
+ * `retry` delay callback: first retry is count 1).
+ */
+export function exponentialBackoffDelayMs(
+  retryCount: number,
+  baseDelayMs = DEFAULT_BASE_DELAY_MS,
+): number {
+  return baseDelayMs * 2 ** (retryCount - 1);
+}
+
+/**
+ * Connect with a limited retry count and optional exponential backoff.
+ * Never retries user cancel or disposed sessions. Refuses to call `connect$`
+ * when the session is already `disposed`.
+ */
+export function connectWithLimitedRetry$(
+  session: SerialSession,
+  options: TimeoutOptions & RetryOptions = {},
+): Observable<void> {
+  const count = options.count ?? DEFAULT_RETRY_COUNT;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+
+  return defer(() =>
+    isDisposedState(session).pipe(
+      mergeMap((disposed) => {
+        if (disposed) {
+          return throwError(
+            () =>
+              new SerialError(
+                SerialErrorCode.SESSION_DISPOSED,
+                'SerialSession has been disposed',
+              ),
+          );
+        }
+        return session.connect$().pipe(timeout({ first: timeoutMs }));
+      }),
+    ),
+  ).pipe(
+    retry({
+      count,
+      delay: (error, retryCount) => {
+        if (!shouldRetryConnect(error)) {
+          return throwError(() => error);
+        }
+        return timer(exponentialBackoffDelayMs(retryCount, baseDelayMs));
+      },
+    }),
+  );
+}
+
+/**
+ * Retry a **idempotent** request/response a limited number of times.
+ *
+ * Only use when re-sending `payload` is safe (read-only queries, etc.).
+ * Pass `idempotent: true` explicitly — non-idempotent commands must not use
+ * this helper (device may execute the side effect more than once).
+ */
+export function requestIdempotentWithRetry$(
+  session: SerialSession,
+  payload: SerialPayload,
+  matcher: LineMatcher,
+  options: RequestResponseOptions & RetryOptions & { idempotent: true },
+): Observable<string> {
+  // Runtime guard in case of unsound casts from application code.
+  if (options.idempotent !== true) {
+    return throwError(
+      () =>
+        new Error(
+          'requestIdempotentWithRetry$ requires idempotent: true — do not auto-resend non-idempotent commands',
+        ),
+    );
+  }
+
+  const count = options.count ?? DEFAULT_RETRY_COUNT;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+
+  return defer(() => requestLine$(session, payload, matcher, options)).pipe(
+    retry({
+      count,
+      delay: (error, retryCount) => {
+        // Never auto-resend after cancel / disposed.
+        if (isUserCancelled(error) || isSessionDisposedError(error)) {
+          return throwError(() => error);
+        }
+        if (
+          error instanceof TimeoutError ||
+          (error instanceof SerialError &&
+            error.is(SerialErrorCode.WRITE_FAILED))
+        ) {
+          return timer(exponentialBackoffDelayMs(retryCount, baseDelayMs));
+        }
+        return throwError(() => error);
+      },
+    }),
+  );
+}
+
+/**
+ * Guard helper: refuse automatic resend for non-idempotent commands.
+ * Prefer calling `requestLine$` once and handling failure in the UI.
+ */
+export function requestNonIdempotent$(
+  session: SerialSession,
+  payload: SerialPayload,
+  matcher: LineMatcher,
+  options: RequestResponseOptions = {},
+): Observable<string> {
+  // Intentionally no retry — side-effecting commands must not be auto-resent.
+  return requestLine$(session, payload, matcher, options);
+}
+
+/**
+ * Reconnect policy that stops when the session is disposed.
+ * Use after a fatal error only with a limited count (see Guide).
+ */
+export function reconnectUnlessDisposed$(
+  session: SerialSession,
+  options: TimeoutOptions & RetryOptions = {},
+): Observable<void> {
+  return isDisposedState(session).pipe(
+    mergeMap((disposed) => {
+      if (disposed) {
+        return throwError(
+          () =>
+            new SerialError(
+              SerialErrorCode.SESSION_DISPOSED,
+              'SerialSession has been disposed — create a new session instead of reconnecting',
+            ),
+        );
+      }
+      return connectWithLimitedRetry$(session, options);
+    }),
+  );
+}
+
+/** Re-export TimeoutError check for Guide / tests. */
+export function isTimeoutError(error: unknown): error is TimeoutError {
+  return error instanceof TimeoutError;
+}

--- a/packages/web-serial-rxjs/tests/session/timeout-cancel-retry-recipes.test.ts
+++ b/packages/web-serial-rxjs/tests/session/timeout-cancel-retry-recipes.test.ts
@@ -1,0 +1,248 @@
+import { Subject, firstValueFrom } from 'rxjs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { SerialError } from '../../src/errors/serial-error';
+import { SerialErrorCode } from '../../src/errors/serial-error-code';
+import { SerialSessionStatus } from '../../src/session/serial-session-state';
+import { createFakeSerialSession } from '../helpers/fake-serial-session';
+import {
+  connectWithLimitedRetry$,
+  connectWithTimeout$,
+  exponentialBackoffDelayMs,
+  isTimeoutError,
+  isUserCancelled,
+  reconnectUnlessDisposed$,
+  requestIdempotentWithRetry$,
+  requestNonIdempotent$,
+  requestWithTimeout$,
+  shouldRetryConnect,
+  withCancel$,
+} from '../helpers/timeout-cancel-retry-recipes';
+
+/**
+ * Timeout / cancel / retry recipe scenarios (Issue #539).
+ *
+ * Uses the Fake SerialSession from #537 — no USB hardware required.
+ */
+
+describe('timeout-cancel-retry recipes (Issue #539)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('times out a hanging connect$', async () => {
+    const fake = createFakeSerialSession();
+    fake.hangNextConnect();
+
+    const result = firstValueFrom(
+      connectWithTimeout$(fake.session, { timeoutMs: 50 }),
+    );
+    const assertion = expect(result).rejects.toSatisfy(isTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+  });
+
+  it('times out when no matching response arrives', async () => {
+    const fake = createFakeSerialSession();
+    await firstValueFrom(fake.session.connect$());
+
+    const result = firstValueFrom(
+      requestWithTimeout$(fake.session, 'AT\r\n', 'OK', { timeoutMs: 50 }),
+    );
+    const assertion = expect(result).rejects.toSatisfy(isTimeoutError);
+
+    await vi.advanceTimersByTimeAsync(50);
+    await assertion;
+    expect(fake.sent).toEqual(['AT\r\n']);
+  });
+
+  it('cancels an in-flight wait with takeUntil / destroy$', async () => {
+    const fake = createFakeSerialSession();
+    await firstValueFrom(fake.session.connect$());
+    const destroy$ = new Subject<void>();
+
+    let completed = false;
+    let errored = false;
+    const emissions: string[] = [];
+
+    const sub = withCancel$(
+      requestWithTimeout$(fake.session, 'AT\r\n', 'OK', { timeoutMs: 5000 }),
+      destroy$,
+    ).subscribe({
+      next: (line) => emissions.push(line),
+      error: () => {
+        errored = true;
+      },
+      complete: () => {
+        completed = true;
+      },
+    });
+
+    expect(fake.sent).toEqual(['AT\r\n']);
+
+    destroy$.next();
+    destroy$.complete();
+
+    expect(completed).toBe(true);
+    expect(errored).toBe(false);
+    expect(emissions).toEqual([]);
+    expect(sub.closed).toBe(true);
+
+    // Late reply after cancel must not be delivered
+    fake.emitLine('OK');
+    expect(emissions).toEqual([]);
+  });
+
+  it('retries connect a limited number of times then succeeds', async () => {
+    const fake = createFakeSerialSession();
+    fake.failConnectTimes(
+      2,
+      new SerialError(SerialErrorCode.PORT_OPEN_FAILED, 'busy'),
+    );
+
+    const result = firstValueFrom(
+      connectWithLimitedRetry$(fake.session, {
+        count: 2,
+        baseDelayMs: 10,
+        timeoutMs: 1000,
+      }),
+    );
+
+    // First failure → backoff 10ms → second failure → backoff 20ms → success
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(20);
+    await expect(result).resolves.toBeUndefined();
+    await expect(firstValueFrom(fake.session.state$)).resolves.toMatchObject({
+      status: SerialSessionStatus.Connected,
+    });
+  });
+
+  it('exhausts limited retries and fails', async () => {
+    const fake = createFakeSerialSession();
+    const openError = new SerialError(
+      SerialErrorCode.PORT_OPEN_FAILED,
+      'still busy',
+    );
+    fake.failConnectTimes(3, openError);
+
+    const result = firstValueFrom(
+      connectWithLimitedRetry$(fake.session, {
+        count: 2,
+        baseDelayMs: 5,
+        timeoutMs: 1000,
+      }),
+    );
+    const assertion = expect(result).rejects.toBe(openError);
+
+    await vi.advanceTimersByTimeAsync(5);
+    await vi.advanceTimersByTimeAsync(10);
+    await assertion;
+  });
+
+  it('uses exponential backoff delays', () => {
+    expect(exponentialBackoffDelayMs(1, 100)).toBe(100);
+    expect(exponentialBackoffDelayMs(2, 100)).toBe(200);
+    expect(exponentialBackoffDelayMs(3, 100)).toBe(400);
+  });
+
+  it('does not retry user cancel (OPERATION_CANCELLED)', async () => {
+    const fake = createFakeSerialSession();
+    const cancelled = new SerialError(
+      SerialErrorCode.OPERATION_CANCELLED,
+      'user cancelled port picker',
+    );
+    fake.failNextConnect(cancelled);
+
+    expect(shouldRetryConnect(cancelled)).toBe(false);
+    expect(isUserCancelled(cancelled)).toBe(true);
+
+    const result = firstValueFrom(
+      connectWithLimitedRetry$(fake.session, {
+        count: 5,
+        baseDelayMs: 10,
+        timeoutMs: 1000,
+      }),
+    );
+
+    // No timer advance needed — cancel must fail immediately without retry delay
+    await expect(result).rejects.toBe(cancelled);
+  });
+
+  it('does not reconnect after dispose$', async () => {
+    const fake = createFakeSerialSession();
+    await firstValueFrom(fake.session.dispose$());
+
+    await expect(
+      firstValueFrom(
+        reconnectUnlessDisposed$(fake.session, {
+          count: 2,
+          baseDelayMs: 5,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: SerialErrorCode.SESSION_DISPOSED,
+    });
+
+    await expect(
+      firstValueFrom(
+        connectWithLimitedRetry$(fake.session, {
+          count: 2,
+          baseDelayMs: 5,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: SerialErrorCode.SESSION_DISPOSED,
+    });
+  });
+
+  it('does not auto-resend non-idempotent commands', async () => {
+    const fake = createFakeSerialSession();
+    await firstValueFrom(fake.session.connect$());
+    fake.failNextSend(
+      new SerialError(SerialErrorCode.WRITE_FAILED, 'write failed'),
+    );
+
+    await expect(
+      firstValueFrom(
+        requestNonIdempotent$(fake.session, 'MOTOR_START\r\n', 'OK', {
+          timeoutMs: 50,
+        }),
+      ),
+    ).rejects.toMatchObject({ code: SerialErrorCode.WRITE_FAILED });
+
+    // Exactly one send attempt — no automatic resend
+    expect(fake.sent).toEqual(['MOTOR_START\r\n']);
+  });
+
+  it('may retry idempotent requests when explicitly opted in', async () => {
+    const fake = createFakeSerialSession();
+    await firstValueFrom(fake.session.connect$());
+    fake.failNextSend(
+      new SerialError(SerialErrorCode.WRITE_FAILED, 'transient'),
+    );
+
+    const result = firstValueFrom(
+      requestIdempotentWithRetry$(fake.session, 'STATUS?\r\n', 'OK', {
+        idempotent: true,
+        count: 1,
+        baseDelayMs: 10,
+        timeoutMs: 200,
+      }),
+    );
+
+    await vi.advanceTimersByTimeAsync(10);
+
+    // Drive reply after the retried send is recorded
+    await vi.waitFor(() => {
+      expect(fake.sent.length).toBeGreaterThanOrEqual(2);
+    });
+    fake.emitLine('OK');
+
+    await expect(result).resolves.toBe('OK');
+    expect(fake.sent).toEqual(['STATUS?\r\n', 'STATUS?\r\n']);
+  });
+});


### PR DESCRIPTION
## Summary
- タイムアウト・キャンセル・再試行の責務と実装例を日英 Guide Recipe として追加しました（#539）
- コア API は拡張せず、Fake を用いた Vitest とコピー用ヘルパーで完了条件を満たします

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #539
- Parent: #535
- Depends on: #537, #538

## What changed?
- `tests/helpers/timeout-cancel-retry-recipes.ts` に接続タイムアウト / キャンセル / 回数制限付き再試行 / 指数バックオフ / 非冪等ガードを追加（npm 非公開）
- Fake に `failConnectTimes` / `hangNextConnect` を追加（#539 シナリオ用）
- Issue シナリオをカバーする Vitest（`timeout-cancel-retry-recipes.test.ts`）を追加
- 日英 Guide `timeout-cancel-retry.md` を追加（責務分離、処理別方針表、ユーザーキャンセル / disposed / 非冪等の注意）
- Guide README / request-response / testing / advanced-usage / overview から導線を更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: なし。ヘルパーは `tests/helpers` と Guide のみ（npm export なし）。コア自動再接続・自動再試行 API は追加しない
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm --filter @gurezo/web-serial-rxjs exec vitest run tests/session/timeout-cancel-retry-recipes.test.ts`
2. Guide を確認: `packages/web-serial-rxjs/docs/guide/en/timeout-cancel-retry.md` / `ja/timeout-cancel-retry.md`
3. Guide README / request-response / testing / advanced-usage から新ページへのリンクが有効であること

## Environment (if relevant)
- Browser: N/A（実機なし Recipe）
- OS: macOS
- web-serial-rxjs version (for verification): workspace
- RxJS version: workspace

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)