### PR TITLE
docs(web-serial-rxjs): separate web serial availability from support policy

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -71,6 +71,8 @@ Web Serial API を最小限の Session 指向 RxJS API でラップする TypeSc
 
 `connect$` を呼ぶ前の **feature detection**（`navigator.serial` の有無）には `isWebSerialSupported()` が使えます（同期的に `boolean` を返します）。これは**互換性や公式サポートの保証ではありません**。セキュアコンテキスト（HTTPS または localhost）は別条件です。
 
+Guide の詳細: [ブラウザサポートと公式サポート方針](packages/web-serial-rxjs/docs/guide/ja/browser-support.md)。
+
 ## インストール
 
 npm または pnpm を使用してパッケージをインストールします：

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,18 +48,28 @@ Web Serial API を最小限の Session 指向 RxJS API でラップする TypeSc
 
 ## ブラウザサポート
 
-Web Serial API は**デスクトップ**ブラウザでのみサポートされています。スマートフォンなどのモバイルブラウザには対応していません。
+この節では、**Web Serial API の実装状況**（ブラウザが提供するもの）と、本プロジェクトの**公式サポート方針**（動作確認・保証の範囲）を分けて記載します。
 
-対応しているデスクトップブラウザ：
+### Web Serial API の実装状況
+
+`navigator.serial` が存在する環境では、本ライブラリは Web Serial API を利用できます。デスクトップでの典型的な対応は次のとおりです。
 
 - **Chrome** 89+
 - **Edge** 89+
 - **Opera** 75+
 - **Firefox** 151+
 
-**Safari** は現時点で Web Serial API をサポートしていません。
+**Safari** は現時点で Web Serial API を**実装していません**。多くの**モバイル**ブラウザにも `navigator.serial` がなく、API が無い場合は `isWebSerialSupported()` が `false` を返します。
 
-`connect$` を呼ぶ前の feature detection には `isWebSerialSupported()` が使えます（同期的に `boolean` を返します）。
+### プロジェクトの公式サポート方針
+
+**公式サポート**の対象は、上記のデスクトップブラウザ（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）です。
+
+**モバイル**ブラウザは**未検証**であり、**公式サポート対象外**です。未検証は「ライブラリが拒否する」ことと同一ではありません。モバイルで Web Serial が公開され、セキュアコンテキストであれば feature detection が成功する場合もありますが、動作は保証しません。
+
+### `isWebSerialSupported()`
+
+`connect$` を呼ぶ前の **feature detection**（`navigator.serial` の有無）には `isWebSerialSupported()` が使えます（同期的に `boolean` を返します）。これは**互換性や公式サポートの保証ではありません**。セキュアコンテキスト（HTTPS または localhost）は別条件です。
 
 ## インストール
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Where `navigator.serial` exists, this library can talk to the Web Serial API. Ty
 
 `isWebSerialSupported()` returns a synchronous boolean for **feature detection** (`navigator.serial` present) before calling `connect$`. It is **not** a compatibility or official-support guarantee. Secure context (HTTPS or localhost) is a separate requirement.
 
+Guide detail: [Browser support and support policy](packages/web-serial-rxjs/docs/guide/en/browser-support.md).
+
 ## Installation
 
 Install the package using npm or pnpm:

--- a/README.md
+++ b/README.md
@@ -48,18 +48,28 @@ This library is framework-agnostic and can be used with:
 
 ## Browser Support
 
-The Web Serial API is supported on **desktop** browsers only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** (what the browser implements) from this project's **official support policy** (what we test and guarantee).
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Where `navigator.serial` exists, this library can talk to the Web Serial API. Typical desktop availability:
 
 - **Chrome** 89+
 - **Edge** 89+
 - **Opera** 75+
 - **Firefox** 151+
 
-**Safari** does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`; when the API is missing, `isWebSerialSupported()` returns `false`.
 
-`isWebSerialSupported()` returns a synchronous boolean for feature detection before calling `connect$`.
+### Project support policy
+
+**Official support** covers the desktop browsers listed above (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+).
+
+**Mobile** browsers are **untested** and **out of official support**. Untested does **not** mean the library rejects them — if a mobile browser exposes Web Serial and the page is in a secure context, feature detection may succeed, but we do not guarantee behavior.
+
+### `isWebSerialSupported()`
+
+`isWebSerialSupported()` returns a synchronous boolean for **feature detection** (`navigator.serial` present) before calling `connect$`. It is **not** a compatibility or official-support guarantee. Secure context (HTTPS or localhost) is a separate requirement.
 
 ## Installation
 

--- a/apps/example-angular/README.md
+++ b/apps/example-angular/README.md
@@ -37,7 +37,7 @@ This is an Angular example application demonstrating how to use the `@gurezo/web
 
 ## Requirements
 
-- Modern browser with Web Serial API support (Chrome, Edge, Opera, etc.)
+- Officially supported desktop browser with Web Serial API (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+)
 - Node.js and npm
 - Nx workspace
 
@@ -129,13 +129,21 @@ This example uses Angular Services and RxJS observables to handle serial port co
 
 ## Browser Compatibility
 
-This example requires a browser that supports the Web Serial API on **desktop** only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** from this project's **official support**.
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Typical desktop availability:
 
 - Chrome 89+
 - Edge 89+
 - Opera 75+
 - Firefox 151+
 
