### PR TITLE
docs(web-serial-rxjs): audit npm README guide and package docs urls

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -198,6 +198,7 @@ Web Serial を表すシリアルコネクタのモチーフを組み合わせた
 
 ## リンク
 
+- **ドキュメント**: [https://gurezo.net/web-serial-rxjs/](https://gurezo.net/web-serial-rxjs/)
 - **GitHub リポジトリ**: [https://github.com/gurezo/web-serial-rxjs](https://github.com/gurezo/web-serial-rxjs)
 - **イシュー**: [https://github.com/gurezo/web-serial-rxjs/issues](https://github.com/gurezo/web-serial-rxjs/issues)
 - **セキュリティポリシー**: [SECURITY.ja.md](SECURITY.ja.md)（[English](SECURITY.md)）

--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Links
 
+- **Documentation**: [https://gurezo.net/web-serial-rxjs/](https://gurezo.net/web-serial-rxjs/)
 - **GitHub Repository**: [https://github.com/gurezo/web-serial-rxjs](https://github.com/gurezo/web-serial-rxjs)
 - **Issues**: [https://github.com/gurezo/web-serial-rxjs/issues](https://github.com/gurezo/web-serial-rxjs/issues)
 - **Security Policy**: [SECURITY.md](SECURITY.md) ([日本語](SECURITY.ja.md))

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -103,11 +103,16 @@ pnpm add rxjs
 - **API の全体像**（機能一覧、`SerialSession` 早見表、`SerialSessionState`、最小サンプル）: [SerialSession の概要](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/overview.md)（[English](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/overview.md)）
 - 最短でポートを開く手順: [クイックスタート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/quick-start.md)
 - よくある問題と自己解決: [トラブルシューティング](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md)
+- 公開ドキュメントサイト: [web-serial-rxjs Documentation](https://gurezo.net/web-serial-rxjs/)
+- API Reference（TypeDoc）: [web-serial-rxjs API Documentation](https://gurezo.net/web-serial-rxjs/api/)
 
 ## ドキュメント
 
 | ドキュメント | 用途 |
 | --- | --- |
+| [ドキュメントホーム](https://gurezo.net/web-serial-rxjs/) | Guide（ja/en）と API Reference へのサイトランディング |
+| [日本語 Guide（公開サイト）](https://gurezo.net/web-serial-rxjs/guide/ja/README.html) | Getting Started の読み順と一覧（公開サイト） |
+| [API Reference（公開サイト）](https://gurezo.net/web-serial-rxjs/api/index.html) | 英語 TypeDoc API Reference |
 | [日本語 Guide 索引](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/README.md) | Getting Started の読み順と一覧 |
 | [English Guide 索引](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/README.md) | Getting Started reading order and full index |
 | [全体像](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/overview.md) | 機能と `SerialSession` / `SerialSessionState` の対応表 |

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -132,6 +132,7 @@ In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscr
 | **[Timeout / cancel / retry](./timeout-cancel-retry.md)** | Timeouts, teardown cancel, bounded retry. |
 | **[Troubleshooting](./troubleshooting.md)** | Common Web Serial / session problems and self-help checks. |
 | **[API Reference (TypeDoc)](modules.html)** | Options, `SerialSessionState`, and `SerialError` details; narrative tables also in [concepts](./concepts.md). |
+| **[v3 → v4 Migration Guide](./migration-v4.md)** ([日本語](../ja/migration-v4.md)) | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup). |
 | **[v2 → v3 Migration Guide](./migration-v3.md)** ([日本語](../ja/migration-v3.md)) | `state$` discriminated union, `SerialSessionStatus`, and `context.cause`. |
 | **[v1 → v2 Migration Guide](./migration-v2.md)** ([日本語](../ja/migration-v2.md)) | Replacing the removed v1 `SerialClient` / `ShellClient` API. |
 | **[Phase 5 archive (legacy v1 doc)](./archive/migration-phase5.md)** | Historical v1 context only. |

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -67,7 +67,8 @@ This library is framework-agnostic and can be used with:
 | `disconnect$()` | **Close** the port and stop the pump. The session stays reusable (`idle`). |
 | `dispose$()` | **Permanently tear down** the session: close any active connection, complete all observables, and prevent reuse. |
 | `send$(string \| Uint8Array)` | **Enqueue** outgoing data; writes are **FIFO-ordered** when multiple `send$` run concurrently. |
-| `isWebSerialSupported()` | Synchronous `boolean` for Web Serial availability before `connect$`. |
+
+**Top-level (not a `SerialSession` member):** `isWebSerialSupported()` — synchronous `boolean` for Web Serial availability before creating a session or calling `connect$`.
 
 ### SerialSessionStatus (quick reference)
 

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -126,6 +126,7 @@ session.send$('hello\r\n').subscribe();
 | **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** | タイムアウト、破棄時キャンセル、回数制限付き再試行。 |
 | **[トラブルシューティング](./troubleshooting.md)** | Web Serial / セッションのよくある問題と自己解決手順。 |
 | **[API Reference（TypeDoc）](../../api/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細。表・図は [概念と設計メモ](./concepts.md) も参照。 |
+| **[v3 → v4 マイグレーション](./migration-v4.md)**（[English](../en/migration-v4.md)） | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理）。 |
 | **[v2 → v3 マイグレーション](./migration-v3.md)**（[English](../en/migration-v3.md)） | `state$` discriminated union、`SerialSessionStatus`、`context.cause`。 |
 | **[v1 → v2 マイグレーション](./migration-v2.md)**（[English](../en/migration-v2.md)） | 削除された v1 API からの対応表。 |
 | **[Phase 5（アーカイブ）](./archive/migration-phase5.md)** | 旧 v1 ドキュメントの参照用。 |

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -61,7 +61,8 @@
 | `disconnect$()` | ポートを閉じ、pump を停止。セッションは `idle` に戻り再利用可能。 |
 | `dispose$()` | セッションを**永久破棄**。接続を閉じ、すべての Observable を complete し、再利用不可にする。 |
 | `send$(string \| Uint8Array)` | 送信を **FIFO** で直列化（並行 `send$` も呼び出し順）。 |
-| `isWebSerialSupported()` | `connect$` の前に使う、Web Serial 利用可否の同期的な `boolean`。 |
+
+**トップレベル（`SerialSession` のメンバーではない）:** `isWebSerialSupported()` — セッション生成前や `connect$` の前に使う、Web Serial 利用可否の同期的な `boolean`。
 
 ### SerialSessionStatus（早見表）
 


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): audit npm README guide and package docs urls

## Summary
Issue #556（P0）として、npm README / Guide / package metadata の公式 Documentation URL（`https://gurezo.net/web-serial-rxjs/`）と v4 API 表記を監査・統一しました。package metadata は既に正しいことを再確認しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #556
- Related to #555

## What changed?
- 日本語 npm README（`packages/web-serial-rxjs/README.ja.md`）に公開ドキュメント / Guide / API の公式 URL を追加し、英語版と揃えた
- Guide overview（en/ja）で `isWebSerialSupported()` をトップレベル export として明示し、SerialSession 早見表から切り離した
- overview のドキュメント索引に v3 → v4 migration への導線を追加した
- ルート README（en/ja）の Links 節にドキュメントホームを追加した
- package `homepage` / `repository` / `bugs`、旧 `gurezo.github.io` 残存箇所を監査（ARCHITECTURE の廃止説明以外なし）

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm nx run web-serial-rxjs:verify-pack` が成功すること（homepage / README / 削除 API 表記 / 主要 HTTPS リンク）
2. `packages/web-serial-rxjs/README.ja.md` に `https://gurezo.net/web-serial-rxjs/` および Guide / API のサイト URL があること
3. overview（en/ja）の最小サンプルが現行公開 API（`createSerialSession` / `isWebSerialSupported` / `lines$` 等）と一致し、`isWebSerialSupported` がセッションメンバーとして誤記されていないこと
4. ルート README Links にドキュメントホームがあること

## Environment (if relevant)
- Browser: N/A（ドキュメント変更のみ）
- OS: macOS
- web-serial-rxjs version (for verification): 4.0.3
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)