### PR TITLE
docs(web-serial-rxjs): update v3 deprecated migration docs for v4

### DIFF
--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.ja.md
@@ -30,7 +30,7 @@ Documentation
 | read / write | 送受信 |
 | 高度な使用方法 | 行フレーミング、擬似リクエスト／レスポンス、リカバリ |
 | トラブルシューティング | Web Serial / セッションのよくある問題と自己解決手順 |
-| マイグレーション | v2 → v3、v1 → v2 への導線 |
+| マイグレーション | v3 → v4、v2 → v3、v1 → v2 への導線 |
 | 概念補足 | 表や図による補足（旧 `API_REFERENCE.md`） |
 
 Guide は**手書き Markdown** の日英二言語で、ライブラリの*使い方*を説明する。
@@ -90,6 +90,8 @@ Guide の source は `guide/{en,ja}/` に配置済み。legacy flat パスは #4
 | `MIGRATION_V2.ja.md` | `guide/ja/migration-v2.md` | |
 | `MIGRATION_V3.md` | `guide/en/migration-v3.md` | |
 | `MIGRATION_V3.ja.md` | `guide/ja/migration-v3.md` | |
+| `MIGRATION_V4.md` | `guide/en/migration-v4.md` | v4 で追加。legacy flat ファイル名なし |
+| `MIGRATION_V4.ja.md` | `guide/ja/migration-v4.md` | v4 で追加。legacy flat ファイル名なし |
 | `API_REFERENCE.md` | `guide/en/concepts.md` | リネーム。Guide 補足 |
 | `API_REFERENCE.ja.md` | `guide/ja/concepts.md` | リネーム。Guide 補足 |
 | `archive/` | `guide/en/archive/` / `guide/ja/archive/` | 現状維持 |

--- a/packages/web-serial-rxjs/docs/ARCHITECTURE.md
+++ b/packages/web-serial-rxjs/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ Documentation
 | Read / write | Sending and receiving data |
 | Advanced usage | Line framing, request/response-style flows, recovery |
 | Troubleshooting | Common Web Serial / session problems and self-help checks |
-| Migration | Links to v2 → v3 and v1 → v2 migration guides |
+| Migration | Links to v3 → v4, v2 → v3, and v1 → v2 migration guides |
 | Concepts | Supplemental tables and diagrams (formerly `API_REFERENCE.md`) |
 
 Guide content is **hand-written Markdown** in two languages. It explains *how to use* the library.
@@ -90,6 +90,8 @@ Guide source files live under `guide/{en,ja}/`. Legacy flat Guide paths were rem
 | `MIGRATION_V2.ja.md` | `guide/ja/migration-v2.md` | |
 | `MIGRATION_V3.md` | `guide/en/migration-v3.md` | |
 | `MIGRATION_V3.ja.md` | `guide/ja/migration-v3.md` | |
+| `MIGRATION_V4.md` | `guide/en/migration-v4.md` | Added with v4; no legacy flat filename |
+| `MIGRATION_V4.ja.md` | `guide/ja/migration-v4.md` | Added with v4; no legacy flat filename |
 | `API_REFERENCE.md` | `guide/en/concepts.md` | Renamed; Guide supplement |
 | `API_REFERENCE.ja.md` | `guide/ja/concepts.md` | Renamed; Guide supplement |
 | `archive/` | `guide/en/archive/` / `guide/ja/archive/` | Preserved |