-Safari does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`.
+
+### Project support policy
+
+**Official support** covers the desktop browsers listed above. **Mobile** browsers are **untested** and **out of official support** (untested ≠ rejected by the library).
+
+`isWebSerialSupported()` is feature detection only — not a compatibility guarantee. See the Guide [Browser support and support policy](../../packages/web-serial-rxjs/docs/guide/en/browser-support.md).

--- a/apps/example-react/README.md
+++ b/apps/example-react/README.md
@@ -36,7 +36,7 @@ This is a minimal React example for the `SerialSession` API (Web Serial). The `u
 
 ## Requirements
 
-- Modern browser with Web Serial API support (Chrome, Edge, Opera, etc.)
+- Officially supported desktop browser with Web Serial API (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+)
 - Node.js and pnpm
 - Nx workspace
 
@@ -117,13 +117,21 @@ The example uses `createSerialSession` directly through `useSerialSession`:
 
 ## Browser Compatibility
 
-This example requires a browser that supports the Web Serial API on **desktop** only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** from this project's **official support**.
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Typical desktop availability:
 
 - Chrome 89+
 - Edge 89+
 - Opera 75+
 - Firefox 151+
 
-Safari does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`.
+
+### Project support policy
+
+**Official support** covers the desktop browsers listed above. **Mobile** browsers are **untested** and **out of official support** (untested ≠ rejected by the library).
+
+`isWebSerialSupported()` is feature detection only — not a compatibility guarantee. See the Guide [Browser support and support policy](../../packages/web-serial-rxjs/docs/guide/en/browser-support.md).

--- a/apps/example-svelte/README.md
+++ b/apps/example-svelte/README.md
@@ -36,7 +36,7 @@ This is a minimal Svelte example for the `SerialSession` API. `useSerialSession`
 
 ## Requirements
 
-- Modern browser with Web Serial API support (Chrome, Edge, Opera, etc.)
+- Officially supported desktop browser with Web Serial API (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+)
 - Node.js and pnpm
 - Nx workspace
 
@@ -118,13 +118,21 @@ The example uses `createSerialSession` directly through `useSerialSession`:
 
 ## Browser Compatibility
 
-This example requires a browser that supports the Web Serial API on **desktop** only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** from this project's **official support**.
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Typical desktop availability:
 
 - Chrome 89+
 - Edge 89+
 - Opera 75+
 - Firefox 151+
 
-Safari does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`.
+
+### Project support policy
+
+**Official support** covers the desktop browsers listed above. **Mobile** browsers are **untested** and **out of official support** (untested ≠ rejected by the library).
+
+`isWebSerialSupported()` is feature detection only — not a compatibility guarantee. See the Guide [Browser support and support policy](../../packages/web-serial-rxjs/docs/guide/en/browser-support.md).

--- a/apps/example-vanilla-js/README.md
+++ b/apps/example-vanilla-js/README.md
@@ -35,7 +35,7 @@ This is a vanilla JavaScript example application demonstrating how to use the `@
 
 ## Requirements
 
-- Modern browser with Web Serial API support (Chrome, Edge, Opera, etc.)
+- Officially supported desktop browser with Web Serial API (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+)
 - Node.js and npm
 - Nx workspace
 
@@ -124,13 +124,21 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 ## Browser Compatibility
 
-This example requires a browser that supports the Web Serial API on **desktop** only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** from this project's **official support**.
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Typical desktop availability:
 
 - Chrome 89+
 - Edge 89+
 - Opera 75+
 - Firefox 151+
 
-Safari does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`.
+
+### Project support policy
+
+**Official support** covers the desktop browsers listed above. **Mobile** browsers are **untested** and **out of official support** (untested ≠ rejected by the library).
+
+`isWebSerialSupported()` is feature detection only — not a compatibility guarantee. See the Guide [Browser support and support policy](../../packages/web-serial-rxjs/docs/guide/en/browser-support.md).

--- a/apps/example-vanilla-ts/README.md
+++ b/apps/example-vanilla-ts/README.md
@@ -36,7 +36,7 @@ This is a vanilla TypeScript example application demonstrating how to use the `@
 
 ## Requirements
 
-- Modern browser with Web Serial API support (Chrome, Edge, Opera, etc.)
+- Officially supported desktop browser with Web Serial API (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+)
 - Node.js and npm
 - Nx workspace
 
@@ -126,13 +126,21 @@ This example uses RxJS observables to handle serial port communication reactivel
 
 ## Browser Compatibility
 
-This example requires a browser that supports the Web Serial API on **desktop** only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** from this project's **official support**.
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Typical desktop availability:
 
 - Chrome 89+
 - Edge 89+
 - Opera 75+
 - Firefox 151+
 
-Safari does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`.
+
+### Project support policy
+
+**Official support** covers the desktop browsers listed above. **Mobile** browsers are **untested** and **out of official support** (untested ≠ rejected by the library).
+
+`isWebSerialSupported()` is feature detection only — not a compatibility guarantee. See the Guide [Browser support and support policy](../../packages/web-serial-rxjs/docs/guide/en/browser-support.md).

