### PR TITLE
docs(workspace): reorganize readme for library users

### DIFF
--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -78,16 +78,35 @@ pnpm run prepare
 
 ### 5. AI アシスタント（MCP）— 任意
 
-このプロジェクトには、AI 支援開発向けの MCP（Model Context Protocol）サーバー設定が含まれています。利用可能なサーバー（Nx、Angular CLI、Svelte）と設定の詳細は、README の [AI アシスタント（MCP）](README.ja.md#ai-アシスタントmcp) セクションを参照してください。
+このプロジェクトには、AI 支援開発向けの [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) サーバー設定が含まれています。利用可能な MCP サーバーは次のとおりです。
+
+| サーバー | 用途 |
+| -------- | ---- |
+| **nx-mcp** | Nx ワークスペース分析、プロジェクトグラフ、CI 監視、ドキュメント |
+| **angular-cli** | example-angular 向け Angular CLI ツール（コード生成、ドキュメント、ベストプラクティス） |
+| **svelte** | example-svelte 向け Svelte / SvelteKit ドキュメントとコード分析 |
+
+**設定ファイル:**
+
+- `.mcp.json` — 標準 MCP 設定（Cursor、VS Code、Claude など）
+- `.cursor/mcp.json` — Cursor 専用設定
+
+Cursor では `.cursor/mcp.json` から設定が自動的に読み込まれます。VS Code では MCP 拡張機能を追加し `.mcp.json` を使うか、MCP 設定にサーバー定義を追加してください。
 
 ### 6. Cursor Rules / Skills — 任意
 
-[Cursor](https://www.cursor.com/) でこのリポジトリを開くと、以下の Rules / Skills が自動的に適用され、AI が Conventional Commits 準拠の commit message / PR タイトルを生成できるようになります。
+このリポジトリには `.cursor/rules/` 配下に [Cursor](https://www.cursor.com/) 用ルールも同梱されています（トピック別: Conventional Commits と PR タイトル用の `commits/`、`typescript/`、`rxjs/`、`angular/`、Nx ワークスペースタスクと **commit scope** ガイドを含む `nx/`、`examples/`、`workflow/`）。ルールは責務ごとに小さな `.mdc` ファイルへ分割し、重複を減らしてプロンプトを絞り込んでいます。
+
+Cursor でこのリポジトリを開くと、以下の Rules / Skills が AI による Conventional Commits 準拠の commit message / PR タイトル生成を支援します。
 
 - `.cursor/rules/commits/40-conventional-commits.mdc`: Conventional Commits の基本ルール
 - `.cursor/rules/commits/41-pull-request-title.mdc`: PR タイトル規約
 - `.cursor/rules/nx/30-nx-project-scope.mdc`: `project.json` の `name` を scope として解決
 - `.cursor/skills/conventional-commits/`: 例集 / 検証項目 / scope 一覧
+
+- `.cursor/agents/ci-monitor-subagent.md` — Nx Cloud CI 監視が有効な場合に `/monitor-ci` および Nx MCP の `ci_information` / `update_self_healing_fix` ツールと併用する任意の CI ヘルパー
+
+commit scope の表は `commitlint.config.js` と整合します。例と scope 一覧は `.cursor/skills/conventional-commits/` を参照してください。
 
 新しい `project.json` を追加・リネームしたときは、`commitlint.config.js` の `scope-enum`、`.cursor/skills/conventional-commits/scopes.md`、`.cursor/rules/nx/30-nx-project-scope.mdc` も同時に更新してください。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,16 +78,35 @@ This will ensure that commit messages are automatically checked for Conventional
 
 ### 5. AI Assistant (MCP) - Optional
 
-This project includes MCP (Model Context Protocol) server configuration for AI-assisted development. See the [AI Assistant (MCP)](README.md#ai-assistant-mcp) section in the README for available servers (Nx, Angular CLI, Svelte) and configuration details.
+This project includes [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server configuration for AI-assisted development. The following MCP servers are available:
+
+| Server          | Purpose                                                                                |
+| --------------- | -------------------------------------------------------------------------------------- |
+| **nx-mcp**      | Nx workspace analysis, project graph, CI monitoring, and documentation                 |
+| **angular-cli** | Angular CLI tools for example-angular (code generation, documentation, best practices) |
+| **svelte**      | Svelte/SvelteKit documentation and code analysis for example-svelte                    |
+
+**Configuration files:**
+
+- `.mcp.json` - Standard MCP configuration (Cursor, VS Code, Claude, etc.)
+- `.cursor/mcp.json` - Cursor-specific configuration
+
+To use MCP servers in Cursor, the configuration is automatically loaded from `.cursor/mcp.json`. For VS Code, add the MCP extension and configure it to use `.mcp.json`, or add the server definitions to your MCP settings.
 
 ### 6. Cursor Rules / Skills - Optional
 
-When you open this repository in [Cursor](https://www.cursor.com/), the following rules and skills are automatically applied so the AI generates Conventional Commits compliant commit messages and PR titles:
+This repository ships [Cursor](https://www.cursor.com/) rules under `.cursor/rules/` (grouped by topic: `commits/` for Conventional Commits and PR titles, `typescript/`, `rxjs/`, `angular/`, `nx/` including Nx workspace tasks and **commit scope** guidance, `examples/`, and `workflow/`). Rules are split into small `.mdc` files by responsibility to reduce overlap and keep prompts focused.
+
+When you open this repository in Cursor, the following rules and skills help the AI generate Conventional Commits compliant commit messages and PR titles:
 
 - `.cursor/rules/commits/40-conventional-commits.mdc`: Conventional Commits base rule
 - `.cursor/rules/commits/41-pull-request-title.mdc`: PR title convention
 - `.cursor/rules/nx/30-nx-project-scope.mdc`: Resolve scope from `project.json` `name`
 - `.cursor/skills/conventional-commits/`: Examples / assertions / scope list
+
+- `.cursor/agents/ci-monitor-subagent.md` — optional CI helper used with `/monitor-ci` and the Nx MCP `ci_information` / `update_self_healing_fix` tools when Nx Cloud CI monitoring is enabled.
+
+Commit scope tables stay aligned with `commitlint.config.js`; see `.cursor/skills/conventional-commits/` for examples and the scope list.
 
 When you add or rename a `project.json`, keep `commitlint.config.js` (`scope-enum`), `.cursor/skills/conventional-commits/scopes.md`, and `.cursor/rules/nx/30-nx-project-scope.mdc` in sync.
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -6,17 +6,23 @@
 
 Web Serial API を最小限の Session 指向 RxJS API でラップする TypeScript ライブラリです。公開 API は単一の `SerialSession` を提供し、アプリケーション側は `state$`（canonical lifecycle state）/ `errors$`（error event channel）/ `receive$` / `lines$` を購読するだけで UI を駆動できます。BehaviorSubject による状態再構築・read loop・送信キューの自前実装は一切不要です。
 
+**主な対象読者:** この README は主に**ライブラリ利用者**向けです（インストール、接続、サンプル、Guide）。コントリビュータ・メンテナは [貢献](#貢献) および [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) から始めてください。短い [npm パッケージ README](packages/web-serial-rxjs/README.ja.md) は `@gurezo/web-serial-rxjs` と一緒に公開される利用者向け索引です。このリポジトリ README はモノレポのハブ（`apps/` のサンプル、貢献、開発ツール案内）です。
+
 ## 目次
 
-- [SerialSession の全体像](#serialsessionの全体像)
 - [機能](#機能)
 - [対応フレームワーク](#対応フレームワーク)
 - [ブラウザサポート](#ブラウザサポート)
 - [インストール](#インストール)
+- [SerialSession の全体像](#serialsessionの全体像)
 - [ドキュメント](#ドキュメント)
 - [サンプル](#サンプル)
-- [プロジェクトアイコンについて](#プロジェクトアイコンについて)
+- [マイグレーション](#マイグレーション)
+- [トラブルシューティング](#トラブルシューティング)
 - [貢献](#貢献)
+- [開発ツール](#開発ツール)
+- [開発とリリース戦略](#開発とリリース戦略)
+- [プロジェクトアイコンについて](#プロジェクトアイコンについて)
 - [セキュリティ](#セキュリティ)
 - [ライセンス](#ライセンス)
 - [リンク](#リンク)
@@ -93,9 +99,12 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 
 **公開ドキュメントサイト:** [gurezo.net/web-serial-rxjs](https://gurezo.net/web-serial-rxjs/)
 
+**役割分担:** [npm パッケージ README](packages/web-serial-rxjs/README.ja.md) はパッケージ同梱の短い利用者向け索引、**このリポジトリ README** はモノレポのサンプル・貢献入口・開発ツール案内です。
+
 | ドキュメント | 用途 |
 | --- | --- |
 | **この README** | モノレポのハブ：機能要約、サンプル、貢献導線。 |
+| **[npm パッケージ README](packages/web-serial-rxjs/README.ja.md)** | `@gurezo/web-serial-rxjs` と同梱される短い利用者向け索引。 |
 | **[日本語 Guide（公開サイト）](https://gurezo.net/web-serial-rxjs/guide/ja/README.html)** | Getting Started の読み順と一覧（公開サイト）。 |
 | **[English Guide（公開サイト）](https://gurezo.net/web-serial-rxjs/guide/en/README.html)** | Getting Started reading order and full index on the published site. |
 | **[API Reference（公開サイト）](https://gurezo.net/web-serial-rxjs/api/index.html)** | 英語 TypeDoc API Reference（公開サイト）。 |
@@ -124,29 +133,19 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 
 各例には、セットアップと使用方法の説明を含む README が含まれています。
 
-## プロジェクトアイコンについて
+## マイグレーション
 
-このプロジェクトのアイコンには、[RxJS](https://rxjs.dev/) のロゴから着想を得たデザインに、
-Web Serial を表すシリアルコネクタのモチーフを組み合わせたものを使用しています。
+旧メジャーバージョンからのアップグレード:
 
-このアイコンは、本ライブラリが Web Serial API を RxJS ベースで扱うための
-ライブラリであることを示す目的でのみ使用しています。
+- [v3 → v4 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v4.md)（[English](packages/web-serial-rxjs/docs/guide/en/migration-v4.md)）
+- [v2 → v3 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v3.md)（[English](packages/web-serial-rxjs/docs/guide/en/migration-v3.md)）
+- [v1 → v2 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v2.md)（[English](packages/web-serial-rxjs/docs/guide/en/migration-v2.md)）
 
-本プロジェクトは **[ReactiveX](http://reactivex.io/) / [RxJS](https://rxjs.dev/) 公式とは関係のない独立したオープンソースプロジェクト** であり、
-公式な提携・承認・スポンサー関係はありません。
+## トラブルシューティング
 
-## 開発とリリース戦略
+Web Serial / セッションのよくある問題と自己解決手順:
 
-このプロジェクトは**trunk-based開発**アプローチに従います：
-
-- **`main`ブランチ**: 常にリリース可能な状態
-- **短命ブランチ**: `feature/*`, `fix/*`, `docs/*` はプルリクエスト用
-- **リリース**: ブランチではなくGitタグ（例: `v1.0.0`）で管理
-- **バージョン保守**: 複数のメジャーバージョンを保守する必要がある場合のみ `release/v*` ブランチを追加
-
-詳細な貢献ガイドラインについては、[CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) を参照してください。
-
-詳細なリリース手順については、[RELEASING.ja.md](RELEASING.ja.md) を参照してください。
+- [トラブルシューティング（日本語 Guide）](packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md)（[English](packages/web-serial-rxjs/docs/guide/en/troubleshooting.md)）
 
 ## 貢献
 
@@ -161,6 +160,33 @@ Web Serial を表すシリアルコネクタのモチーフを組み合わせた
 英語版の貢献ガイドは [CONTRIBUTING.md](CONTRIBUTING.md) を参照してください。
 
 リリース手順については、[RELEASING.ja.md](RELEASING.ja.md)（または英語版は [RELEASING.md](RELEASING.md)）を参照してください。
+
+## 開発ツール
+
+このリポジトリでの AI 支援開発について:
+
+- **MCP サーバー**（Nx、Angular CLI、Svelte）と設定 — CONTRIBUTING.ja.md の [AI アシスタント（MCP）](CONTRIBUTING.ja.md#5-ai-アシスタントmcp--任意) を参照
+- **Cursor rules / skills / agents** — CONTRIBUTING.ja.md の [Cursor Rules / Skills](CONTRIBUTING.ja.md#6-cursor-rules--skills--任意) を参照
+
+English: see the same sections in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## 開発とリリース戦略
+
+このプロジェクトは **trunk-based 開発**に従います。`main` は常にリリース可能、作業は短命の `feature/*` / `fix/*` / `docs/*` プルリクエスト経由、リリースは Git タグ（例: `v1.0.0`）です。
+
+- 貢献の詳細: [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)
+- リリース手順: [RELEASING.ja.md](RELEASING.ja.md)
+
+## プロジェクトアイコンについて
+
+このプロジェクトのアイコンには、[RxJS](https://rxjs.dev/) のロゴから着想を得たデザインに、
+Web Serial を表すシリアルコネクタのモチーフを組み合わせたものを使用しています。
+
+このアイコンは、本ライブラリが Web Serial API を RxJS ベースで扱うための
+ライブラリであることを示す目的でのみ使用しています。
+
+本プロジェクトは **[ReactiveX](http://reactivex.io/) / [RxJS](https://rxjs.dev/) 公式とは関係のない独立したオープンソースプロジェクト** であり、
+公式な提携・承認・スポンサー関係はありません。
 
 ## セキュリティ
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -16,7 +16,6 @@ Web Serial API を最小限の Session 指向 RxJS API でラップする TypeSc
 - [ドキュメント](#ドキュメント)
 - [サンプル](#サンプル)
 - [プロジェクトアイコンについて](#プロジェクトアイコンについて)
-- [AI アシスタント（MCP）](#ai-アシスタントmcp)
 - [貢献](#貢献)
 - [セキュリティ](#セキュリティ)
 - [ライセンス](#ライセンス)
@@ -135,31 +134,6 @@ Web Serial を表すシリアルコネクタのモチーフを組み合わせた
 
 本プロジェクトは **[ReactiveX](http://reactivex.io/) / [RxJS](https://rxjs.dev/) 公式とは関係のない独立したオープンソースプロジェクト** であり、
 公式な提携・承認・スポンサー関係はありません。
-
-## AI アシスタント（MCP）
-
-このプロジェクトには、AI 支援開発向けの [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) サーバー設定が含まれています。利用可能な MCP サーバーは次のとおりです。
-
-| サーバー | 用途 |
-| -------- | ---- |
-| **nx-mcp** | Nx ワークスペース分析、プロジェクトグラフ、CI 監視、ドキュメント |
-| **angular-cli** | example-angular 向け Angular CLI ツール（コード生成、ドキュメント、ベストプラクティス） |
-| **svelte** | example-svelte 向け Svelte / SvelteKit ドキュメントとコード分析 |
-
-**設定ファイル:**
-
-- `.mcp.json` — 標準 MCP 設定（Cursor、VS Code、Claude など）
-- `.cursor/mcp.json` — Cursor 専用設定
-
-Cursor では `.cursor/mcp.json` から設定が自動的に読み込まれます。VS Code では MCP 拡張機能を追加し `.mcp.json` を使うか、MCP 設定にサーバー定義を追加してください。
-
-### Cursor rules と agents
-
-このリポジトリには `.cursor/rules/` 配下に [Cursor](https://www.cursor.com/) 用ルールも同梱されています（トピック別: Conventional Commits と PR タイトル用の `commits/`、`typescript/`、`rxjs/`、`angular/`、Nx ワークスペースタスクと **commit scope** ガイドを含む `nx/`、`examples/`、`workflow/`）。ルールは責務ごとに小さな `.mdc` ファイルへ分割し、重複を減らしてプロンプトを絞り込んでいます。
-
-- `.cursor/agents/ci-monitor-subagent.md` — Nx Cloud CI 監視が有効な場合に `/monitor-ci` および Nx MCP の `ci_information` / `update_self_healing_fix` ツールと併用する任意の CI ヘルパー
-
-commit scope の表は `commitlint.config.js` と整合します。例と scope 一覧は `.cursor/skills/conventional-commits/` を参照してください。
 
 ## 開発とリリース戦略
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,23 @@
 
 A TypeScript library that wraps the Web Serial API with a minimal, session-oriented RxJS surface. The public API exposes a single `SerialSession` so applications can drive their UI from `state$` (canonical lifecycle state) + `errors$` (error event channel) + `receive$` + `lines$`, without rebuilding state, read loops, or send queues themselves.
 
+**Audience:** This README is primarily for **library users** (install, connect, Examples, Guide). Contributors and maintainers should start from [Contributing](#contributing) and [CONTRIBUTING.md](CONTRIBUTING.md). The short [npm package README](packages/web-serial-rxjs/README.md) is the consumer-facing index published with `@gurezo/web-serial-rxjs`; this repository README is the monorepo hub (examples under `apps/`, contribution, and development tools).
+
 ## Table of Contents
 
-- [SerialSession at a glance](#serialsession-at-a-glance)
 - [Features](#features)
 - [Framework Support](#framework-support)
 - [Browser Support](#browser-support)
 - [Installation](#installation)
+- [SerialSession at a glance](#serialsession-at-a-glance)
 - [Documentation](#documentation)
 - [Examples](#examples)
-- [Project Icon](#project-icon)
+- [Migration](#migration)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
+- [Development tools](#development-tools)
+- [Development and Release Strategy](#development-and-release-strategy)
+- [Project Icon](#project-icon)
 - [Security](#security)
 - [License](#license)
 - [Links](#links)
@@ -93,9 +99,12 @@ Documentation is split into **Guide** (how to use; Japanese and English hand-wri
 
 **Published documentation site:** [gurezo.net/web-serial-rxjs](https://gurezo.net/web-serial-rxjs/)
 
+**Role split:** use the [npm package README](packages/web-serial-rxjs/README.md) for a short consumer index shipped with the package; use **this repository README** for monorepo examples, contribution entry points, and development-tool pointers.
+
 | Doc | Use it for |
 | --- | --- |
 | **This README** | Monorepo hub: feature summary, examples, and contribution links. |
+| **[npm package README](packages/web-serial-rxjs/README.md)** | Short consumer-facing index published with `@gurezo/web-serial-rxjs`. |
 | **[English Guide (site)](https://gurezo.net/web-serial-rxjs/guide/en/README.html)** | Getting Started reading order and full index on the published site. |
 | **[日本語 Guide (site)](https://gurezo.net/web-serial-rxjs/guide/ja/README.html)** | Getting Started の読み順と一覧（公開サイト）。 |
 | **[API Reference (site)](https://gurezo.net/web-serial-rxjs/api/index.html)** | English TypeDoc API Reference on the published site. |
@@ -124,29 +133,19 @@ Each sample is a **minimal smoke test** for **connect**, **receive** (terminal-s
 
 Each example includes a README with setup and usage instructions.
 
-## Project Icon
+## Migration
 
-The project icon includes a modified design inspired by the [RxJS](https://rxjs.dev/) logo,
-combined with a serial connector motif to represent Web Serial communication.
+Upgrading from an older major version:
 
-The icon is used only to indicate that this library provides
-RxJS-based abstractions for the Web Serial API.
+- [v3 → v4 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v4.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/migration-v4.md)
+- [v2 → v3 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v3.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/migration-v3.md)
+- [v1 → v2 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v2.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/migration-v2.md)
 
-This project is an independent open source project and is **not affiliated with,
-endorsed by, or sponsored by the [ReactiveX](http://reactivex.io/) or [RxJS](https://rxjs.dev/) project**.
+## Troubleshooting
 
-## Development and Release Strategy
+Common Web Serial / session problems and self-help checks:
 
-This project follows a **trunk-based development** approach:
-
-- **`main` branch**: Always in a release-ready state
-- **Short-lived branches**: `feature/*`, `fix/*`, `docs/*` for pull requests
-- **Releases**: Managed via Git tags (e.g., `v1.0.0`), not branches
-- **Version maintenance**: `release/v*` branches are added only when needed for maintaining multiple major versions
-
-For detailed contribution guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
-For detailed release instructions, see [RELEASING.md](RELEASING.md).
+- [Troubleshooting (English Guide)](packages/web-serial-rxjs/docs/guide/en/troubleshooting.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md)
 
 ## Contributing
 
@@ -161,6 +160,33 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 For Japanese contributors, please see [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md).
 
 For release instructions, see [RELEASING.md](RELEASING.md) (or [RELEASING.ja.md](RELEASING.ja.md) for Japanese).
+
+## Development tools
+
+For AI-assisted development in this repository:
+
+- **MCP servers** (Nx, Angular CLI, Svelte) and configuration — see [AI Assistant (MCP)](CONTRIBUTING.md#5-ai-assistant-mcp---optional) in CONTRIBUTING
+- **Cursor rules, skills, and agents** — see [Cursor Rules / Skills](CONTRIBUTING.md#6-cursor-rules--skills---optional) in CONTRIBUTING
+
+日本語は [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md) の同セクションを参照してください。
+
+## Development and Release Strategy
+
+This project follows **trunk-based development**: `main` stays release-ready; work lands via short-lived `feature/*` / `fix/*` / `docs/*` pull requests; releases are Git tags (for example `v1.0.0`).
+
+- Contribution details: [CONTRIBUTING.md](CONTRIBUTING.md)
+- Release instructions: [RELEASING.md](RELEASING.md)
+
+## Project Icon
+
+The project icon includes a modified design inspired by the [RxJS](https://rxjs.dev/) logo,
+combined with a serial connector motif to represent Web Serial communication.
+
+The icon is used only to indicate that this library provides
+RxJS-based abstractions for the Web Serial API.
+
+This project is an independent open source project and is **not affiliated with,
+endorsed by, or sponsored by the [ReactiveX](http://reactivex.io/) or [RxJS](https://rxjs.dev/) project**.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ A TypeScript library that wraps the Web Serial API with a minimal, session-orien
 - [Documentation](#documentation)
 - [Examples](#examples)
 - [Project Icon](#project-icon)
-- [AI Assistant (MCP)](#ai-assistant-mcp)
 - [Contributing](#contributing)
 - [Security](#security)
 - [License](#license)
@@ -135,31 +134,6 @@ RxJS-based abstractions for the Web Serial API.
 
 This project is an independent open source project and is **not affiliated with,
 endorsed by, or sponsored by the [ReactiveX](http://reactivex.io/) or [RxJS](https://rxjs.dev/) project**.
-
-## AI Assistant (MCP)
-
-This project includes [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server configuration for AI-assisted development. The following MCP servers are available:
-
-| Server          | Purpose                                                                                |
-| --------------- | -------------------------------------------------------------------------------------- |
-| **nx-mcp**      | Nx workspace analysis, project graph, CI monitoring, and documentation                 |
-| **angular-cli** | Angular CLI tools for example-angular (code generation, documentation, best practices) |
-| **svelte**      | Svelte/SvelteKit documentation and code analysis for example-svelte                    |
-
-**Configuration files:**
-
-- `.mcp.json` - Standard MCP configuration (Cursor, VS Code, Claude, etc.)
-- `.cursor/mcp.json` - Cursor-specific configuration
-
-To use MCP servers in Cursor, the configuration is automatically loaded from `.cursor/mcp.json`. For VS Code, add the MCP extension and configure it to use `.mcp.json`, or add the server definitions to your MCP settings.
-
-### Cursor rules and agents
-
-This repository also ships [Cursor](https://www.cursor.com/) rules under `.cursor/rules/` (grouped by topic: `commits/` for Conventional Commits and PR titles, `typescript/`, `rxjs/`, `angular/`, `nx/` including Nx workspace tasks and **commit scope** guidance, `examples/`, and `workflow/`). Rules are split into small `.mdc` files by responsibility to reduce overlap and keep prompts focused.
-
-- `.cursor/agents/ci-monitor-subagent.md` — optional CI helper used with `/monitor-ci` and the Nx MCP `ci_information` / `update_self_healing_fix` tools when Nx Cloud CI monitoring is enabled.
-
-Commit scope tables stay aligned with `commitlint.config.js`; see `.cursor/skills/conventional-commits/` for examples and the scope list.
 
 ## Development and Release Strategy
 

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -118,7 +118,8 @@ pnpm add rxjs
 | [v3 → v4 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md) | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理） |
 | [v2 → v3 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md) | `state$` discriminated union、`SerialSessionStatus`、`context.cause` |
 | [v1 → v2 マイグレーション](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v2.md) | 廃止された v1 API の置き換え |
-| **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ構成、**`apps/` のサンプル**、貢献、MCP、プロジェクトアイコン |
+| **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポのハブ：**`apps/` のサンプル**、貢献入口、開発ツール案内 |
+| **[CONTRIBUTING](https://github.com/gurezo/web-serial-rxjs/blob/main/CONTRIBUTING.ja.md#5-ai-アシスタントmcp--任意)** | リポジトリ貢献者向けの MCP / Cursor 設定 |
 
 ## ライセンス
 

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -122,7 +122,8 @@ pnpm add rxjs
 | [v3 → v4 migration](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v4.md) | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup) |
 | [v2 → v3 migration](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v3.md) | `state$` discriminated union, `SerialSessionStatus`, `context.cause` |
 | [v1 → v2 migration](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v2.md) | Replacing the removed v1 `SerialClient` / `ShellClient` API |
-| [Repository README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md) | Monorepo layout, **examples** under `apps/`, contributing, MCP, and project icon |
+| [Repository README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md) | Monorepo hub: **examples** under `apps/`, contribution entry, development-tool pointers |
+| [CONTRIBUTING](https://github.com/gurezo/web-serial-rxjs/blob/main/CONTRIBUTING.md#5-ai-assistant-mcp---optional) | MCP / Cursor setup for repository contributors |
 
 ## License
 


### PR DESCRIPTION
## PR Title (Conventional Commits)

docs(workspace): reorganize readme for library users

## Summary

ルート README をライブラリ利用者優先の構成へ再編し、MCP / Cursor の詳細を CONTRIBUTING へ移動しました。開発・リリース戦略は要約のみ残し、英語・日本語の情報設計を揃えています（#542 / 親 #535）。

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues

- Fixes #542
- Parent: #535

## What changed?

- ルート README に主な対象読者と npm パッケージ README との役割分担を明記
- 利用者向けセクション（Features〜Examples / Migration / Troubleshooting）を上部へ集約
- MCP / Cursor の詳細を CONTRIBUTING(.ja) へ移動し、README には短い開発ツール案内を残置
- Development and Release Strategy を要約化し、RELEASING へのリンクを維持
- 英語・日本語 README / CONTRIBUTING / パッケージ README の相互リンクを更新

## API / Compatibility

- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test

1. ルート `README.md` / `README.ja.md` を上から読み、Installation → Quick Start 導線 → Examples が MCP 詳細より先に見えることを確認する
2. `CONTRIBUTING.md` / `CONTRIBUTING.ja.md` の §5 / §6 に MCP 表と Cursor 説明があることを確認する
3. 旧アンカー `README.md#ai-assistant-mcp` / `README.ja.md#ai-アシスタントmcp` への参照が残っていないことを確認する
4. パッケージ README の Repository / CONTRIBUTING 行が意図どおりであることを確認する
5. EN / JA の見出し構成が対応していることを確認する

## Environment (if relevant)

- Browser: N/A（ドキュメントのみ）
- OS: N/A
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist

- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)