### PR TITLE
docs(web-serial-rxjs): clarify examples start-here and purposes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -120,14 +120,18 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 
 ## サンプル
 
-以下の環境向けのサンプルを用意しています。
+Framework Examples は各スタックでの **`SerialSession` の配線方法**を示すデモです。**対応デバイス一覧ではありません**。通信パターン（行プロトコル、コマンド／応答、タイムアウトなど）を探す場合は [Recipes 索引](packages/web-serial-rxjs/docs/guide/ja/recipes.md) を使ってください。
 
-- **[Angular](apps/example-angular/)** - Service を使用した Angular の例
-- **[React](apps/example-react/)** - カスタムフック（`useSerialSession`）を使用した React の例
-- **[Svelte](apps/example-svelte/)** - Svelte Store を使用した Svelte の例
-- **[Vanilla JavaScript](apps/example-vanilla-js/)** - バニラ JavaScript での基本的な使用方法
-- **[Vanilla TypeScript](apps/example-vanilla-ts/)** - RxJS を使用した TypeScript の例
-- **[Vue](apps/example-vue/)** - Composition API を使用した Vue 3 の例
+**まずはこちら:** [Vanilla TypeScript](apps/example-vanilla-ts/)（Recommended / まずはこちら）— UI フレームワークなしで、TypeScript と RxJS からライブラリ API を試せます。
+
+- **[Vanilla TypeScript](apps/example-vanilla-ts/)** — 推奨の開始地点（TypeScript + RxJS、フレームワークなし）
+- **[Vanilla JavaScript](apps/example-vanilla-js/)** — TypeScript / UI フレームワークなしで同じ接続フローを確認
+- **[Angular](apps/example-angular/)** — Service 経由で SerialSession を配線
+- **[React](apps/example-react/)** — カスタムフック（`useSerialSession`）
+- **[Vue](apps/example-vue/)** — Vue 3 Composition API（composable）
+- **[Svelte](apps/example-svelte/)** — Svelte Store
+
+対話デモ: [https://gurezo.net/web-serial-rxjs/examples/](https://gurezo.net/web-serial-rxjs/examples/)。
 
 各サンプルは **connect・受信（ターミナル表示は `\r` を保持するため `receive$` で連結）・send・disconnect** の最小動作確認用です。**`lines$`** は改行区切りログや解析向けであり、対話的シェル出力のミラーには **`receive$`** を使ってください。行フレーミングや応用パターンの詳細は [高度な使用方法](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md) に集約しています。
 

--- a/README.md
+++ b/README.md
@@ -120,14 +120,18 @@ Documentation is split into **Guide** (how to use; Japanese and English hand-wri
 
 ## Examples
 
-Examples are available for the following environments:
+Framework examples demonstrate **how to wire `SerialSession`** in each stack. They are **not** a supported-device catalog. For communication patterns (line protocol, command/reply, timeout, and so on), see the [Recipes index](packages/web-serial-rxjs/docs/guide/en/recipes.md) instead.
 
-- **[Angular](apps/example-angular/)** - Angular example using a Service
-- **[React](apps/example-react/)** - React example with custom hook (`useSerialSession`)
-- **[Svelte](apps/example-svelte/)** - Svelte example using Svelte Store
-- **[Vanilla JavaScript](apps/example-vanilla-js/)** - Basic usage with vanilla JavaScript
-- **[Vanilla TypeScript](apps/example-vanilla-ts/)** - TypeScript example with RxJS
-- **[Vue](apps/example-vue/)** - Vue 3 example using Composition API
+**Start here:** [Vanilla TypeScript](apps/example-vanilla-ts/) (Recommended / まずはこちら) — try the library API with TypeScript and RxJS, with no UI framework.
+
+- **[Vanilla TypeScript](apps/example-vanilla-ts/)** — Recommended starting point (TypeScript + RxJS, no framework)
+- **[Vanilla JavaScript](apps/example-vanilla-js/)** — Same connect flow without TypeScript or a UI framework
+- **[Angular](apps/example-angular/)** — Wire SerialSession through an injectable Service
+- **[React](apps/example-react/)** — Custom hook (`useSerialSession`)
+- **[Vue](apps/example-vue/)** — Vue 3 Composition API (composable)
+- **[Svelte](apps/example-svelte/)** — Svelte Store
+
+Interactive demos: [https://gurezo.net/web-serial-rxjs/examples/](https://gurezo.net/web-serial-rxjs/examples/).
 
 Each sample is a **minimal smoke test** for **connect**, **receive** (terminal-style append via **`receive$`** so `\r` redraws stay intact), **send**, and **disconnect**. Use **`lines$`** only when you want newline-delimited logging or parsing—not for mirroring interactive terminal output; deeper patterns live in [Advanced Usage](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/advanced-usage.md).
 

--- a/packages/web-serial-rxjs/scripts/build-docs-index.mjs
+++ b/packages/web-serial-rxjs/scripts/build-docs-index.mjs
@@ -71,7 +71,7 @@ session.lines$.subscribe((line) => console.log(line));
 </section>
 <section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
 <h2 style="margin:0 0 0.5rem;font-size:1.15rem;">Examples</h2>
-<p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Interactive Angular, React, Svelte, Vue, and Vanilla JS/TS examples using SerialSession.</p>
+<p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">Interactive framework wiring demos for SerialSession (start with Vanilla TS). Not a supported-device catalog — use Recipes for communication patterns.</p>
 <a href="examples/"><strong>Open Examples</strong></a>
 </section>
 <section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">

--- a/packages/web-serial-rxjs/scripts/build-examples-index.mjs
+++ b/packages/web-serial-rxjs/scripts/build-examples-index.mjs
@@ -16,6 +16,8 @@ const repoRoot = join(__dirname, '../../..');
 const examplesOutDir = join(repoRoot, 'docs/examples');
 const indexPath = join(examplesOutDir, 'index.html');
 
+const GITHUB_REPO = 'https://github.com/gurezo/web-serial-rxjs';
+
 const assetBase = apiAssetPrefixFromDocsPath('examples/index.html');
 const dataBase = assetBase;
 const title = 'web-serial-rxjs Examples';
@@ -27,26 +29,48 @@ const toolbarLinks = buildToolbarLinks({
   siteIndexHref: '../index.html',
 });
 
-const cards = EXAMPLE_ENTRIES.map(({ slug, label, description, audience, recommended }) => {
-  const badge = recommended
-    ? `<span style="display:inline-block;margin-left:0.5rem;padding:0.15rem 0.5rem;font-size:0.75rem;font-weight:600;border:1px solid var(--color-accent);border-radius:4px;color:var(--color-accent);vertical-align:middle;">Recommended</span>`
-    : '';
-  const purpose = audience || description;
-  return `<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
+const cards = EXAMPLE_ENTRIES.map(
+  ({ slug, label, description, audience, recommended, highlights, appDir }) => {
+    const badge = recommended
+      ? `<span style="display:inline-block;margin-left:0.5rem;padding:0.15rem 0.5rem;font-size:0.75rem;font-weight:600;border:1px solid var(--color-accent);border-radius:4px;color:var(--color-accent);vertical-align:middle;">Recommended / まずはこちら</span>`
+      : '';
+    const purpose = audience || description;
+    const highlightsList =
+      Array.isArray(highlights) && highlights.length > 0
+        ? `<p style="margin:0 0 0.35rem;font-size:0.9rem;"><strong>What you will see</strong></p>
+<ul style="margin:0 0 0.75rem;padding-left:1.25rem;color:var(--color-text-secondary);font-size:0.9rem;">
+${highlights.map((item) => `<li>${item}</li>`).join('\n')}
+</ul>`
+        : '';
+    const sourceHref = `${GITHUB_REPO}/tree/main/${appDir}`;
+    return `<section class="card" style="border:1px solid var(--color-border);border-radius:8px;padding:1.25rem;">
 <h2 style="margin:0 0 0.5rem;font-size:1.15rem;">${label}${badge}</h2>
 <p style="margin:0 0 0.75rem;color:var(--color-text-secondary);">${purpose}</p>
+${highlightsList}
+<p style="margin:0;">
 <a href="${slug}/"><strong>Open example</strong></a>
+<span style="margin:0 0.5rem;color:var(--color-text-secondary);">·</span>
+<a href="${sourceHref}"><strong>View source</strong></a>
+</p>
 </section>`;
-}).join('\n');
+  },
+).join('\n');
 
 const mainContent = `<div class="col-content">
 <div class="tsd-page-title"><h1>web-serial-rxjs Examples</h1></div>
 <div class="tsd-panel tsd-typography">
-<p class="lead">Interactive framework examples for web-serial-rxjs. Each link resolves under <code>/web-serial-rxjs/examples/</code> when published via portal.</p>
+<p class="lead">Interactive framework examples for web-serial-rxjs. Each link resolves under <code>/web-serial-rxjs/examples/</code> when published via portal. These apps demonstrate <strong>framework wiring</strong> for <code>SerialSession</code> — they are <strong>not</strong> a supported-device catalog.</p>
+
+<h2>Recipes vs Examples</h2>
+<ul>
+<li><strong>Examples</strong> (this page): interactive demos of how to wire <code>SerialSession</code> in Angular, React, Vue, Svelte, or Vanilla JS/TS.</li>
+<li><strong>Recipes</strong>: Guide index by <strong>communication pattern</strong> (line protocol, command/reply, timeout, and so on) — not by device brand. Prefer Recipes when you know the pattern you need.</li>
+</ul>
+<p style="margin:0 0 1.25rem;">Open Recipes: <a href="../guide/en/recipes.html">English</a> · <a href="../guide/ja/recipes.html">日本語</a>.</p>
 
 <h2>Which example should I start with?</h2>
 <ul>
-<li><strong>New to the library?</strong> Start with <strong>Vanilla TS</strong> (Recommended). It shows <code>SerialSession</code> with TypeScript and RxJS and no UI framework.</li>
+<li><strong>New to the library?</strong> Start with <strong>Vanilla TS</strong> (Recommended / まずはこちら). It shows <code>SerialSession</code> with TypeScript and RxJS and no UI framework.</li>
 <li><strong>Prefer plain JavaScript?</strong> Use <strong>Vanilla JS</strong> for the same flow without TypeScript.</li>
 <li><strong>Building with a framework?</strong> Pick the example that matches your stack (React hook, Vue Composition API, Angular Service, or Svelte Store).</li>
 </ul>

--- a/packages/web-serial-rxjs/scripts/examples-portal.mjs
+++ b/packages/web-serial-rxjs/scripts/examples-portal.mjs
@@ -2,45 +2,93 @@
  * Framework example slugs published under /web-serial-rxjs/examples/<slug>/.
  * Builds land in #354–#359 (angular #354, react #355); the index page (#353) links to these paths.
  * Entries are listed in alphabetical order by label.
+ *
+ * Parent: #555 · Issue: #560 — start-here guidance and per-example purpose / highlights.
  */
 export const EXAMPLE_ENTRIES = [
   {
     slug: 'angular',
     label: 'Angular',
     description: 'Angular example app using SerialSession.',
-    audience: 'Angular apps wiring SerialSession through a Service.',
+    audience:
+      'See how Angular apps wire SerialSession through an injectable Service.',
+    highlights: [
+      'Angular Service wrapping createSerialSessionController',
+      'connect$ / disconnect$ / dispose$ from a component',
+      'terminalText$ for UI display; receive$ as raw stream',
+      'send$ / state$ / errors$',
+    ],
+    appDir: 'apps/example-angular',
   },
   {
     slug: 'react',
     label: 'React',
     description: 'React example app using SerialSession.',
-    audience: 'React apps using a custom hook (`useSerialSession`).',
+    audience:
+      'See how React apps expose SerialSession via a custom hook (`useSerialSession`).',
+    highlights: [
+      'Custom hook useSerialSession',
+      'connect$ / disconnect$ / dispose$ from UI events',
+      'terminalText$ for UI display; receive$ as raw stream',
+      'send$ / state$ / errors$',
+    ],
+    appDir: 'apps/example-react',
   },
   {
     slug: 'svelte',
     label: 'Svelte',
     description: 'Svelte example app using SerialSession.',
-    audience: 'Svelte apps using a Svelte Store.',
+    audience: 'See how Svelte apps expose SerialSession via a Svelte Store.',
+    highlights: [
+      'Svelte Store wrapping createSerialSessionController',
+      'connect$ / disconnect$ / dispose$ from UI events',
+      'terminalText$ for UI display; receive$ as raw stream',
+      'send$ / state$ / errors$',
+    ],
+    appDir: 'apps/example-svelte',
   },
   {
     slug: 'vanilla-js',
     label: 'Vanilla JS',
     description: 'Vanilla JavaScript example using SerialSession.',
-    audience: 'Minimal setup without TypeScript or a UI framework.',
+    audience:
+      'Minimal setup without TypeScript or a UI framework — same connect flow as Vanilla TS, in plain JavaScript.',
+    highlights: [
+      'createSerialSessionController in plain JavaScript',
+      'connect$ / disconnect$ / dispose$',
+      'terminalText$ for UI display; receive$ as raw stream',
+      'send$ / state$ / errors$',
+    ],
+    appDir: 'apps/example-vanilla-js',
   },
   {
     slug: 'vanilla-ts',
     label: 'Vanilla TS',
     description: 'Vanilla TypeScript example using SerialSession.',
     audience:
-      'Best starting point: try the library API directly with TypeScript and RxJS (no framework).',
+      'Best starting point: try the library API directly with TypeScript and RxJS (no UI framework).',
+    highlights: [
+      'createSerialSessionController with TypeScript',
+      'connect$ / disconnect$ / dispose$',
+      'terminalText$ for UI display; receive$ as raw stream',
+      'send$ / state$ / errors$',
+    ],
+    appDir: 'apps/example-vanilla-ts',
     recommended: true,
   },
   {
     slug: 'vue',
     label: 'Vue',
     description: 'Vue example app using SerialSession.',
-    audience: 'Vue 3 apps using the Composition API.',
+    audience:
+      'See how Vue 3 apps wire SerialSession with the Composition API (composable).',
+    highlights: [
+      'Vue 3 composable wrapping createSerialSessionController',
+      'connect$ / disconnect$ / dispose$ from UI events',
+      'terminalText$ for UI display; receive$ as raw stream',
+      'send$ / state$ / errors$',
+    ],
+    appDir: 'apps/example-vue',
   },
 ];
 


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): clarify examples start-here and purposes

## Summary
Examples 一覧で Vanilla TS を推奨開始地点（Recommended / まずはこちら）として明示し、各 Framework Example の目的・実装要素・Recipes との役割差を明確化しました（#560）。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #560
- Parent: #555

## What changed?
- `EXAMPLE_ENTRIES` に目的文・`highlights`・`appDir` を追加
- Examples index に Recipes vs Examples の役割説明、デバイス一覧ではない旨、バイリンガル Recommended バッジ、カードごとの実装要素、View source リンクを追加
- README（en/ja）と Docs ホームの Examples カード文言を開始地点・役割に合わせて更新

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm run docs:examples-index` を実行する
2. `docs/examples/index.html` で次を確認する
   - Vanilla TS に `Recommended / まずはこちら` バッジがある
   - 「Recipes vs Examples」と「対応デバイス一覧ではない」旨がある
   - 各カードに What you will see と View source がある
3. README.md / README.ja.md の Examples 節で Vanilla TS が開始地点になっていることを確認する

## Environment (if relevant)
- Browser: N/A（ドキュメント変更）
- OS: macOS
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)