--- a/packages/web-serial-rxjs/docs/guide/en/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/en/concepts.md
@@ -60,14 +60,14 @@ import {
 
 ## Deprecated exports
 
-The following remain available from the public export in v3.x but are not part of the canonical API. They are scheduled for removal in the next major version. See [Migrating to v3 – §9 `assertNever` public export audit](./migration-v3.md#9-public-export-audit).
+The following remain available from the public export in **v4** but are not part of the canonical API. They are **deprecated** and scheduled for removal in a future major (**v5+**). See [Migrating to v3 – §9 `assertNever` public export audit](./migration-v3.md#9-public-export-audit) for the audit history. APIs already removed in v4 (`destroy$`, `isConnected$`, `portInfo$`, `getPortInfo()`, `getCurrentPort()`, `receiveReplay$`, `isBrowserSupported()`, …) are documented in [Migrating to v4](./migration-v4.md).
 
 | Export | Status | Migration |
 | --- | --- | --- |
-| `assertNever` | `@deprecated` in v3.x | Define a local helper in application code, or use `switch (state.status)` with `SerialSessionStatus` |
+| `assertNever` | `@deprecated` in v4 | Define a local helper in application code, or use `switch (state.status)` with `SerialSessionStatus` |
 
 ```typescript
-// Deprecated (still works in v3.x but triggers warnings)
+// Deprecated (still available in v4 but triggers warnings)
 import { assertNever } from '@gurezo/web-serial-rxjs';
 
 // Recommended: local helper
@@ -339,7 +339,7 @@ Enqueues a payload for ordered transmission. Strings are UTF-8 encoded through a
 
 `SerialError` extends `Error` with a `code: SerialErrorCode` and structured per-code metadata on `context`. `is(code)` narrows both `code` and `context` to the literal types for that code.
 
-For cause-bearing error codes, **`context.cause`** (`unknown`) is the canonical source for the underlying failure. `originalError` remains in v3.x for backward compatibility but is **deprecated** and scheduled for removal in the next major version. See [Migrating to v3 – originalError deprecation](./migration-v3.md#3-originalerror-deprecation).
+For cause-bearing error codes, **`context.cause`** (`unknown`) is the canonical source for the underlying failure. `originalError` remains in **v4** for backward compatibility but is **deprecated** and scheduled for removal in a future major (**v5+**). See [Migrating to v3 – originalError deprecation](./migration-v3.md#3-originalerror-deprecation).
 
 ```typescript
 session.errors$.subscribe((error) => {
@@ -370,7 +370,7 @@ Runtime emission coverage for the implemented codes is audited in [Migrating to 
 
 `ValidationErrorContext` is `{ field: string; value: unknown; constraint: ValidationErrorConstraint; filterIndex?: number }`. `message` stays human-readable; use `context` for programmatic handling.
 
-### Implemented (emitted in v3.x)
+### Implemented (emitted in v4)
 
 | Code                     | When it is emitted                                                  |
 | ------------------------ | ------------------------------------------------------------------- |
@@ -389,7 +389,7 @@ Runtime emission coverage for the implemented codes is audited in [Migrating to 
 | `SESSION_DISPOSED`       | `connect$` or `send$` called after `dispose$`.                       |
 | `UNKNOWN`                | Unclassified dispose / disconnect fallback; see `context.cause`.    |
 
-### Reserved (not emitted in v3.x; scheduled for removal in next major)
+### Reserved (not emitted in v4; scheduled for removal in a future major / v5+)
 
 | Code                     | Notes                                                               |
 | ------------------------ | ------------------------------------------------------------------- |

--- a/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/en/migration-v3.md
@@ -41,6 +41,8 @@ session.errors$.subscribe((error) => {
 
 Phase 1 of [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) removed duplicate / escape-hatch APIs so `state$` and `dispose$()` are the only public sources for lifecycle and teardown. See [#478](https://github.com/gurezo/web-serial-rxjs/issues/478) for the documentation pass.
 
+**These removals shipped in v4.** For a unified Phase 1+2 upgrade path, prefer [Migrating to v4](./migration-v4.md). The sections below retain the detailed before/after examples from the Phase 1 work.
+
 | Removed API | Replacement |
 | --- | --- |
 | `destroy$()` | `dispose$()` |
@@ -159,7 +161,7 @@ export type SerialSessionState =
 
 v3.0.0 introduced typed `SerialError.context`. For cause-bearing error codes, **`context.cause`** is the canonical source for the underlying failure.
 
-`SerialError.originalError` and the legacy constructor third argument remain in v3.x for backward compatibility but are **deprecated** and scheduled for removal in the next major version.
+`SerialError.originalError` and the legacy constructor third argument remain in **v4** for backward compatibility but are **deprecated** and scheduled for removal in a future major (**v5+**).
 
 ### v2 / legacy pattern (deprecated)
 
@@ -188,11 +190,12 @@ session.errors$.subscribe((error) => {
 - [ ] If you construct errors with `new SerialError(code, message, cause)`, switch to `new SerialError(code, message, undefined, { cause })`.
 - [ ] Address TypeScript `@deprecated` warnings by migrating to the patterns above.
 
-### Compatibility in v3.x
+### Compatibility in v4 (still deprecated)
 
-- `originalError` remains available in v3.x.
+- `originalError` remains available in v4 (deprecated since v3).
 - When `context.cause` is an `Error` instance, `originalError` is kept in sync for legacy callers.
 - `context.cause` is typed as `unknown` because JavaScript allows throwing non-`Error` values.
+- Removal is deferred to a future major (**v5+**).
 
 ---
 
@@ -398,24 +401,24 @@ Operations such as `getSignals()` / `setSignals()` that previously required a ra
 
 ## 8. `SerialErrorCode` runtime emission audit
 
-Some members of the public `SerialErrorCode` contract were not emitted by the v3.x runtime. To prevent unreachable error-handling branches, all 19 codes were audited ([#438](https://github.com/gurezo/web-serial-rxjs/issues/438)) and the results are recorded here and in the [API Reference](./concepts.md#serialerror--serialerrorcode).
+Some members of the public `SerialErrorCode` contract were not emitted by the v3.x runtime (and remain unemitted in **v4**). To prevent unreachable error-handling branches, all 19 codes were audited ([#438](https://github.com/gurezo/web-serial-rxjs/issues/438)) and the results are recorded here and in the [API Reference](./concepts.md#serialerror--serialerrorcode).
 
 ### Classification
 
 | Category | Count | Description |
 | --- | --- | --- |
 | **Implemented** | 15 | Emitted at runtime in v3.x / v4 (or thrown at factory time) |
-| **Reserved** | 2 | Present in the public API but not emitted; scheduled for removal in the next major version |
+| **Reserved** | 2 | Present in the public API but not emitted; still deprecated in v4; removal deferred to a future major (**v5+**) |
 | **Removed in v4 Phase 2** | 2 | Receive-replay codes deleted with `receiveReplay$` / `receiveReplay` |
 
-### Reserved codes (not emitted in v3.x)
+### Reserved codes (not emitted in v4)
 
 | Code | Reason | Alternative |
 | --- | --- | --- |
 | `PORT_NOT_AVAILABLE` | Current implementation uses only `navigator.serial.requestPort`; no `getPorts` API path exists | Use `PORT_OPEN_FAILED` or `OPERATION_CANCELLED` for port acquisition failures |
 | `OPERATION_TIMEOUT` | No timeout / prompt detection / transaction API yet | None (revisit when a future API is added) |
 
-v3.x adds `@deprecated` annotations only; runtime values and exports are unchanged. Removal is deferred to the next major version.
+v3 added `@deprecated` annotations only; **v4** still retains the runtime values and exports. Removal is deferred to a future major (**v5+**).
 
 ### Implemented codes
 
@@ -450,7 +453,7 @@ Fatal vs non-fatal follows `ERROR_SEVERITY` inside `reportError`. Factory-thrown
 
 ### Migration checklist
 
-- [ ] Remove error handling for `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` (unreachable in v3.x).
+- [ ] Remove error handling for `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` (unreachable in v4).
 - [ ] Handle port acquisition failures with `PORT_OPEN_FAILED` / `OPERATION_CANCELLED`.
 - [ ] See [API Reference – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode) for per-code emit conditions.
 
@@ -477,7 +480,7 @@ Structured context for validation errors (`INVALID_*`) was added in [#439](https
 
 `assertNever` is an internal implementation utility, not a canonical public API. For exhaustive handling of `SerialSessionState`, prefer `switch (state.status)` with `SerialSessionStatus`, or narrowing with `isConnectedSessionState`.
 
-v3.x adds `@deprecated` annotations only; the public export is retained. Removal is deferred to the next major version.
+v3 added `@deprecated` annotations only; **v4** still retains the public export. Removal is deferred to a future major (**v5+**).
 
 ### Legacy pattern (deprecated)
 
@@ -535,9 +538,9 @@ session.state$.subscribe((state: SerialSessionState) => {
 - [ ] Prefer `switch (state.status)` with `SerialSessionStatus` for `SerialSessionState` branches.
 - [ ] Migrate when TypeScript shows `@deprecated` warnings.
 
-### v3.x compatibility
+### Compatibility in v4 (still deprecated)
 
-`assertNever` remains available from the public export in v3.x. It is scheduled for removal in the next major version.
+`assertNever` remains available from the public export in **v4**. It is scheduled for removal in a future major (**v5+**).
 
 ---
 
@@ -572,7 +575,7 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 
 See [API Reference – SerialSessionOptions](./concepts.md#serialsessionoptions) for details. Boundary semantics (`0` = unlimited for buffer limits only; connection fields require `> 0`) are documented there ([#488](https://github.com/gurezo/web-serial-rxjs/issues/488)).
 
-### v3.x compatibility
+### Compatibility through v4
 
 The `createSerialSession(options?)` signature and existing options object literals remain **unchanged** for connection / buffer fields. `SerialSessionFeatureOptions` is added as a new public export. `receiveReplay` is removed in v4 — migrate via [Migrating to v4](./migration-v4.md).
 

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -86,7 +86,7 @@ Each `state$` emission has a `status` field. Prefer the **const object** (e.g. `
 
 **`receive$` vs `lines$`:** use **`receive$`** when the UI must preserve **unframed UTF-8 decoder chunks** from the device text stream (e.g. interactive shells, `ls` progress, any stream using `\r` to redraw a line). This is decoded text with control characters intact — **not** raw wire bytes. Use **`lines$`** for **newline-oriented** consumers—logs, one-line replies, parsers. Feeding **`lines$`** into a terminal widget can drop or split on `\r` and break redraw semantics. For custom delimiters beyond the built-in line buffer, compose on **`receive$`** ([Advanced Usage](./advanced-usage.md#line-framing)). See [Supported data](./concepts.md#supported-data-text--binary--charset).
 
-**Connected boolean for UI** — when you only need a flag, derive it from `state$` (see [Advanced Usage](./advanced-usage.md#connected-boolean-ui-narrowing)) or narrow on `state.status === SerialSessionStatus.Connected`. Removed convenience APIs are documented in [Migrating to v3 – Phase 1 API removals](./migration-v3.md#phase-1-api-removals).
+**Connected boolean for UI** — when you only need a flag, derive it from `state$` (see [Advanced Usage](./advanced-usage.md#connected-boolean-ui-narrowing)) or narrow on `state.status === SerialSessionStatus.Connected`. Removed convenience APIs are documented in [Migrating to v4 – Phase 1 API removals](./migration-v4.md#phase-1-api-removals).
 
 **`lines$` (newline framing)** — built-in line splitting; for non-line protocols or terminal mirrors, subscribe to **`receive$`** instead (recipes in [Advanced Usage](./advanced-usage.md#line-framing)).
 

--- a/packages/web-serial-rxjs/docs/guide/ja/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/concepts.md
@@ -60,14 +60,14 @@ import {
 
 ## Deprecated exports
 
-以下は v3.x で引き続き public export から利用できますが、canonical API ではありません。次回 major version で削除予定です。詳細は [v3 への移行 – §9 `assertNever` public export 監査](./migration-v3.md#9-public-export-監査) を参照してください。
+以下は **v4** でも引き続き public export から利用できますが、canonical API ではありません。**非推奨**であり、将来の major（**v5 以降**）で削除予定です。監査の経緯は [v3 への移行 – §9 `assertNever` public export 監査](./migration-v3.md#9-public-export-監査) を参照してください。v4 で既に削除された API（`destroy$`、`isConnected$`、`portInfo$`、`getPortInfo()`、`getCurrentPort()`、`receiveReplay$`、`isBrowserSupported()` など）は [v4 への移行](./migration-v4.md) を参照してください。
 
 | Export | 状態 | 移行先 |
 | --- | --- | --- |
-| `assertNever` | v3.x で `@deprecated` | アプリケーション側でローカル helper を定義するか、`switch (state.status)` + `SerialSessionStatus` を使用する |
+| `assertNever` | v4 で `@deprecated` | アプリケーション側でローカル helper を定義するか、`switch (state.status)` + `SerialSessionStatus` を使用する |
 
 ```typescript
-// 非推奨（v3.x では動作するが警告が出る）
+// 非推奨（v4 でも利用可能だが警告が出る）
 import { assertNever } from '@gurezo/web-serial-rxjs';
 
 // 推奨: ローカル helper
@@ -339,7 +339,7 @@ dispose 後の `connect$` と `send$` は `SerialErrorCode.SESSION_DISPOSED` で
 
 `SerialError` は `Error` を継承し、`code: SerialErrorCode` と code 別の構造化メタデータ `context` を持ちます。`is(code)` は `code` と `context` を literal 型に narrow します。
 
-cause 系 error code では **`context.cause`**（`unknown`）が原因エラーの canonical source です。`originalError` は後方互換のため v3.x に残っていますが **非推奨** で、次回 major version で削除予定です。詳細は [v3 移行ガイド – originalError の非推奨化](./migration-v3.md#3-originalerror-の非推奨化) を参照してください。
+cause 系 error code では **`context.cause`**（`unknown`）が原因エラーの canonical source です。`originalError` は後方互換のため **v4** にも残っていますが **非推奨** で、将来の major（**v5 以降**）で削除予定です。詳細は [v3 移行ガイド – originalError の非推奨化](./migration-v3.md#3-originalerror-の非推奨化) を参照してください。
 
 ```typescript
 session.errors$.subscribe((error) => {
@@ -370,7 +370,7 @@ try {
 
 `ValidationErrorContext` は `{ field: string; value: unknown; constraint: ValidationErrorConstraint; filterIndex?: number }` です。`message` は人間向け、`context` はプログラム向けの metadata として利用してください。
 
-### Implemented（v3.x で emit される）
+### Implemented（v4 で emit される）
 
 | Code                     | emit されるタイミング                                              |
 | ------------------------ | ------------------------------------------------------------------ |
@@ -389,7 +389,7 @@ try {
 | `SESSION_DISPOSED`       | `dispose$` 後に `connect$` または `send$` を呼んだ                 |
 | `UNKNOWN`                | dispose / disconnect の分類不能 fallback。`context.cause` を確認     |
 
-### Reserved（v3.x では emit されない・次回 major で削除予定）
+### Reserved（v4 では emit されない・将来の major / v5 以降で削除予定）
 
 | Code                     | 備考                                                               |
 | ------------------------ | ------------------------------------------------------------------ |

--- a/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/migration-v3.md
@@ -41,6 +41,8 @@ session.errors$.subscribe((error) => {
 
 [#472](https://github.com/gurezo/web-serial-rxjs/issues/472) の Phase 1 では、重複・escape hatch な API を削除し、ライフサイクルと破棄の正規情報源を `state$` と `dispose$()` に統一しました。ドキュメント整備は [#478](https://github.com/gurezo/web-serial-rxjs/issues/478) です。
 
+**これらの削除は v4 で出荷済みです。** Phase 1+2 をまとめた移行手順は [v4 への移行](./migration-v4.md) を優先してください。以下の各節は Phase 1 作業時の詳細な before/after 例を履歴として残しています。
+
 | 削除 API | 移行先 |
 | --- | --- |
 | `destroy$()` | `dispose$()` |
@@ -159,7 +161,7 @@ export type SerialSessionState =
 
 v3.0.0 では typed `SerialError.context` を導入しました。cause 系 error code では **`context.cause`** が原因エラーの canonical source です。
 
-後方互換のため `SerialError.originalError` と constructor の legacy 第 3 引数は v3.x で残っていますが、**非推奨**です。次回 major version で削除予定です。
+後方互換のため `SerialError.originalError` と constructor の legacy 第 3 引数は **v4** にも残っていますが、**非推奨**です。将来の major（**v5 以降**）で削除予定です。
 
 ### v2 / 旧パターン（非推奨）
 
@@ -188,11 +190,12 @@ session.errors$.subscribe((error) => {
 - [ ] 独自に `new SerialError(code, message, cause)` としていた場合は `new SerialError(code, message, undefined, { cause })` に変更する。
 - [ ] TypeScript の `@deprecated` 警告が出たら、上記パターンへ移行する。
 
-### v3.x での互換性
+### v4 での互換性（引き続き非推奨）
 
-- `originalError` は v3.x では引き続き利用可能です。
+- `originalError` は **v4** でも引き続き利用可能です（v3 以降 deprecated）。
 - `context.cause` が `Error` インスタンスの場合、`originalError` も同期して設定されます（legacy 利用者向け）。
 - `context.cause` の型は `unknown` です（JavaScript では `Error` 以外も throw 可能なため）。
+- 削除は将来の major（**v5 以降**）に延期されています。
 
 ---
 
@@ -398,24 +401,24 @@ session.state$.subscribe((state) => {
 
 ## 8. `SerialErrorCode` runtime emission 監査
 
-public API contract として定義されている `SerialErrorCode` のうち、一部は v3.x の runtime implementation から emit されていませんでした。到達不能な error handling を防ぐため、全 19 code の emission coverage を監査し（[#438](https://github.com/gurezo/web-serial-rxjs/issues/438)）、結果を本セクションと [概念と設計メモ](./concepts.md#serialerror--serialerrorcode) に反映しました。
+public API contract として定義されている `SerialErrorCode` のうち、一部は v3.x の runtime implementation から emit されていませんでした（**v4** でも未 emit のままです）。到達不能な error handling を防ぐため、全 19 code の emission coverage を監査し（[#438](https://github.com/gurezo/web-serial-rxjs/issues/438)）、結果を本セクションと [概念と設計メモ](./concepts.md#serialerror--serialerrorcode) に反映しました。
 
 ### 分類
 
 | 分類 | 件数 | 説明 |
 | --- | --- | --- |
 | **Implemented** | 15 | v3.x / v4 で runtime から emit される（または factory 時に throw される） |
-| **Reserved** | 2 | public API に存在するが emit されない。次回 major version で削除予定 |
+| **Reserved** | 2 | public API に存在するが emit されない。v4 でも deprecated。削除は将来の major（**v5 以降**） |
 | **v4 Phase 2 で削除** | 2 | `receiveReplay$` / `receiveReplay` と共に削除された receive-replay コード |
 
-### Reserved code（v3.x では emit されない）
+### Reserved code（v4 では emit されない）
 
 | Code | 理由 | 代替 |
 | --- | --- | --- |
 | `PORT_NOT_AVAILABLE` | 現行実装は `navigator.serial.requestPort` のみ使用。`getPorts` 系 API 未実装のため emit 経路がない | ポート取得失敗は `PORT_OPEN_FAILED` または `OPERATION_CANCELLED` を参照 |
 | `OPERATION_TIMEOUT` | timeout / prompt detection / transaction API が未実装 | 該当なし（将来 API 追加時に再評価） |
 
-v3.x では `@deprecated` 注記のみ付与し、runtime 値と export は維持します。削除は次回 major version に集約します。
+v3 で `@deprecated` 注記のみ付与し、**v4** でも runtime 値と export は維持しています。削除は将来の major（**v5 以降**）に延期されています。
 
 ### Implemented code 一覧
 
@@ -450,7 +453,7 @@ fatal / non-fatal の判定は `reportError` 経由の `ERROR_SEVERITY` に従�
 
 ### 移行チェックリスト
 
-- [ ] `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` 向けの error handling を削除する（v3.x では到達しない）。
+- [ ] `PORT_NOT_AVAILABLE` / `OPERATION_TIMEOUT` 向けの error handling を削除する（v4 では到達しない）。
 - [ ] ポート取得失敗は `PORT_OPEN_FAILED` / `OPERATION_CANCELLED` で処理する。
 - [ ] 全 code の emit 条件は [概念と設計メモ – SerialError / SerialErrorCode](./concepts.md#serialerror--serialerrorcode) を参照する。
 
@@ -477,7 +480,7 @@ validation error（`INVALID_*`）への structured context 追加は [#439](http
 
 `assertNever` は内部実装用 utility であり、canonical public API ではありません。`SerialSessionState` の exhaustive handling は `switch (state.status)` + `SerialSessionStatus`、または `isConnectedSessionState` による narrowing が推奨パターンです。
 
-v3.x では `@deprecated` 注記のみ付与し、public export は維持します。削除は次回 major version に集約します。
+v3 で `@deprecated` 注記のみ付与し、**v4** でも public export は維持しています。削除は将来の major（**v5 以降**）に延期されています。
 
 ### v2 / 旧パターン（非推奨）
 
@@ -535,9 +538,9 @@ session.state$.subscribe((state: SerialSessionState) => {
 - [ ] `SerialSessionState` の分岐は `switch (state.status)` + `SerialSessionStatus` を優先する。
 - [ ] TypeScript の `@deprecated` 警告が出たら、上記パターンへ移行する。
 
-### v3.x での互換性
+### v4 での互換性（引き続き非推奨）
 
-`assertNever` は v3.x では引き続き public export から利用可能です。次回 major version で削除予定です。
+`assertNever` は **v4** でも引き続き public export から利用可能です。将来の major（**v5 以降**）で削除予定です。
 
 ---
 
@@ -572,7 +575,7 @@ SerialSessionOptions        = Partial<SerialConnectionOptions> & SerialSessionFe
 
 詳細は [概念と設計メモ – SerialSessionOptions](./concepts.md#serialsessionoptions) を参照してください。境界値の意味（バッファ上限のみ `0` = 無制限、接続フィールドは `> 0` 必須）も同ページに記載しています（[#488](https://github.com/gurezo/web-serial-rxjs/issues/488)）。
 
-### v3.x での互換性
+### v4 までの互換性
 
 `createSerialSession(options?)` のシグネチャと、接続・バッファ系の既存 options オブジェクトリテラルは **変更不要** です。`SerialSessionFeatureOptions` は新規 public export として追加されます。`receiveReplay` は v4 で削除されるため、[v4 への移行](./migration-v4.md) に従ってください。
 

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -80,7 +80,7 @@
 
 **`receive$` と `lines$`:** 機器から来た **UTF-8 デコード済みチャンク**を行分割せず画面に反映する（シェル、`ls` のプログレス、`\r` で行を描き直す出力など）ときは **`receive$`** を使います。制御文字は保持されますが、**ワイヤ上の生バイトではありません**。**改行区切りのログ**や**1 行ずつ処理するプロトコル**では **`lines$`** が適しています。ターミナル表示に **`lines$`** を繋ぐと、内部で `\r` を行境界として扱うため **上書き表示が壊れる**ことがあります。独自区切りは **`receive$` 上で RxJS を合成**します（[高度な使用方法 — 行単位のフレーミング](./advanced-usage.md)）。詳細は [対応範囲](./concepts.md#対応範囲テキスト--バイナリ--文字コード) を参照してください。
 
-**UI 用の接続 boolean** — フラグだけ必要な場合は `state$` から derive するか（[高度な使用方法](./advanced-usage.md#接続中フラグ（-narrowing）)）、`state.status === SerialSessionStatus.Connected` で narrowing してください。削除された convenience API は [v3 移行ガイド – Phase 1 API 削除](./migration-v3.md#phase-1-api-削除) を参照してください。
+**UI 用の接続 boolean** — フラグだけ必要な場合は `state$` から derive するか（[高度な使用方法](./advanced-usage.md#接続中フラグ（-narrowing）)）、`state.status === SerialSessionStatus.Connected` で narrowing してください。削除された convenience API は [v4 への移行 – Phase 1 API 削除](./migration-v4.md#phase-1-api-削除) を参照してください。
 
 **`lines$`（行区切り）** — 組み込みの行分割。ターミナルのミラーや `\r` を保持したいときは **`receive$`** を購読します（[高度な使用方法 — 行単位のフレーミング](./advanced-usage.md)）。
 

--- a/packages/web-serial-rxjs/src/errors/serial-error-code.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error-code.ts
@@ -39,15 +39,15 @@ export const SerialErrorCode = {
   /**
    * Serial port is not available.
    *
-   * **Reserved — not emitted in v3.x.** The current implementation uses only
-   * `navigator.serial.requestPort`; there is no `getPorts` API path. Scheduled
-   * for removal in the next major version.
+   * **Reserved — not emitted in v4.** The current implementation uses only
+   * `navigator.serial.requestPort`; there is no `getPorts` API path. Still
+   * present in v4 (deprecated); scheduled for removal in a future major (v5+).
    *
    * **Suggested action**: Handle port acquisition failures with
    * {@link SerialErrorCode.PORT_OPEN_FAILED} or
    * {@link SerialErrorCode.OPERATION_CANCELLED} instead.
    *
-   * @deprecated Not emitted at runtime in v3.x. Will be removed in the next major version.
+   * @deprecated Not emitted at runtime in v4. Will be removed in a future major (v5+).
    * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/438 | Issue #438}
    */
   PORT_NOT_AVAILABLE: 'PORT_NOT_AVAILABLE',
@@ -136,11 +136,11 @@ export const SerialErrorCode = {
   /**
    * Operation timed out before completion.
    *
-   * **Reserved — not emitted in v3.x.** No timeout / prompt detection /
-   * transaction API exists yet. Scheduled for removal in the next major version
-   * unless a future API adopts this code.
+   * **Reserved — not emitted in v4.** No timeout / prompt detection /
+   * transaction API exists yet. Still present in v4 (deprecated); scheduled for
+   * removal in a future major (v5+) unless a future API adopts this code.
    *
-   * @deprecated Not emitted at runtime in v3.x. Will be removed in the next major version.
+   * @deprecated Not emitted at runtime in v4. Will be removed in a future major (v5+).
    * @see {@link https://github.com/gurezo/web-serial-rxjs/issues/438 | Issue #438}
    */
   OPERATION_TIMEOUT: 'OPERATION_TIMEOUT',

--- a/packages/web-serial-rxjs/src/errors/serial-error.ts
+++ b/packages/web-serial-rxjs/src/errors/serial-error.ts
@@ -78,9 +78,9 @@ export class SerialError<
    * This property contains the underlying error (e.g., DOMException, TypeError)
    * that was wrapped in this SerialError. It may be undefined if no original error exists.
    *
-   * @deprecated Prefer {@link context} for cause-bearing codes. This property is
-   *   retained for backward compatibility and is kept in sync when a cause is
-   *   provided.
+   * @deprecated Prefer {@link context} for cause-bearing codes. Still present in
+   *   v4 for backward compatibility and kept in sync when a cause is provided.
+   *   Removal is deferred to a future major (v5+).
    */
   public readonly originalError?: Error;
 
@@ -90,9 +90,9 @@ export class SerialError<
    * @param code - The error code identifying the type of error
    * @param message - A human-readable error message
    * @param originalError - The original error that caused this SerialError, if any.
-   *   @deprecated Prefer passing `{ cause }` via {@link context}. When omitted,
-   *   cause-bearing codes derive `{ cause }` from this argument for backward
-   *   compatibility.
+   *   @deprecated Prefer passing `{ cause }` via {@link context}. Still accepted
+   *   in v4 for backward compatibility; when omitted, cause-bearing codes derive
+   *   `{ cause }` from this argument. Removal is deferred to a future major (v5+).
    * @param context - Structured metadata for the error code. For cause-bearing
    *   codes, pass `{ cause }` here. When omitted, cause-bearing codes derive
    *   `{ cause }` from the legacy {@link originalError} argument.

--- a/packages/web-serial-rxjs/src/internal/assert-never.ts
+++ b/packages/web-serial-rxjs/src/internal/assert-never.ts
@@ -3,8 +3,8 @@
  *
  * @deprecated Not part of the canonical public API. Define a local helper in
  *   application code, or use `switch (state.status)` with
- *   {@link SerialSessionStatus}. Will be removed from public exports in the
- *   next major version.
+ *   {@link SerialSessionStatus}. Still available in v4; will be removed from
+ *   public exports in a future major (v5+).
  * @internal
  */
 export function assertNever(value: never): never {

--- a/packages/web-serial-rxjs/tests/errors/serial-error-code-emission.test.ts
+++ b/packages/web-serial-rxjs/tests/errors/serial-error-code-emission.test.ts
@@ -3,7 +3,7 @@ import { SerialErrorCode } from '../../src/errors/serial-error-code';
 
 /**
  * Regression guard for the SerialErrorCode emission audit (Issue #438).
- * Keep in sync with MIGRATION_V3 §8 and API_REFERENCE.
+ * Keep in sync with MIGRATION_V3 §8 and concepts.md SerialError / SerialErrorCode.
  */
 const IMPLEMENTED_CODES = [
   SerialErrorCode.BROWSER_NOT_SUPPORTED,
@@ -44,7 +44,7 @@ describe('SerialErrorCode emission audit (#438)', () => {
     }
   });
 
-  it('marks reserved codes as not implemented at runtime in v3.x', () => {
+  it('marks reserved codes as not emitted at runtime in v4', () => {
     expect(RESERVED_CODES).toEqual([
       SerialErrorCode.PORT_NOT_AVAILABLE,
       SerialErrorCode.OPERATION_TIMEOUT,

--- a/packages/web-serial-rxjs/tests/internal/assert-never-export-audit.test.ts
+++ b/packages/web-serial-rxjs/tests/internal/assert-never-export-audit.test.ts
@@ -6,7 +6,7 @@ import * as publicApi from '../../src/index';
 
 /**
  * Regression guard for the assertNever public export audit (Issue #440).
- * Keep in sync with MIGRATION_V3 §9 and API_REFERENCE.
+ * Keep in sync with MIGRATION_V3 §9 and concepts.md Deprecated exports.
  */
 const CANONICAL_PUBLIC_EXPORTS = [
   'createSerialSession',
@@ -27,7 +27,7 @@ const assertNeverSource = readFileSync(
 );
 
 describe('assertNever public export audit (#440)', () => {
-  it('retains assertNever on the public barrel for v3.x backward compatibility', () => {
+  it('retains assertNever on the public barrel as a v4 deprecated export', () => {
     expect(publicApi.assertNever).toBeTypeOf('function');
   });
 


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): update v3 deprecated migration docs for v4

## Summary
Issue #557（親 #555 / P0）として、Guide / Concepts / JSDoc に残っていた v3 現在形の deprecated / migration 記述を v4 利用者向けの現在形へ更新しました。削除済み API と依然 deprecated な API を区別し、履歴説明は Migration Guide に維持しています。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #557
- Related to #555

## What changed?
- Concepts（en/ja）の Deprecated exports / `originalError` / Implemented・Reserved 見出しを v4 現在形へ更新
- `assertNever` / reserved `SerialErrorCode` / `SerialError.originalError` の JSDoc を v4 表記に揃え、削除時期を将来 major（v5+）と明示
- migration-v3（en/ja）で Phase 1 削除が v4 出荷済みであること、残 deprecated が v4 でも継続することを明記
- overview の削除 API 導線を migration-v4 へ変更し、ARCHITECTURE に migration-v4 を追加
- 監査テストのテスト名・コメントを v4 表記に更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details: JSDoc 文言のみ。runtime / export は変更なし
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `rg -i 'v3\.x|next major' packages/web-serial-rxjs/docs packages/web-serial-rxjs/src` で、通常 Guide / Concepts / JSDoc に v3 現在形が残っていないこと（migration-v3 の履歴言及は除外）
2. Concepts（en/ja）で削除済み API と deprecated 残存 API（`assertNever` / `originalError` / reserved codes）が区別できること
3. overview（en/ja）の削除 convenience API 導線が `migration-v4.md` の Phase 1 節を指すこと
4. `pnpm nx test web-serial-rxjs -- tests/internal/assert-never-export-audit.test.ts tests/errors/serial-error-code-emission.test.ts` が通ること

## Environment (if relevant)
- Browser: N/A（ドキュメント / JSDoc / テスト文言のみ）
- OS: macOS
- web-serial-rxjs version (for verification): 4.0.3
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)