### PR TITLE
docs(web-serial-rxjs): improve cross-links across recipes troubleshooting testing

### DIFF
--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -126,9 +126,11 @@ In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscr
 | **Repository [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md)** | Monorepo overview, examples index, and contribution links. |
 | **[Quick Start](./quick-start.md)** | Shortest path to a working open port and subscriptions. |
 | **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** | Pick the receive stream by use case. |
+| **[Communication pattern Recipes](./recipes.md)** | Pattern → Guide / Recipe index (not device compatibility). |
 | **[Advanced Usage](./advanced-usage.md)** | Line framing, derived streams, and recovery. |
 | **[Request / Response](./request-response.md)** | Command + matching reply on `lines$` / `receive$`. |
 | **[Timeout / cancel / retry](./timeout-cancel-retry.md)** | Timeouts, teardown cancel, bounded retry. |
+| **[Hardware-free testing](./testing.md)** | Controllable Fake `SerialSession` without a port. |
 | **[Troubleshooting](./troubleshooting.md)** | Common Web Serial / session problems and self-help checks. |
 | **[API Reference (TypeDoc)](modules.html)** | Options, `SerialSessionState`, and `SerialError` details; narrative tables also in [concepts](./concepts.md). |
 | **[v3 → v4 Migration Guide](./migration-v4.md)** ([日本語](../ja/migration-v4.md)) | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup). |

--- a/packages/web-serial-rxjs/docs/guide/en/recipes.md
+++ b/packages/web-serial-rxjs/docs/guide/en/recipes.md
@@ -128,6 +128,8 @@ await firstValueFrom(session.send$(payload));
 ## Related
 
 - [Choosing receive$ / lines$ / terminalText$](./stream-selection.md) — pick the receive stream first when unsure
+- [Hardware-free testing](./testing.md) — fake session and contract tests without a port
 - [Troubleshooting](./troubleshooting.md) — port picker, line endings, reconnect symptoms
+- [API Reference (TypeDoc)](modules.html) — options, types, and formal signatures
 - [Examples](../../examples/) — Angular / React / Vue / Svelte / Vanilla apps
 - [日本語 Recipes](../ja/recipes.md)

--- a/packages/web-serial-rxjs/docs/guide/en/testing.md
+++ b/packages/web-serial-rxjs/docs/guide/en/testing.md
@@ -344,6 +344,7 @@ it('reads connected state from Fake', async () => {
 ## Related
 
 - [Communication pattern Recipes](./recipes.md) — pattern → Guide index
+- [API concepts – SerialSession](./concepts.md#serialsession) — public surface under test
 - [Swappable public contract](./concepts.md#swappable-public-contract-decision-536)
 - [Advanced Usage](./advanced-usage.md) — compose RxJS on top of `receive$` / `send$`
 - [Request / Response recipes](./request-response.md) — command + matching reply (#538)

--- a/packages/web-serial-rxjs/docs/guide/en/troubleshooting.md
+++ b/packages/web-serial-rxjs/docs/guide/en/troubleshooting.md
@@ -130,6 +130,7 @@ Please include:
 
 ## Related links
 
+- [Communication pattern Recipes](./recipes.md) — pattern → Guide index for line protocols, request/response, timeout
 - [Quick Start](./quick-start.md)
 - [API concepts and design notes](./concepts.md)
 - [Advanced Usage](./advanced-usage.md)

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -120,9 +120,11 @@ session.send$('hello\r\n').subscribe();
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ全体の目次、サンプル索引、貢献の導線。 |
 | **[クイックスタート](./quick-start.md)** | 最短でポートを開いて購読するところまで。 |
 | **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** | 用途から受信ストリームを選ぶ。 |
+| **[通信パターン別 Recipes](./recipes.md)** | パターン → Guide / Recipe 索引（デバイス互換の保証ではない）。 |
 | **[高度な使用方法](./advanced-usage.md)** | 行フレーミング、派生ストリーム、リカバリ。 |
 | **[Request / Response](./request-response.md)** | `lines$` / `receive$` でのコマンド送信後の応答待ち。 |
 | **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** | タイムアウト、破棄時キャンセル、回数制限付き再試行。 |
+| **[実機なしのテスト](./testing.md)** | ポートなしで使える Fake `SerialSession`。 |
 | **[トラブルシューティング](./troubleshooting.md)** | Web Serial / セッションのよくある問題と自己解決手順。 |
 | **[API Reference（TypeDoc）](../../api/modules.html)** | オプション、`SerialSessionState`、`SerialError` の詳細。表・図は [概念と設計メモ](./concepts.md) も参照。 |
 | **[v3 → v4 マイグレーション](./migration-v4.md)**（[English](../en/migration-v4.md)） | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理）。 |

--- a/packages/web-serial-rxjs/docs/guide/ja/recipes.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/recipes.md
@@ -128,6 +128,8 @@ await firstValueFrom(session.send$(payload));
 ## 関連
 
 - [receive$ / lines$ / terminalText$ の選び方](./stream-selection.md) — 迷ったら先に受信ストリームを選ぶ
+- [実機なしのテスト](./testing.md) — fake session と契約テスト
 - [トラブルシューティング](./troubleshooting.md) — ポート選択、改行、再接続の症状
+- [API Reference（TypeDoc）](../../api/modules.html) — オプション、型、正式なシグネチャ
 - [Examples](../../examples/) — Angular / React / Vue / Svelte / Vanilla
 - [English Recipes](../en/recipes.md)

--- a/packages/web-serial-rxjs/docs/guide/ja/testing.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/testing.md
@@ -344,6 +344,7 @@ it('reads connected state from Fake', async () => {
 ## 関連
 
 - [通信パターン別 Recipes](./recipes.md) — パターン → Guide 索引
+- [概念 – SerialSession](./concepts.md#serialsession) — テスト対象の公開面
 - [差し替え可能な公開契約](./concepts.md#差し替え可能な公開契約decision-536)
 - [高度な使用方法](./advanced-usage.md) — `receive$` / `send$` 上の RxJS 組み立て
 - [Request / Response レシピ](./request-response.md) — コマンド送信後の応答待ち（#538）

--- a/packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md
@@ -130,6 +130,7 @@ session.errors$.subscribe((error) => {
 
 ## 関連リンク
 
+- [通信パターン別 Recipes](./recipes.md) — 行プロトコル、コマンド／応答、タイムアウトなどの索引
 - [クイックスタート](./quick-start.md)
 - [概念と設計メモ](./concepts.md)
 - [高度な使用方法](./advanced-usage.md)


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): improve cross-links across recipes troubleshooting testing

## Summary
Recipes / Troubleshooting / Testing / API Reference / overview 間の相互導線を、説明の複製ではなく Related・索引リンク追加で整理しました（#562）。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #562
- Related to #555

## What changed?
- Recipes hub（EN/JA）の Related に Testing と API Reference へのリンクを追加
- Troubleshooting（EN/JA）の関連リンクに Recipes への戻リンクを追加
- Testing（EN/JA）の Related に `concepts.md#serialsession` を追加
- overview の Documentation index（EN/JA）に Recipes / Testing 行を追加し、Guide README 索引と整合

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/docs/guide/{en,ja}/recipes.md` の Related から Testing / API Reference / Troubleshooting へ辿れることを確認する
2. `troubleshooting.md` → Recipes、`testing.md` → SerialSession Concepts を確認する
3. `overview.md` の Documentation index に Recipes / Testing があることを確認する
4. `pnpm run docs`（または `pnpm run docs:check-links`）で内部リンクが通ることを確認する

## Environment (if relevant)
- Browser: N/A（ドキュメントのみ）
- OS: macOS
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)