--- a/apps/example-vue/README.md
+++ b/apps/example-vue/README.md
@@ -37,7 +37,7 @@ This is a Vue example application demonstrating how to use the `@gurezo/web-seri
 
 ## Requirements
 
-- Modern browser with Web Serial API support (Chrome, Edge, Opera, etc.)
+- Officially supported desktop browser with Web Serial API (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+)
 - Node.js and npm
 - Nx workspace
 
@@ -131,13 +131,21 @@ This example uses Vue 3 Composition API and RxJS observables to handle serial po
 
 ## Browser Compatibility
 
-This example requires a browser that supports the Web Serial API on **desktop** only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** from this project's **official support**.
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Typical desktop availability:
 
 - Chrome 89+
 - Edge 89+
 - Opera 75+
 - Firefox 151+
 
-Safari does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`.
+
+### Project support policy
+
+**Official support** covers the desktop browsers listed above. **Mobile** browsers are **untested** and **out of official support** (untested ≠ rejected by the library).
+
+`isWebSerialSupported()` is feature detection only — not a compatibility guarantee. See the Guide [Browser support and support policy](../../packages/web-serial-rxjs/docs/guide/en/browser-support.md).

--- a/libs/examples-shared/src/example-requirements.ts
+++ b/libs/examples-shared/src/example-requirements.ts
@@ -33,7 +33,7 @@ const CANCEL_MESSAGE =
   'ポート選択がキャンセルされました。再度『接続』を押してポートを選んでください。';
 
 const RECOMMENDED_BROWSERS =
