### PR TITLE
ci(web-serial-rxjs): verify npm pack contents and consumer imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,8 @@ jobs:
       - name: Verify publish dist artifacts
         run: pnpm exec nx run web-serial-rxjs:verify-dist
 
+      - name: Verify npm pack contents
+        run: pnpm exec nx run web-serial-rxjs:verify-pack
+
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,30 +31,7 @@ jobs:
       - run: pnpm test
       - run: pnpm exec nx build web-serial-rxjs
       - run: pnpm exec nx run web-serial-rxjs:verify-dist
-      - name: Verify npm package includes required files
-        shell: bash
-        run: |
-          set -euo pipefail
-          PACK_RESULT="$(npm pack --dry-run --json ./packages/web-serial-rxjs)"
-
-          node -e '
-            const result = JSON.parse(process.argv[1]);
-            const files = (result[0]?.files ?? []).map((file) => file.path);
-            const required = [
-              "README.md",
-              "README.ja.md",
-              "dist/index.mjs",
-              "dist/index.d.ts",
-            ];
-            const missing = required.filter((path) => !files.includes(path));
-
-            if (missing.length > 0) {
-              console.error(`Missing files in npm pack output: ${missing.join(", ")}`);
-              process.exit(1);
-            }
-
-            console.log("Verified npm pack includes required publish files.");
-          ' "$PACK_RESULT"
+      - run: pnpm exec nx run web-serial-rxjs:verify-pack
 
       # リリース添付用の zip を作る（パッケージ単位）
       - name: Create release zip

--- a/RELEASING.ja.md
+++ b/RELEASING.ja.md
@@ -92,11 +92,20 @@ git push origin v1.0.0
 2. ✅ 依存関係をインストール（`pnpm install --frozen-lockfile`）
 3. ✅ テストを実行（`pnpm test`）
 4. ✅ パッケージをビルド（`pnpm exec nx build web-serial-rxjs`）— npm publish と同じ package scripts 経由
-5. ✅ 配布用 dist 成果物（`dist/index.mjs`, `dist/index.d.ts`）と npm pack 内容を検証
+5. ✅ `verify:dist`（ビルド済み `dist/` + 公開 API allowlist）と `verify:pack`（npm tarball 内容、package metadata、README リンク、消費者 ESM/型 smoke）を実行
 6. ✅ リリース用 zip ファイルを作成
 7. ✅ Trusted Publishing (OIDC) を使用して npm に公開 - トークン不要！
 8. ✅ 自動生成されたリリースノート付きの GitHub リリースを作成
 9. ✅ GitHub リリースにリリース zip を添付
