### PR TITLE
chore(web-serial-rxjs): bump version to 4.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs/workspace",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gurezo/web-serial-rxjs",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "description": "RxJS-based utilities for the Web Serial API, usable from Angular, React, Svelte, and Vanilla JavaScript/TypeScript.",
   "author": "Akihiko Kigure <akihiko.kigure@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
## PR Title (Conventional Commits)
chore(web-serial-rxjs): bump version to 4.0.3

## Summary
#535 配下の DX 改善（#536〜#543）後のパッチリリース準備として、ライブラリとルートの version を 4.0.2 から 4.0.3 に更新する。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #552

## What changed?
- `packages/web-serial-rxjs/package.json` の version を `4.0.2` → `4.0.3` に更新
- ルート `package.json` の version を `4.0.2` → `4.0.3` に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/package.json` とルート `package.json` の `version` がともに `4.0.3` であることを確認する
2. 必要に応じて `pnpm publish:test` で dry-run を実行する

## Environment (if relevant)
- Browser: N/A（バージョン番号のみの変更）
- OS: N/A
- web-serial-rxjs version (for verification): 4.0.3
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [ ] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)