-  'Chrome、Edge、Opera、Firefox などの対応ブラウザ（デスクトップ）をご使用ください。Safari およびモバイルブラウザは非対応です。';
+  '公式サポート対象のデスクトップブラウザ（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）をご使用ください。Safari は Web Serial API 未実装です。モバイルは未検証・公式サポート対象外です。';
 
 /**
  * Static copy for the Example “利用条件” panel (Japanese UI).
@@ -44,7 +44,7 @@ export function getExampleRequirementsCopy(): ExampleRequirementsCopy {
     items: [
       'ページは HTTPS または localhost（セキュアコンテキスト）で開いてください。',
       '「接続」はユーザー操作（ボタンクリック）から実行してください。そうでないとポート選択ダイアログが開きません。',
-      'Web Serial はデスクトップブラウザのみ対応です（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）。実機のシリアルデバイス（または互換アダプタ）が必要です。',
+      'Web Serial の公式サポート対象はデスクトップブラウザです（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）。モバイルは未検証です。実機のシリアルデバイス（または互換アダプタ）が必要です。',
     ],
   };
 }

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -33,6 +33,8 @@ Web Serial API を最小限の Session 指向 RxJS 表面でラップする Type
 
 `connect$` の前の **feature detection**（`navigator.serial` の有無）には `isWebSerialSupported()`（同期的に `boolean`）を使います。これは**互換性や公式サポートの保証ではありません**。セキュアコンテキスト（HTTPS または localhost）は別条件です。
 
+Guide の詳細: [ブラウザサポートと公式サポート方針](docs/guide/ja/browser-support.md)。
+
 ## 接続状態（ライフサイクル UI）
 
 ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。セッション破棄には **`dispose$()`** を使用します（購読により実行されます）。詳細は [v4 への移行](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md) を参照してください。

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -10,18 +10,28 @@ Web Serial API を最小限の Session 指向 RxJS 表面でラップする Type
 
 ## ブラウザサポート
 
-Web Serial API は**デスクトップ**ブラウザでのみサポートされています。スマートフォンなどのモバイルブラウザには対応していません。
+この節では、**Web Serial API の実装状況**（ブラウザが提供するもの）と、本プロジェクトの**公式サポート方針**（動作確認・保証の範囲）を分けて記載します。
 
-対応しているデスクトップブラウザ：
+### Web Serial API の実装状況
+
+`navigator.serial` が存在する環境では、本ライブラリは Web Serial API を利用できます。デスクトップでの典型的な対応は次のとおりです。
 
 - **Chrome** 89+
 - **Edge** 89+
 - **Opera** 75+
 - **Firefox** 151+
 
-**Safari** は現時点で Web Serial API をサポートしていません。
+**Safari** は現時点で Web Serial API を**実装していません**。多くの**モバイル**ブラウザにも `navigator.serial` がなく、API が無い場合は `isWebSerialSupported()` が `false` を返します。
 
-`connect$` の前の feature detection には `isWebSerialSupported()`（同期的に `boolean`）を使います。
+### プロジェクトの公式サポート方針
+
+**公式サポート**の対象は、上記のデスクトップブラウザ（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）です。
+
+**モバイル**ブラウザは**未検証**であり、**公式サポート対象外**です。未検証は「ライブラリが拒否する」ことと同一ではありません。モバイルで Web Serial が公開され、セキュアコンテキストであれば feature detection が成功する場合もありますが、動作は保証しません。
+
+### `isWebSerialSupported()`
+
+`connect$` の前の **feature detection**（`navigator.serial` の有無）には `isWebSerialSupported()`（同期的に `boolean`）を使います。これは**互換性や公式サポートの保証ではありません**。セキュアコンテキスト（HTTPS または localhost）は別条件です。
 
 ## 接続状態（ライフサイクル UI）
 

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -33,8 +33,6 @@ Web Serial API を最小限の Session 指向 RxJS 表面でラップする Type
 
 `connect$` の前の **feature detection**（`navigator.serial` の有無）には `isWebSerialSupported()`（同期的に `boolean`）を使います。これは**互換性や公式サポートの保証ではありません**。セキュアコンテキスト（HTTPS または localhost）は別条件です。
 
-Guide の詳細: [ブラウザサポートと公式サポート方針](docs/guide/ja/browser-support.md)。
-
 ## 接続状態（ライフサイクル UI）
 
 ライフサイクル UI には **`state$`** の `state.status` narrowing を canonical API として使用してください。boolean だけ必要な場合は `state$` から derive してください。セッション破棄には **`dispose$()`** を使用します（購読により実行されます）。詳細は [v4 への移行](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/migration-v4.md) を参照してください。

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -10,18 +10,28 @@ A TypeScript library that wraps the Web Serial API with a minimal, session-orien
 
 ## Browser support
 
-The Web Serial API is supported on **desktop** browsers only. Smartphones and other mobile browsers are not supported.
+This section separates **Web Serial API availability** (what the browser implements) from this project's **official support policy** (what we test and guarantee).
 
-Supported desktop browsers:
+### Web Serial API availability
+
+Where `navigator.serial` exists, this library can talk to the Web Serial API. Typical desktop availability:
 
 - **Chrome** 89+
 - **Edge** 89+
 - **Opera** 75+
 - **Firefox** 151+
 
-**Safari** does not currently support the Web Serial API.
+**Safari** does not currently implement the Web Serial API. Many **mobile** browsers also lack `navigator.serial`; when the API is missing, `isWebSerialSupported()` returns `false`.
 
-`isWebSerialSupported()` returns a synchronous `boolean` for feature detection before `connect$`.
+### Project support policy
+
+**Official support** covers the desktop browsers listed above (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+).
+
+**Mobile** browsers are **untested** and **out of official support**. Untested does **not** mean the library rejects them — if a mobile browser exposes Web Serial and the page is in a secure context, feature detection may succeed, but we do not guarantee behavior.
+
+### `isWebSerialSupported()`
+
+`isWebSerialSupported()` returns a synchronous `boolean` for **feature detection** (`navigator.serial` present) before `connect$`. It is **not** a compatibility or official-support guarantee. Secure context (HTTPS or localhost) is a separate requirement.
 
 ## Connection state (lifecycle UI)
 

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -33,6 +33,8 @@ Where `navigator.serial` exists, this library can talk to the Web Serial API. Ty
 
 `isWebSerialSupported()` returns a synchronous `boolean` for **feature detection** (`navigator.serial` present) before `connect$`. It is **not** a compatibility or official-support guarantee. Secure context (HTTPS or localhost) is a separate requirement.
 
+Guide detail: [Browser support and support policy](docs/guide/en/browser-support.md).
+
 ## Connection state (lifecycle UI)
 
 Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. Session teardown uses **`dispose$()`** (subscribe to run it). See [Migrating to v4](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v4.md).

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -33,8 +33,6 @@ Where `navigator.serial` exists, this library can talk to the Web Serial API. Ty
 
 `isWebSerialSupported()` returns a synchronous `boolean` for **feature detection** (`navigator.serial` present) before `connect$`. It is **not** a compatibility or official-support guarantee. Secure context (HTTPS or localhost) is a separate requirement.
 
-Guide detail: [Browser support and support policy](docs/guide/en/browser-support.md).
-
 ## Connection state (lifecycle UI)
 
 Prefer **`state$`** with `state.status` narrowing as the canonical API for lifecycle UI. Derive a boolean from `state$` when you only need a connected flag. Session teardown uses **`dispose$()`** (subscribe to run it). See [Migrating to v4](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/migration-v4.md).

--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -8,14 +8,15 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 
 1. **[Overview](./overview.md)** — `SerialSession` public surface, role of `state$` / `errors$`, minimal sample
 2. **[Quick Start](./quick-start.md)** — installation, connect, receive/send, disconnect/dispose, error handling
-3. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
-4. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
-5. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
-6. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
-7. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
-8. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
-9. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
-10. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
+3. **[Browser support and support policy](./browser-support.md)** — Web Serial API availability vs official support
+4. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
+5. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
+6. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
+7. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
+8. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
+9. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
+10. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
+11. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
 
 When migrating existing code:
 
@@ -29,6 +30,7 @@ When migrating existing code:
 | --- | --- |
 | **[Overview](./overview.md)** | Public surface quick reference, feature summary, minimal sample |
 | **[Quick Start](./quick-start.md)** | Basic flow from installation through disconnect |
+| **[Browser support and support policy](./browser-support.md)** | API availability vs official support / untested |
 | **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** | Decision guide for the three receive streams |
 | **[Communication pattern Recipes](./recipes.md)** | Pattern → Guide / Recipe index (not device compatibility) |
 | **[Advanced Usage](./advanced-usage.md)** | Application patterns and RxJS recipes |
@@ -55,5 +57,5 @@ When migrating existing code:
 - **`state$`** — canonical lifecycle source. Branch on `state.status` with `SerialSessionStatus`; use `state.portInfo` when connected
 - **`errors$`** — canonical fatal / non-fatal error event channel. Branch with `SerialError.is(SerialErrorCode.*)`
 - **`dispose$()`** — sole session teardown API (subscribe to run it)
-- **`isWebSerialSupported()`** — top-level sync feature detection (not a session method)
+- **`isWebSerialSupported()`** — top-level sync feature detection (not a session method; not a support guarantee) — see [Browser support](./browser-support.md)
 - Phase 1+2 removals (`destroy$`, `isConnected$`, `portInfo$`, `getPortInfo()`, `getCurrentPort()`, `receiveReplay$`, `isBrowserSupported()`) are documented in [Migrating to v4](./migration-v4.md)

--- a/packages/web-serial-rxjs/docs/guide/en/browser-support.md
+++ b/packages/web-serial-rxjs/docs/guide/en/browser-support.md
@@ -1,0 +1,48 @@
+# Browser support and support policy
+
+Web Serial **API availability** (what the browser implements) is not the same as this project's **official support** (what we test and guarantee). This page keeps those apart.
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#561](https://github.com/gurezo/web-serial-rxjs/issues/561) · Related: [Troubleshooting](./troubleshooting.md)
+
+## Terminology
+
+| Term | Meaning |
+| --- | --- |
+| Web Serial API availability | Whether `navigator.serial` exists in the browser |
+| Official support / tested | Environments this project tests and treats as supported |
+| Untested / out of official support | Not verified; behavior is not guaranteed — **not** the same as “the library rejects it” |
+| Not available (API) | The browser does not implement Web Serial |
+
+## Web Serial API availability
+
+Where `navigator.serial` exists, this library can use the Web Serial API. Typical **desktop** availability:
+
+- **Chrome** 89+
+- **Edge** 89+
+- **Opera** 75+
+- **Firefox** 151+
+
+**Safari** does not currently **implement** the Web Serial API. Many **mobile** browsers also lack `navigator.serial`; when the API is missing, `isWebSerialSupported()` returns `false`.
+
+## Project support policy
+
+**Official support** covers the desktop browsers listed above (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+).
+
+**Mobile** browsers are **untested** and **out of official support**. Untested does **not** mean the library rejects them — if a mobile browser exposes Web Serial and the page is in a secure context, feature detection may succeed, but we do not guarantee behavior.
+
+This Guide does **not** maintain a full browser matrix; version floors above reflect known Web Serial availability, not a claim of exhaustive CI coverage for every minor release.
+
+## `isWebSerialSupported()`
+
+`isWebSerialSupported()` is top-level **feature detection**: it returns whether `navigator.serial` is present. Prefer it **before** creating a session or calling `connect$`.
+
+It is **not** a compatibility guarantee and **not** a statement of official support. Secure context (HTTPS or localhost) is a **separate** requirement — see [Quick Start – Requirements](./quick-start.md#requirements) and [Troubleshooting – Secure context](./troubleshooting.md#secure-context-https--localhost).
+
+After a session exists, drive unsupported UI from `state$` with `SerialSessionStatus.Unsupported`. Details: [API concepts – isWebSerialSupported](./concepts.md#iswebserialsupported-boolean).
+
+## Related
+
+- Repository [README – Browser Support](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md#browser-support)
+- Package [README – Browser support](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/README.md#browser-support)
+- [Troubleshooting](./troubleshooting.md)
+- [Quick Start](./quick-start.md)

--- a/packages/web-serial-rxjs/docs/guide/en/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/en/concepts.md
@@ -297,7 +297,9 @@ createSerialUi(session);
 
 ### `isWebSerialSupported(): boolean`
 
-Synchronous feature check. Returns `true` when `navigator.serial` is available. Prefer this **before** creating a session. After the session exists, drive unsupported UI from `state$` with `SerialSessionStatus.Unsupported`. See [Migrating to v4 – browser support](./migration-v4.md#browser-support-detection).
+Synchronous **feature detection**. Returns `true` when `navigator.serial` is available. Prefer this **before** creating a session. After the session exists, drive unsupported UI from `state$` with `SerialSessionStatus.Unsupported`.
+
+This check is **not** a compatibility or official-support guarantee — see [Browser support and support policy](./browser-support.md). Secure context is a separate requirement. Migration notes: [Migrating to v4 – browser support](./migration-v4.md#browser-support-detection).
 
 ### `connect$(): Observable<void>`
 

--- a/packages/web-serial-rxjs/docs/guide/en/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/en/overview.md
@@ -125,6 +125,7 @@ In real apps, handle `connect$().subscribe({ next, error })` and `send$().subscr
 | **[日本語 Guide 索引](../ja/README.md)** | Getting Started の読み順と一覧。 |
 | **Repository [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md)** | Monorepo overview, examples index, and contribution links. |
 | **[Quick Start](./quick-start.md)** | Shortest path to a working open port and subscriptions. |
+| **[Browser support and support policy](./browser-support.md)** | Web Serial API availability vs official support / untested. |
 | **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** | Pick the receive stream by use case. |
 | **[Communication pattern Recipes](./recipes.md)** | Pattern → Guide / Recipe index (not device compatibility). |
 | **[Advanced Usage](./advanced-usage.md)** | Line framing, derived streams, and recovery. |

--- a/packages/web-serial-rxjs/docs/guide/en/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/en/quick-start.md
@@ -33,7 +33,7 @@ npm install rxjs
 pnpm add rxjs
 ```
 
-For monorepo-wide browser support and example app index, see the [repository README.md](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md).
+For browser **API availability** vs this project's **official support** (and untested mobile), see [Browser support and support policy](./browser-support.md). The monorepo [README.md](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md) also summarizes browser support and lists example apps.
 
 ## Connect, receive, and send
 

--- a/packages/web-serial-rxjs/docs/guide/en/troubleshooting.md
+++ b/packages/web-serial-rxjs/docs/guide/en/troubleshooting.md
@@ -10,7 +10,7 @@ Common Web Serial and `@gurezo/web-serial-rxjs` problems, with check steps and f
 
 1. Call `connect$()` from a **user gesture** (button click). The browser blocks the picker otherwise — see [Quick Start – Requirements](./quick-start.md#requirements).
 2. Confirm the page is a [secure context](#secure-context-https--localhost) (HTTPS or localhost).
-3. Confirm Web Serial is available — see [Web Serial not supported](#web-serial-not-supported).
+3. Confirm Web Serial is available — see [Web Serial API not available](#web-serial-api-not-available).
 4. Try another USB cable / port, and close other apps that might hold the serial device (Arduino IDE, screen, minicom, another browser tab).
 5. On the OS, confirm the device appears and drivers are installed.
 

--- a/packages/web-serial-rxjs/docs/guide/en/troubleshooting.md
+++ b/packages/web-serial-rxjs/docs/guide/en/troubleshooting.md
@@ -16,7 +16,7 @@ Common Web Serial and `@gurezo/web-serial-rxjs` problems, with check steps and f
 
 **Fix:** Wire Connect to a click handler, fix secure context / browser support, free the port, then call `connect$()` again and subscribe.
 
-## Web Serial not supported
+## Web Serial API not available
 
 **Symptoms:** `state$` stays at `unsupported`, or `connect$` fails with `SerialErrorCode.BROWSER_NOT_SUPPORTED`.
 
@@ -30,7 +30,7 @@ if (!isWebSerialSupported()) {
 }
 ```
 
-**Fix:** Use a desktop Chromium-based browser or Firefox with Web Serial (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+). Safari and mobile browsers are not supported. See the [Examples requirements](https://gurezo.net/web-serial-rxjs/examples/) and repository README browser support notes.
+**Fix:** Use an officially supported desktop browser with Web Serial (Chrome 89+, Edge 89+, Opera 75+, Firefox 151+). **Safari** does not currently implement the Web Serial API. **Mobile** browsers are untested and out of official support — many also lack the API (so `isWebSerialSupported()` is `false`). See [Browser support and support policy](./browser-support.md), the [Examples requirements](https://gurezo.net/web-serial-rxjs/examples/), and the repository README.
 
 ## Secure context (HTTPS / localhost)
 
@@ -130,6 +130,7 @@ Please include:
 
 ## Related links
 
+- [Browser support and support policy](./browser-support.md) — API availability vs official support
 - [Communication pattern Recipes](./recipes.md) — pattern → Guide index for line protocols, request/response, timeout
 - [Quick Start](./quick-start.md)
 - [API concepts and design notes](./concepts.md)

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -8,14 +8,15 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 
 1. **[概要](./overview.md)** — `SerialSession` の公開面、`state$` / `errors$` の位置付け、最小サンプル
 2. **[クイックスタート](./quick-start.md)** — インストール、接続、受信・送信、切断・破棄、エラーハンドリング
-3. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
-4. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
-5. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
-6. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
-7. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
-8. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
-9. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
-10. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
+3. **[ブラウザサポートと公式サポート方針](./browser-support.md)** — Web Serial API 実装状況と公式サポートの分離
+4. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
+5. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
+6. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
+7. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
+8. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
+9. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
+10. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
+11. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
 
 既存コードから移行する場合:
 
@@ -29,6 +30,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | --- | --- |
 | **[概要](./overview.md)** | 公開面の早見表、機能概要、最小サンプル |
 | **[クイックスタート](./quick-start.md)** | インストールから切断までの基本フロー |
+| **[ブラウザサポートと公式サポート方針](./browser-support.md)** | API 実装状況と公式サポート / 未検証の区別 |
 | **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** | 3 系統の受信ストリームの判断ガイド |
 | **[通信パターン別 Recipes](./recipes.md)** | パターン → Guide / Recipe 索引（デバイス互換の保証ではない） |
 | **[高度な使用方法](./advanced-usage.md)** | 応用パターンと RxJS レシピ |
@@ -55,5 +57,5 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 - **`state$`** — 接続ライフサイクルの canonical source。`state.status` と `SerialSessionStatus` で分岐し、connected 時は `state.portInfo` を利用する
 - **`errors$`** — fatal / non-fatal エラーの canonical event channel。`SerialError.is(SerialErrorCode.*)` で分岐する
 - **`dispose$()`** — セッション破棄の唯一の API（購読により実行）
-- **`isWebSerialSupported()`** — トップレベルの同期 feature detection（セッションメソッドではない）
+- **`isWebSerialSupported()`** — トップレベルの同期 feature detection（セッションメソッドではない。サポート保証ではない）— [ブラウザサポート](./browser-support.md) を参照
 - Phase 1+2 で削除された API（`destroy$`、`isConnected$`、`portInfo$`、`getPortInfo()`、`getCurrentPort()`、`receiveReplay$`、`isBrowserSupported()`）は [v4 への移行](./migration-v4.md) を参照

--- a/packages/web-serial-rxjs/docs/guide/ja/browser-support.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/browser-support.md
@@ -1,0 +1,48 @@
+# ブラウザサポートと公式サポート方針
+
+Web Serial の **API 実装状況**（ブラウザが提供するもの）と、本プロジェクトの **公式サポート**（動作確認・保証の範囲）は別です。このページでは両者を分けて記載します。
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#561](https://github.com/gurezo/web-serial-rxjs/issues/561) · Related: [トラブルシューティング](./troubleshooting.md)
+
+## 用語
+
+| 用語 | 意味 |
+| --- | --- |
+| Web Serial API の実装状況 | ブラウザに `navigator.serial` があるか |
+| 公式サポート / 検証済み | 本プロジェクトが動作確認し、サポート対象とする環境 |
+| 未検証 / 公式サポート対象外 | 未確認であり動作を保証しない。**「ライブラリが拒否する」こととは異なる** |
+| API 未実装 | ブラウザが Web Serial を実装していない |
+
+## Web Serial API の実装状況
+
+`navigator.serial` が存在する環境では、本ライブラリは Web Serial API を利用できます。**デスクトップ**での典型的な対応は次のとおりです。
+
+- **Chrome** 89+
+- **Edge** 89+
+- **Opera** 75+
+- **Firefox** 151+
+
+**Safari** は現時点で Web Serial API を**実装していません**。多くの**モバイル**ブラウザにも `navigator.serial` がなく、API が無い場合は `isWebSerialSupported()` が `false` を返します。
+
+## プロジェクトの公式サポート方針
+
+**公式サポート**の対象は、上記のデスクトップブラウザ（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）です。
+
+**モバイル**ブラウザは**未検証**であり、**公式サポート対象外**です。未検証は「ライブラリが拒否する」ことと同一ではありません。モバイルで Web Serial が公開され、セキュアコンテキストであれば feature detection が成功する場合もありますが、動作は保証しません。
+
+本 Guide では詳細なブラウザマトリクスは維持しません。上記のバージョン下限は Web Serial の既知の実装状況を示すものであり、すべてのマイナー版を CI で網羅検証しているという意味ではありません。
+
+## `isWebSerialSupported()`
+
+`isWebSerialSupported()` はトップレベルの **feature detection** です。`navigator.serial` の有無を返します。セッション生成や `connect$` の**前**に使うことを推奨します。
+
+これは**互換性の保証ではなく**、**公式サポートの宣言でもありません**。セキュアコンテキスト（HTTPS または localhost）は**別条件**です — [クイックスタート – 利用条件](./quick-start.md#利用条件) と [トラブルシューティング – セキュアコンテキスト](./troubleshooting.md#セキュアコンテキストhttps--localhost) を参照してください。
+
+セッション生成後は、`state$` の `SerialSessionStatus.Unsupported` で非対応 UI を駆動してください。詳細: [API の概念 – isWebSerialSupported](./concepts.md#iswebserialsupported-boolean)。
+
+## 関連
+
+- リポジトリ [README – ブラウザサポート](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md#ブラウザサポート)
+- パッケージ [README – ブラウザサポート](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/README.ja.md#ブラウザサポート)
+- [トラブルシューティング](./troubleshooting.md)
+- [クイックスタート](./quick-start.md)

--- a/packages/web-serial-rxjs/docs/guide/ja/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/concepts.md
@@ -297,7 +297,9 @@ createSerialUi(session);
 
 ### `isWebSerialSupported(): boolean`
 
-同期的な feature detection。`navigator.serial` が存在すれば `true` を返します。セッション生成**前**に使ってください。生成後の unsupported UI は `state$` の `SerialSessionStatus.Unsupported` を推奨します。詳細は [v4 への移行 – ブラウザー対応判定](./migration-v4.md#ブラウザー対応判定) を参照してください。
+同期的な **feature detection**。`navigator.serial` が存在すれば `true` を返します。セッション生成**前**に使ってください。生成後の unsupported UI は `state$` の `SerialSessionStatus.Unsupported` を推奨します。
+
+これは**互換性や公式サポートの保証ではありません** — [ブラウザサポートと公式サポート方針](./browser-support.md) を参照してください。セキュアコンテキストは別条件です。移行メモ: [v4 への移行 – ブラウザー対応判定](./migration-v4.md#ブラウザー対応判定)。
 
 ### `connect$(): Observable<void>`
 

--- a/packages/web-serial-rxjs/docs/guide/ja/overview.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/overview.md
@@ -119,6 +119,7 @@ session.send$('hello\r\n').subscribe();
 | **[English Guide 索引](../en/README.md)** | Getting Started reading order and full index. |
 | **リポジトリ [README](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md)** | モノレポ全体の目次、サンプル索引、貢献の導線。 |
 | **[クイックスタート](./quick-start.md)** | 最短でポートを開いて購読するところまで。 |
+| **[ブラウザサポートと公式サポート方針](./browser-support.md)** | Web Serial API 実装状況と公式サポート / 未検証の区別。 |
 | **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** | 用途から受信ストリームを選ぶ。 |
 | **[通信パターン別 Recipes](./recipes.md)** | パターン → Guide / Recipe 索引（デバイス互換の保証ではない）。 |
 | **[高度な使用方法](./advanced-usage.md)** | 行フレーミング、派生ストリーム、リカバリ。 |

--- a/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
@@ -33,7 +33,7 @@ npm install rxjs
 pnpm add rxjs
 ```
 
-モノレポ全体のブラウザサポートやサンプルアプリの索引は [リポジトリ README.ja.md](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md) を参照してください。
+ブラウザの **API 実装状況**と本プロジェクトの **公式サポート**（および未検証のモバイル）の区別は [ブラウザサポートと公式サポート方針](./browser-support.md) を参照してください。モノレポ [README.ja.md](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md) にもブラウザサポートの要約とサンプルアプリ索引があります。
 
 ## 接続・受信・送信
 

--- a/packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md
@@ -10,7 +10,7 @@ Web Serial および `@gurezo/web-serial-rxjs` でよくある問題の確認手
 
 1. **`connect$()`** を **ユーザー操作**（ボタンクリックなど）から呼び出しているか。そうでないとブラウザはダイアログを開きません — [クイックスタート – 利用条件](./quick-start.md#利用条件)。
 2. ページが [セキュアコンテキスト](#セキュアコンテキストhttps--localhost)（HTTPS または localhost）か。
-3. Web Serial が使えるか — [Web Serial 非対応](#web-serial-非対応)。
+3. Web Serial が使えるか — [Web Serial API が利用できない](#web-serial-api-が利用できない)。
 4. 別の USB ケーブル / ポートを試し、Arduino IDE・screen・minicom・別タブなどポートを掴んでいるアプリを閉じる。
 5. OS 上でデバイスが見え、ドライバが入っているか。
 

--- a/packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md
@@ -16,7 +16,7 @@ Web Serial および `@gurezo/web-serial-rxjs` でよくある問題の確認手
 
 **対処:** クリックハンドラから接続し、セキュアコンテキスト / ブラウザ対応を直し、ポートを解放してから再度 `connect$()` を購読してください。
 
-## Web Serial 非対応
+## Web Serial API が利用できない
 
 **症状:** `state$` が `unsupported` のまま、または `connect$` が `SerialErrorCode.BROWSER_NOT_SUPPORTED` で失敗する。
 
@@ -30,7 +30,7 @@ if (!isWebSerialSupported()) {
 }
 ```
 
-**対処:** Web Serial 対応のデスクトップブラウザ（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）を使ってください。Safari およびモバイルブラウザは非対応です。[Examples の利用条件](https://gurezo.net/web-serial-rxjs/examples/) とリポジトリ README のブラウザ対応も参照してください。
+**対処:** 公式サポート対象のデスクトップブラウザ（Chrome 89+、Edge 89+、Opera 75+、Firefox 151+）を使ってください。**Safari** は現時点で Web Serial API を**実装していません**。**モバイル**ブラウザは未検証・公式サポート対象外であり、多くの環境では API 自体が無く `isWebSerialSupported()` が `false` になります。[ブラウザサポートと公式サポート方針](./browser-support.md)、[Examples の利用条件](https://gurezo.net/web-serial-rxjs/examples/)、リポジトリ README も参照してください。
 
 ## セキュアコンテキスト（HTTPS / localhost）
 
@@ -130,6 +130,7 @@ session.errors$.subscribe((error) => {
 
 ## 関連リンク
 
+- [ブラウザサポートと公式サポート方針](./browser-support.md) — API 実装状況と公式サポートの区別
 - [通信パターン別 Recipes](./recipes.md) — 行プロトコル、コマンド／応答、タイムアウトなどの索引
 - [クイックスタート](./quick-start.md)
 - [概念と設計メモ](./concepts.md)

--- a/packages/web-serial-rxjs/src/index.ts
+++ b/packages/web-serial-rxjs/src/index.ts
@@ -33,20 +33,28 @@
  *
  * ## Browser Support
  *
- * The Web Serial API is supported on **desktop** browsers only. Smartphones and
- * other mobile browsers are not supported.
+ * Separates **Web Serial API availability** (what the browser implements) from
+ * this project's **official support policy** (what we test and guarantee).
  *
- * Supported desktop browsers:
+ * ### Web Serial API availability
  *
- * - Chrome 89+
- * - Edge 89+
- * - Opera 75+
- * - Firefox 151+
+ * Where `navigator.serial` exists, this library can use the Web Serial API.
+ * Typical desktop availability: Chrome 89+, Edge 89+, Opera 75+, Firefox 151+.
+ * **Safari** does not currently implement the Web Serial API. Many mobile
+ * browsers also lack `navigator.serial`; when missing,
+ * {@link isWebSerialSupported} returns `false`.
  *
- * **Safari** does not currently support the Web Serial API.
+ * ### Project support policy
  *
- * Use {@link isWebSerialSupported} for a synchronous feature
- * check before calling {@link SerialSession.connect$}.
+ * **Official support** covers the desktop browsers listed above. **Mobile**
+ * browsers are **untested** and **out of official support**. Untested does
+ * **not** mean the library rejects them — behavior is not guaranteed.
+ *
+ * ### {@link isWebSerialSupported}
+ *
+ * Synchronous **feature detection** (`navigator.serial` present) before
+ * {@link SerialSession.connect$}. It is **not** a compatibility or
+ * official-support guarantee. Secure context is a separate requirement.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): separate web serial availability from support policy

## Summary
Web Serial API の実装状況と本プロジェクトの公式サポート範囲を分離して記載し、mobile を未検証・公式サポート対象外として README / Guide / Examples の表現を EN・JA で統一しました（#561）。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #561
- Related to #555

## What changed?
- ルート / パッケージ README（EN/JA）と `index.ts` JSDoc を「API 実装状況」と「公式サポート方針」の二段構成に更新
- Guide に `browser-support.md`（EN/JA）を追加し、README / overview / quick-start から導線を追加
- Troubleshooting / concepts の Safari・mobile・`isWebSerialSupported()` 表現を整合
- `examples-shared` の利用条件文言と全 example README の Browser Compatibility を統一
- mobile は未検証・公式サポート対象外とし、「非対応」とは断定しない

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/docs/guide/{en,ja}/browser-support.md` で API 実装状況と公式サポートが別見出しになっていることを確認する
2. ルート / パッケージ README（EN/JA）と Troubleshooting が同方針の用語になっていることを確認する
3. Examples の利用条件パネル文言（`examples-shared`）と各 `apps/example-*/README.md` が一致することを確認する
4. `pnpm exec nx test examples-shared` が通ることを確認する
5. （任意）`pnpm run docs` 後に Guide 索引から Browser support ページへ辿れることを確認する

## Environment (if relevant)
- Browser: N/A（ドキュメントのみ）
- OS: macOS
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)

Made with [Cursor](https://cursor.com)