+
+**検証の責務分担**（PR の CI でも実行）:
+
+| コマンド | 検証内容 |
+| --- | --- |
+| `pnpm exec nx run web-serial-rxjs:verify-dist` | ビルド直後の `dist/` 成果物と公開 API 表面 |
+| `pnpm exec nx run web-serial-rxjs:verify-pack` | npm tarball: 必須ファイル、禁止パス、`homepage` / `repository` / `bugs`、README の削除済み API 表記、主要リンク、ローカル消費者 import/型 smoke（`tools/package-smoke-test`） |
+
+npm レジストリへの公開**後**の自動 smoke は対象外です。各リリース後はステップ 5 の手動インストール確認を行ってください。
 
 進行状況は GitHub の [Actions タブ](https://github.com/gurezo/web-serial-rxjs/actions) で確認できます。
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -92,11 +92,20 @@ Once you push the tag, GitHub Actions automatically:
 2. ✅ Installs dependencies (`pnpm install --frozen-lockfile`)
 3. ✅ Runs tests (`pnpm test`)
 4. ✅ Builds the package (`pnpm exec nx build web-serial-rxjs`) via the same package scripts used for npm publish
-5. ✅ Verifies publish dist artifacts (`dist/index.mjs`, `dist/index.d.ts`) and npm pack contents
+5. ✅ Runs `verify:dist` (built `dist/` + public API allowlist) and `verify:pack` (npm tarball contents, package metadata, README links, consumer ESM/types smoke)
 6. ✅ Creates a release zip file
 7. ✅ Publishes to npm using Trusted Publishing (OIDC) - no tokens needed!
 8. ✅ Creates a GitHub Release with auto-generated release notes
 9. ✅ Attaches the release zip to the GitHub Release
+
+**Verification split** (also run on pull requests via CI):
+
+| Command | What it checks |
+| --- | --- |
+| `pnpm exec nx run web-serial-rxjs:verify-dist` | Post-build `dist/` artifacts and public API surface |
+| `pnpm exec nx run web-serial-rxjs:verify-pack` | Packed npm tarball: required files, forbidden paths, `homepage` / `repository` / `bugs`, README removed-API wording, major links, local consumer import/types smoke (`tools/package-smoke-test`) |
+
+Automated **post-publish** smoke against the live npm registry is intentionally out of scope; use the manual install check in Step 5 after each release.
 
 You can monitor the progress in the [Actions tab](https://github.com/gurezo/web-serial-rxjs/actions) on GitHub.
 

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -6,7 +6,7 @@
 
 Web Serial API を最小限の Session 指向 RxJS 表面でラップする TypeScript ライブラリです。公開 API は単一の `SerialSession` を提供し、`state$`（canonical lifecycle state）/ `errors$`（error event channel）/ `receive$` / `lines$` を購読するだけで UI を駆動できます。read loop や送信キューの自前実装は不要です。
 
-**主対象は UTF-8 テキスト通信です。** 受信データは常にストリーミング UTF-8 `TextDecoder` でデコードされます。`receive$` が返すのは**デコード済みテキストチャンク**（行未分割）であり、ワイヤ上の生バイトではありません。バイナリ**送信**（`send$(Uint8Array)`）は対応しますが、バイナリ**受信**・UTF-8 以外の文字コード・プロトコルフレーミング（Modbus / COBS / SLIP など）は対象外です。詳細は下記の [対応範囲](#対応範囲テキスト--バイナリ--文字コード) と [API の概念](./docs/guide/ja/concepts.md#対応範囲テキスト--バイナリ--文字コード) を参照してください。
+**主対象は UTF-8 テキスト通信です。** 受信データは常にストリーミング UTF-8 `TextDecoder` でデコードされます。`receive$` が返すのは**デコード済みテキストチャンク**（行未分割）であり、ワイヤ上の生バイトではありません。バイナリ**送信**（`send$(Uint8Array)`）は対応しますが、バイナリ**受信**・UTF-8 以外の文字コード・プロトコルフレーミング（Modbus / COBS / SLIP など）は対象外です。詳細は下記の [対応範囲](#対応範囲テキスト--バイナリ--文字コード) と [API の概念](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/concepts.md#対応範囲テキスト--バイナリ--文字コード) を参照してください。
 
 ## ブラウザサポート
 
@@ -25,11 +25,11 @@ Web Serial API は**デスクトップ**ブラウザでのみサポートされ�
 
 ## 接続状態（ライフサイクル UI）
 
-ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。セッション破棄には **`dispose$()`** を使用します（購読により実行されます）。詳細は [v4 への移行](./docs/guide/ja/migration-v4.md) を参照してください。
+ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。セッション破棄には **`dispose$()`** を使用します（購読により実行されます）。詳細は [v4 への移行](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md) を参照してください。
 
 ## 接続中のポート情報（デバイス識別）
 
-`connect$` 成功後、`state$` を `state.status === SerialSessionStatus.Connected` で handling する場合は **`state.portInfo`** を canonical API として使用してください。生の `SerialPort` は公開しません。削除された convenience API（`isConnected$`、`portInfo$`、`getPortInfo()`、`destroy$()`、`getCurrentPort()`、`receiveReplay$`、`isBrowserSupported()`）と置換先は [v4 への移行](./docs/guide/ja/migration-v4.md) を参照してください。
+`connect$` 成功後、`state$` を `state.status === SerialSessionStatus.Connected` で handling する場合は **`state.portInfo`** を canonical API として使用してください。生の `SerialPort` は公開しません。削除された convenience API（`isConnected$`、`portInfo$`、`getPortInfo()`、`destroy$()`、`getCurrentPort()`、`receiveReplay$`、`isBrowserSupported()`）と置換先は [v4 への移行](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md) を参照してください。
 
 ## 対応範囲（テキスト / バイナリ / 文字コード）
 
@@ -44,7 +44,7 @@ Web Serial API は**デスクトップ**ブラウザでのみサポートされ�
 | UTF-8 以外の文字コード | **非対応** |
 | 特定プロトコル（Modbus / COBS / SLIP など） | **利用側で実装** |
 
-詳細と将来検討時の設計論点: [API の概念 — 対応範囲](./docs/guide/ja/concepts.md#対応範囲テキスト--バイナリ--文字コード)。
+詳細と将来検討時の設計論点: [API の概念 — 対応範囲](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/concepts.md#対応範囲テキスト--バイナリ--文字コード)。
 
 ## `receive$` と `lines$`
 

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -6,7 +6,7 @@
 
 A TypeScript library that wraps the Web Serial API with a minimal, session-oriented RxJS surface. The public API exposes a single `SerialSession` so applications can drive their UI from `state$` (canonical lifecycle state) + `errors$` (error event channel) + `receive$` + `lines$`, without rebuilding read loops or send queues themselves.
 
-**Primary focus: UTF-8 text.** Incoming data is always decoded with a streaming UTF-8 `TextDecoder`. `receive$` emits **decoded text chunks** (unframed), not raw wire bytes. Binary **send** via `send$(Uint8Array)` is supported; binary **receive**, non-UTF-8 charsets, and protocol framing (Modbus, COBS, SLIP, …) are out of scope. See [Supported data](#supported-data-text--binary--charset) below and [API concepts](./docs/guide/en/concepts.md#supported-data-text--binary--charset).
+**Primary focus: UTF-8 text.** Incoming data is always decoded with a streaming UTF-8 `TextDecoder`. `receive$` emits **decoded text chunks** (unframed), not raw wire bytes. Binary **send** via `send$(Uint8Array)` is supported; binary **receive**, non-UTF-8 charsets, and protocol framing (Modbus, COBS, SLIP, …) are out of scope. See [Supported data](#supported-data-text--binary--charset) below and [API concepts](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/concepts.md#supported-data-text--binary--charset).
 
 ## Browser support
 
@@ -25,11 +25,11 @@ Supported desktop browsers:
 
 ## Connection state (lifecycle UI)
 
-Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. Session teardown uses **`dispose$()`** (subscribe to run it). See [Migrating to v4](./docs/guide/en/migration-v4.md).
+Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. Session teardown uses **`dispose$()`** (subscribe to run it). See [Migrating to v4](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v4.md).
 
 ## Port info (device identification)
 
-After a successful `connect$`, use `state.portInfo` when handling `state$` with `state.status === SerialSessionStatus.Connected` — this is the canonical API. Raw `SerialPort` is not exposed. Removed convenience APIs (`isConnected$`, `portInfo$`, `getPortInfo()`, `destroy$()`, `getCurrentPort()`, `receiveReplay$`, `isBrowserSupported()`) and their replacements are documented in [Migrating to v4](./docs/guide/en/migration-v4.md).
+After a successful `connect$`, use `state.portInfo` when handling `state$` with `state.status === SerialSessionStatus.Connected` — this is the canonical API. Raw `SerialPort` is not exposed. Removed convenience APIs (`isConnected$`, `portInfo$`, `getPortInfo()`, `destroy$()`, `getCurrentPort()`, `receiveReplay$`, `isBrowserSupported()`) and their replacements are documented in [Migrating to v4](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v4.md).
 
 ## Supported data (text / binary / charset)
 
@@ -44,7 +44,7 @@ After a successful `connect$`, use `state.portInfo` when handling `state$` with 
 | Non-UTF-8 charsets | **Not supported** |
 | Protocol framing (Modbus, COBS, SLIP, …) | **Application-side** |
 
-Full notes and future design considerations: [API concepts — Supported data](./docs/guide/en/concepts.md#supported-data-text--binary--charset).
+Full notes and future design considerations: [API concepts — Supported data](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/concepts.md#supported-data-text--binary--charset).
 
 ## `receive$` vs `lines$`
 

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -27,6 +27,7 @@
     "build:copy-files": "cp ../../LICENSE . 2>/dev/null || true",
     "build:cleanup": "rm -rf dist/packages dist/package.json 2>/dev/null || true",
     "verify:dist": "node scripts/verify-dist.mjs",
+    "verify:pack": "node scripts/verify-pack.mjs",
     "clean": "rm -rf dist",
     "prepublishOnly": "pnpm run build"
   },

--- a/packages/web-serial-rxjs/project.json
+++ b/packages/web-serial-rxjs/project.json
@@ -22,6 +22,13 @@
         "command": "pnpm run verify:dist",
         "cwd": "packages/web-serial-rxjs"
       }
+    },
+    "verify-pack": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "pnpm run verify:pack",
+        "cwd": "packages/web-serial-rxjs"
+      }
     }
   }
 }

--- a/packages/web-serial-rxjs/scripts/verify-pack.mjs
+++ b/packages/web-serial-rxjs/scripts/verify-pack.mjs
@@ -1,0 +1,415 @@
+/**
+ * Verify the npm tarball from a consumer perspective (Issue #543).
+ *
+ * Responsibility split with verify-dist.mjs:
+ * - verify:dist — post-build dist artifacts and public API allowlist
+ * - verify:pack — packed tarball contents, package metadata, README, links
+ *   (and optionally consumer ESM/types smoke via tools/package-smoke-test)
+ *
+ * Post-publish npm registry smoke is intentionally out of scope; see RELEASING.md.
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import { REMOVED_SESSION_APIS } from './public-api-allowlist.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageRoot = join(__dirname, '..');
+const workspaceRoot = join(packageRoot, '../..');
+const require = createRequire(import.meta.url);
+
+const REQUIRED_FILES = [
+  'README.md',
+  'README.ja.md',
+  'LICENSE',
+  'dist/index.mjs',
+  'dist/index.d.ts',
+  'package.json',
+];
+
+const FORBIDDEN_PREFIXES = ['src/', 'tests/', 'docs/', 'scripts/'];
+
+const EXPECTED_NAME = '@gurezo/web-serial-rxjs';
+const EXPECTED_HOMEPAGE = 'https://gurezo.net/web-serial-rxjs/';
+const EXPECTED_BUGS = 'https://github.com/gurezo/web-serial-rxjs/issues';
+const EXPECTED_REPO_SUBSTRING = 'github.com/gurezo/web-serial-rxjs';
+
+const REMOVAL_CONTEXT_RE = /Removed|削除|Migrat|移行|replacements|置換/i;
+
+/** Major URLs that must respond (docs site / GitHub / homepage). */
+const MAJOR_LINK_HOST_ALLOWLIST = [
+  'gurezo.net',
+  'github.com',
+  'raw.githubusercontent.com',
+  'wicg.github.io',
+];
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function listFilesRecursive(dir, base = dir) {
+  const entries = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const rel = relative(base, full).split(sep).join('/');
+    if (statSync(full).isDirectory()) {
+      entries.push(...listFilesRecursive(full, base));
+    } else {
+      entries.push(rel);
+    }
+  }
+  return entries;
+}
+
+function runNpmPack() {
+  const output = execFileSync('npm', ['pack', '--json'], {
+    cwd: packageRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const parsed = JSON.parse(output);
+  const filename = parsed[0]?.filename;
+  if (!filename) {
+    fail('npm pack did not return a filename');
+  }
+  const tarballPath = join(packageRoot, filename);
+  if (!existsSync(tarballPath)) {
+    fail(`npm pack tarball missing: ${tarballPath}`);
+  }
+  return tarballPath;
+}
+
+function extractTarball(tarballPath, extractRoot) {
+  execFileSync('tar', ['-xzf', tarballPath, '-C', extractRoot], {
+    stdio: 'inherit',
+  });
+  const packageDir = join(extractRoot, 'package');
+  if (!existsSync(packageDir)) {
+    fail(`Expected extracted package directory at ${packageDir}`);
+  }
+  return packageDir;
+}
+
+function assertRequiredFiles(packageDir, files) {
+  const missing = REQUIRED_FILES.filter((path) => !files.includes(path));
+  if (missing.length > 0) {
+    fail(`Missing required files in npm pack: ${missing.join(', ')}`);
+  }
+  console.log('Verified required publish files are present in the tarball.');
+}
+
+function assertNoForbiddenPaths(files) {
+  const forbidden = files.filter((path) =>
+    FORBIDDEN_PREFIXES.some(
+      (prefix) => path === prefix.slice(0, -1) || path.startsWith(prefix),
+    ),
+  );
+  if (forbidden.length > 0) {
+    fail(
+      `Forbidden paths found in npm pack (should not be published):\n${forbidden
+        .map((p) => `  - ${p}`)
+        .join('\n')}`,
+    );
+  }
+  console.log('Verified tarball does not include src/tests/docs/scripts.');
+}
+
+function assertPackageMetadata(packageDir) {
+  const pkg = JSON.parse(readFileSync(join(packageDir, 'package.json'), 'utf8'));
+
+  if (pkg.name !== EXPECTED_NAME) {
+    fail(`package.json name mismatch: actual=${pkg.name} expected=${EXPECTED_NAME}`);
+  }
+  if (pkg.homepage !== EXPECTED_HOMEPAGE) {
+    fail(
+      `package.json homepage mismatch: actual=${pkg.homepage} expected=${EXPECTED_HOMEPAGE}`,
+    );
+  }
+  const repoUrl = pkg.repository?.url ?? '';
+  if (!repoUrl.includes(EXPECTED_REPO_SUBSTRING)) {
+    fail(
+      `package.json repository.url must include ${EXPECTED_REPO_SUBSTRING}; got: ${repoUrl}`,
+    );
+  }
+  if (pkg.bugs?.url !== EXPECTED_BUGS) {
+    fail(
+      `package.json bugs.url mismatch: actual=${pkg.bugs?.url} expected=${EXPECTED_BUGS}`,
+    );
+  }
+
+  console.log('Verified package.json name, homepage, repository, and bugs URLs.');
+  return pkg;
+}
+
+function assertVersionMatchesTag(pkg) {
+  const refType = process.env.GITHUB_REF_TYPE;
+  const refName = process.env.GITHUB_REF_NAME;
+
+  if (refType !== 'tag' || !refName) {
+    console.log(
+      'Skipped package version ↔ Git tag check (not a tag CI run).',
+    );
+    return;
+  }
+
+  if (!/^v\d+\.\d+\.\d+/.test(refName)) {
+    fail(`Unexpected tag name for version check: ${refName}`);
+  }
+
+  const expectedVersion = refName.slice(1);
+  if (pkg.version !== expectedVersion) {
+    fail(
+      `package.json version (${pkg.version}) does not match Git tag ${refName} (expected ${expectedVersion})`,
+    );
+  }
+  console.log(`Verified package version ${pkg.version} matches tag ${refName}.`);
+}
+
+function splitMarkdownSegments(source) {
+  const segments = [];
+  const fenceRe = /```[\s\S]*?```/g;
+  let lastIndex = 0;
+  let match;
+  while ((match = fenceRe.exec(source)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({
+        kind: 'prose',
+        text: source.slice(lastIndex, match.index),
+      });
+    }
+    segments.push({ kind: 'code', text: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < source.length) {
+    segments.push({ kind: 'prose', text: source.slice(lastIndex) });
+  }
+  return segments;
+}
+
+function assertRemovedApisNotMisdocumented(packageDir) {
+  const readmeNames = ['README.md', 'README.ja.md'];
+  const apiPatterns = REMOVED_SESSION_APIS.map((name) => ({
+    name,
+    // Match API identifiers; allow optional () for function-style names.
+    re: new RegExp(
+      String.raw`\b${name.replace(/\$/g, '\\$')}(?:\s*\(\s*\))?`,
+      'g',
+    ),
+  }));
+
+  for (const readmeName of readmeNames) {
+    const source = readFileSync(join(packageDir, readmeName), 'utf8');
+    const segments = splitMarkdownSegments(source);
+
+    for (const segment of segments) {
+      for (const { name, re } of apiPatterns) {
+        re.lastIndex = 0;
+        if (!re.test(segment.text)) continue;
+
+        if (segment.kind === 'code') {
+          fail(
+            `${readmeName}: removed API "${name}" must not appear inside fenced code blocks`,
+          );
+        }
+
+        // Prose: require removal/migration context in the same paragraph.
+        const paragraphs = segment.text.split(/\n{2,}/);
+        for (const paragraph of paragraphs) {
+          re.lastIndex = 0;
+          if (!re.test(paragraph)) continue;
+          if (!REMOVAL_CONTEXT_RE.test(paragraph)) {
+            fail(
+              `${readmeName}: removed API "${name}" appears without removal/migration context:\n${paragraph.trim().slice(0, 200)}`,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  console.log(
+    'Verified package README does not present removed APIs as current usage.',
+  );
+}
+
+function extractMarkdownLinks(source) {
+  const links = [];
+  const mdLinkRe = /\[([^\]]*)\]\(([^)]+)\)/g;
+  let match;
+  while ((match = mdLinkRe.exec(source)) !== null) {
+    links.push(match[2].trim());
+  }
+  const hrefRe = /href="([^"]+)"/gi;
+  while ((match = hrefRe.exec(source)) !== null) {
+    links.push(match[1].trim());
+  }
+  const srcRe = /src="([^"]+)"/gi;
+  while ((match = srcRe.exec(source)) !== null) {
+    links.push(match[1].trim());
+  }
+  return links;
+}
+
+function assertRelativeLinksResolve(packageDir, readmeName, links) {
+  for (const href of links) {
+    if (
+      !href ||
+      href.startsWith('#') ||
+      href.startsWith('http://') ||
+      href.startsWith('https://') ||
+      href.startsWith('mailto:')
+    ) {
+      continue;
+    }
+
+    const pathPart = href.split('#')[0].split('?')[0];
+    if (!pathPart) continue;
+
+    const resolved = resolve(packageDir, pathPart);
+    const rel = relative(packageDir, resolved);
+    if (rel.startsWith('..') || !existsSync(resolved)) {
+      fail(
+        `${readmeName}: relative link does not resolve inside the npm tarball: ${href}`,
+      );
+    }
+  }
+}
+
+async function assertMajorHttpsLinks(links) {
+  const unique = [
+    ...new Set(
+      links.filter((href) => href.startsWith('https://')).map((href) => {
+        try {
+          const url = new URL(href);
+          // Drop fragment for fetch
+          url.hash = '';
+          return url.toString();
+        } catch {
+          return href;
+        }
+      }),
+    ),
+  ];
+
+  const major = unique.filter((href) => {
+    try {
+      const host = new URL(href).hostname;
+      return MAJOR_LINK_HOST_ALLOWLIST.some(
+        (allowed) => host === allowed || host.endsWith(`.${allowed}`),
+      );
+    } catch {
+      return false;
+    }
+  });
+
+  const failures = [];
+  for (const href of major) {
+    try {
+      let response = await fetch(href, { method: 'HEAD', redirect: 'follow' });
+      if (response.status === 405 || response.status === 403) {
+        response = await fetch(href, { method: 'GET', redirect: 'follow' });
+      }
+      if (!response.ok) {
+        failures.push(`${href} → HTTP ${response.status}`);
+      }
+    } catch (error) {
+      failures.push(`${href} → ${error.message}`);
+    }
+  }
+
+  if (failures.length > 0) {
+    fail(
+      `Major documentation / package links failed:\n${failures
+        .map((f) => `  - ${f}`)
+        .join('\n')}`,
+    );
+  }
+
+  console.log(`Verified ${major.length} major https link(s) respond successfully.`);
+}
+
+async function assertReadmeLinks(packageDir) {
+  for (const readmeName of ['README.md', 'README.ja.md']) {
+    const source = readFileSync(join(packageDir, readmeName), 'utf8');
+    const links = extractMarkdownLinks(source);
+    assertRelativeLinksResolve(packageDir, readmeName, links);
+    await assertMajorHttpsLinks(links);
+  }
+  console.log('Verified package README relative links resolve inside the tarball.');
+}
+
+async function maybeRunSmoke(tarballPath) {
+  const smokeDir = join(workspaceRoot, 'tools/package-smoke-test');
+  const smokeEntry = join(smokeDir, 'run-smoke.mjs');
+  if (!existsSync(smokeEntry)) {
+    console.log(
+      'Skipped package smoke fixture (tools/package-smoke-test/run-smoke.mjs not present yet).',
+    );
+    return;
+  }
+
+  const { runPackageSmoke } = await import(pathToFileURL(smokeEntry).href);
+  await runPackageSmoke(tarballPath);
+}
+
+function cleanup(paths) {
+  for (const path of paths) {
+    try {
+      if (existsSync(path)) {
+        rmSync(path, { recursive: true, force: true });
+      }
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+async function main() {
+  if (!existsSync(join(packageRoot, 'dist/index.mjs'))) {
+    fail(
+      'dist/index.mjs is missing; run `pnpm exec nx build web-serial-rxjs` before verify-pack',
+    );
+  }
+
+  const extractRoot = mkdtempSync(join(tmpdir(), 'web-serial-rxjs-pack-'));
+  let tarballPath;
+
+  try {
+    tarballPath = runNpmPack();
+    console.log(`Created tarball: ${relative(workspaceRoot, tarballPath)}`);
+
+    const packageDir = extractTarball(tarballPath, extractRoot);
+    const files = listFilesRecursive(packageDir);
+
+    assertRequiredFiles(packageDir, files);
+    assertNoForbiddenPaths(files);
+    const pkg = assertPackageMetadata(packageDir);
+    assertVersionMatchesTag(pkg);
+    assertRemovedApisNotMisdocumented(packageDir);
+    await assertReadmeLinks(packageDir);
+    await maybeRunSmoke(tarballPath);
+
+    console.log('verify:pack completed successfully.');
+  } finally {
+    cleanup([extractRoot, tarballPath].filter(Boolean));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/tools/package-smoke-test/.gitignore
+++ b/tools/package-smoke-test/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+packed.tgz
+package-lock.json

--- a/tools/package-smoke-test/package.json
+++ b/tools/package-smoke-test/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "web-serial-rxjs-package-smoke-test",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "description": "Consumer smoke fixture for npm pack verification (Issue #543). Not part of the pnpm workspace.",
+  "scripts": {
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@gurezo/web-serial-rxjs": "file:./packed.tgz",
+    "rxjs": "^7.8.0"
+  },
+  "devDependencies": {
+    "typescript": "~5.9.0"
+  }
+}

--- a/tools/package-smoke-test/run-smoke.mjs
+++ b/tools/package-smoke-test/run-smoke.mjs
@@ -1,0 +1,79 @@
+/**
+ * Install a local npm tarball into this fixture and verify consumer ESM + types.
+ * Invoked by packages/web-serial-rxjs/scripts/verify-pack.mjs.
+ */
+
+import { copyFileSync, existsSync, readFileSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { execFileSync } from 'node:child_process';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const smokeRoot = __dirname;
+const packedTgz = join(smokeRoot, 'packed.tgz');
+const installedPackageRoot = join(
+  smokeRoot,
+  'node_modules/@gurezo/web-serial-rxjs',
+);
+
+function run(command, args) {
+  execFileSync(command, args, {
+    cwd: smokeRoot,
+    stdio: 'inherit',
+  });
+}
+
+function resolvePackageImportEntry() {
+  const pkg = JSON.parse(
+    readFileSync(join(installedPackageRoot, 'package.json'), 'utf8'),
+  );
+  const importPath =
+    pkg.exports?.['.']?.import ?? pkg.module ?? pkg.main ?? null;
+  if (typeof importPath !== 'string') {
+    throw new Error(
+      'Installed @gurezo/web-serial-rxjs package.json has no exports["."].import',
+    );
+  }
+  return join(installedPackageRoot, importPath.replace(/^\.\//, ''));
+}
+
+export async function runPackageSmoke(tarballPath) {
+  if (!existsSync(tarballPath)) {
+    throw new Error(`Smoke test tarball missing: ${tarballPath}`);
+  }
+
+  rmSync(join(smokeRoot, 'node_modules'), { recursive: true, force: true });
+  rmSync(join(smokeRoot, 'package-lock.json'), { force: true });
+  copyFileSync(tarballPath, packedTgz);
+
+  try {
+    run('npm', ['install', '--no-fund', '--no-audit', '--ignore-scripts']);
+    run('npx', ['--no-install', 'tsc', '--noEmit', '-p', 'tsconfig.json']);
+
+    const packageEntry = resolvePackageImportEntry();
+    if (!existsSync(packageEntry)) {
+      throw new Error(`Package import entry missing: ${packageEntry}`);
+    }
+
+    const mod = await import(pathToFileURL(packageEntry).href);
+    const required = [
+      'createSerialSession',
+      'isWebSerialSupported',
+      'SerialSessionStatus',
+    ];
+    for (const name of required) {
+      if (!(name in mod)) {
+        throw new Error(`ESM import missing export: ${name}`);
+      }
+    }
+
+    console.log(
+      'Verified package smoke fixture: tsc --noEmit and ESM imports succeeded.',
+    );
+  } finally {
+    rmSync(packedTgz, { force: true });
+    rmSync(join(smokeRoot, 'node_modules'), { recursive: true, force: true });
+    rmSync(join(smokeRoot, 'package-lock.json'), { force: true });
+  }
+}

--- a/tools/package-smoke-test/src/index.ts
+++ b/tools/package-smoke-test/src/index.ts
@@ -1,0 +1,10 @@
+import {
+  createSerialSession,
+  isWebSerialSupported,
+  SerialSessionStatus,
+} from '@gurezo/web-serial-rxjs';
+
+// Keep references so tsc and the ESM runtime import stay meaningful.
+void createSerialSession;
+void isWebSerialSupported;
+void SerialSessionStatus;

--- a/tools/package-smoke-test/tsconfig.json
+++ b/tools/package-smoke-test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "types": []
+  },
+  "include": ["src/index.ts"]
+}


### PR DESCRIPTION
## Summary
npm 公開 tarball を利用者視点で検証する `verify:pack` を追加し、PR / リリース CI から実行できるようにしました。既存の `verify:dist`（ビルド成果物）と責務を分離し、公開ファイル不足・metadata 不整合・削除済み API の誤案内・消費者 ESM/型 import をリリース前に検出します。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #543
- Parent: #535

## What changed?
- `packages/web-serial-rxjs/scripts/verify-pack.mjs` を追加（`npm pack` → 必須ファイル / 禁止パス / metadata / タグ時 version 整合 / README 削除済み API / 主要リンク / smoke）
- `tools/package-smoke-test/` で tarball をローカルインストールし、ESM import と `tsc --noEmit` を実行
- PR CI（`ci.yml`）とリリース CI（`release.yml`）に `verify-pack` を配線。リリースの inline `npm pack --dry-run` チェックを置換
- `RELEASING(.ja).md` に `verify:dist` / `verify:pack` の責務分担を記載（公開後 npm smoke の自動化は対象外・手動確認を維持）
- package README の `./docs/...` 相対リンクを GitHub 絶対 URL へ変更（tarball 内で解決できないリンクを解消）

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm exec nx build web-serial-rxjs`
2. `pnpm exec nx run web-serial-rxjs:verify-dist`
3. `pnpm exec nx run web-serial-rxjs:verify-pack`（必須ファイル・metadata・README・リンク・smoke が成功すること）
4. タグ CI 相当の確認（任意）: `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v4.0.2 pnpm exec nx run web-serial-rxjs:verify-pack`

## Environment (if relevant)
- Browser: N/A（パッケージ検証のみ）
- OS: macOS / Linux (CI: ubuntu-latest)
- web-serial-rxjs version (for verification): 4.0.2
- RxJS version: ^7.8.0（smoke fixture peer）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)