### PR TITLE
docs(web-serial-rxjs): document binary receive API design decision

### DIFF
--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -15,8 +15,9 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 7. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
 8. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
 9. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
-10. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
-11. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
+10. **[Binary receive API — design decision](./binary-receive-design.md)** — go / no-go for a future `receiveBytes$` (not implemented)
+11. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
+12. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
 
 When migrating existing code:
 
@@ -37,6 +38,7 @@ When migrating existing code:
 | **[Request / Response](./request-response.md)** | Command + matching reply on `lines$` / `receive$` (no core `request$`) |
 | **[Timeout / cancel / retry](./timeout-cancel-retry.md)** | Timeouts, cancel on teardown, limited retry (no core auto-retry) |
 | **[API concepts and design notes](./concepts.md)** | Options, error codes, type tables, swappable `SerialSession` contract, [supported data](./concepts.md#supported-data-text--binary--charset) |
+| **[Binary receive API — design decision](./binary-receive-design.md)** | Design review: defer `receiveBytes$`; go / no-go criteria |
 | **[Hardware-free testing](./testing.md)** | Controllable Fake `SerialSession`, Vitest / Angular / React examples (npm: not bundled) |
 | **[Troubleshooting](./troubleshooting.md)** | Common problems, check steps, and what to report |
 | **[v3 → v4 Migration](./migration-v4.md)** | Unified Phase 1+2 public API cleanup |

--- a/packages/web-serial-rxjs/docs/guide/en/binary-receive-design.md
+++ b/packages/web-serial-rxjs/docs/guide/en/binary-receive-design.md
@@ -1,0 +1,172 @@
+# Binary receive API — design decision
+
+This page records the **design review** for a possible binary receive API (for example `receiveBytes$`). It is **not** an implementation spec and does **not** ship a public `Uint8Array` receive stream in the current release.
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#545](https://github.com/gurezo/web-serial-rxjs/issues/545) · Related: [Supported data](./concepts.md#supported-data-text--binary--charset) · [Choosing receive$ / lines$ / terminalText$](./stream-selection.md) · [v1 → v2 Migration](./migration-v2.md)
+
+## Recommendation (current)
+
+**Do not add `receiveBytes$` (or any public wire-byte receive stream) for now.**
+
+Revisit only when concrete product demand shows that existing text APIs and application-side Web Serial usage cannot meet the need, and the complexity cost is justified.
+
+| Decision | Status |
+| --- | --- |
+| Add binary receive to the public API now | **No** (defer) |
+| Document current limits clearly | Done ([Supported data](./concepts.md#supported-data-text--binary--charset), [#540](https://github.com/gurezo/web-serial-rxjs/issues/540)) |
+| Preferred shape **if** revisited later | Additive opt-in (see [Preferred additive sketch](#preferred-additive-sketch-if-revisited)) |
+| Implementation | Separate issue + separate PR from this design note |
+
+This matches parent [#555](https://github.com/gurezo/web-serial-rxjs/issues/555): do not expand the core API casually; prefer Recipes and existing streams until a gap is proven.
+
+## Current behavior
+
+The library is **UTF-8 text–first**.
+
+- The internal read pump reads `port.readable` (`ReadableStream<Uint8Array>`), then immediately decodes with a streaming `TextDecoder` (UTF-8, `fatal: false`, `stream: true`).
+- `receive$`, `lines$`, and `terminalText$` are all `Observable<string>` derived from those decoded chunks.
+- **Binary send** via `send$(Uint8Array)` is supported; **binary receive** is not. Send and receive are asymmetric for binary payloads.
+- In docs and JSDoc, **“raw” on `receive$` means unframed decoded text chunks**, not wire bytes.
+
+There is no public encoding option and no public byte stream today.
+
+## Use-case gate
+
+Ask whether raw bytes are **required**, or whether text streams already suffice.
+
+| Need | Fit with current API |
+| --- | --- |
+| Newline / prompt text protocols, shells, logs | Use `lines$` / `receive$` / `terminalText$` |
+| Custom **text** framing on decoder chunks | Compose RxJS on `receive$` ([Advanced Usage](./advanced-usage.md)) |
+| Modbus RTU, COBS, SLIP, custom **binary** frames | **Not** a core concern — application-side (or outside this library) |
+| Non-UTF-8 charsets (e.g. Shift_JIS) | **Not supported**; bytes-first would still need app decoding |
+| Must preserve invalid UTF-8 / arbitrary octets | Requires wire bytes **before** `TextDecoder` — current pump cannot provide this |
+
+**Gate:** add a library byte stream only when multiple real consumers need shared session lifecycle **and** cannot reasonably open Web Serial themselves or stay on decoded text.
+
+Re-encoding decoded text (`new TextEncoder().encode(chunk)`) does **not** recover original wire bytes. It is lossy for invalid UTF-8 and binary protocols. Do not treat it as a substitute for `receiveBytes$`.
+
+## Technical notes
+
+### Chunk boundaries vs `ReadableStream` read sizes
+
+Web Serial delivers `Uint8Array` chunks sized by the browser / OS, **not** by application protocol frames.
+
+- One logical frame may span many reads.
+- One read may contain multiple frames or partial frames.
+- A future `receiveBytes$` would still emit **unframed byte chunks**. Framing (length prefixes, CRC, COBS, etc.) remains application responsibility — same rule as “do not depend on chunk boundaries” for `receive$` ([stream selection](./stream-selection.md#do-not-depend-on-chunk-boundaries)).
+
+### Fan-out from one read loop
+
+The port has a **single** `readable` stream and one active reader. Text and bytes cannot each own a separate `getReader()` without tearing down the other.
+
+If a byte API were added later, the preferred internal shape is:
+
+1. Read `Uint8Array` from the pump.
+2. Optionally multicast a **copy** (or carefully documented ownership) to byte subscribers.
+3. Only then run `TextDecoder` for the existing text pipeline (`receive$` → `lines$` / `terminalText$`).
+
+Bytes must be taken **before** decoding. Passing binary through `TextDecoder` first and hoping to recover octets is incorrect.
+
+### Slow subscribers and buffer growth
+
+Today the receive path uses a multicast `Subject` for decoded text: the pump keeps reading; there is **no** Observable backpressure into Web Serial. A slow `receive$` subscriber does not pause `reader.read()`.
+
+A byte stream would inherit the same tension:
+
+- Defaulting to unbounded buffering to “catch up” late or slow subscribers risks memory growth.
+- Pausing the read loop for one slow byte subscriber would stall **all** consumers, including text UI.
+
+**Preferred policy if revisited:** keep pump-driven multicast with **no** unbounded replay; document that late subscribers miss past chunks (same as `receive$`); consider explicit caps / drop / error strategies only if real overload cases appear. Do not promise TCP-style backpressure through RxJS alone.
+
+### Relationship to `receive$` / `lines$` / `terminalText$`
+
+| Stream | Role |
+| --- | --- |
+| `receive$` | Unframed UTF-8 **decoded** chunks |
+| `lines$` | Newline-framed strings from the text pipeline |
+| `terminalText$` | Display-oriented fold of `receive$` |
+| `receiveBytes$` (hypothetical) | Unframed **wire** `Uint8Array` chunks — parallel opt-in, **not** a replacement |
+
+Do **not** replace or redefine `receive$` as bytes. Keep text streams stable; any byte API must be additive.
+
+## Preferred additive sketch (if revisited)
+
+Illustrative only — **not implemented**:
+
+```typescript
+interface SerialSession {
+  readonly receive$: Observable<string>;
+  readonly lines$: Observable<string>;
+  readonly terminalText$: Observable<string>;
+  /** Hypothetical — not in this release */
+  readonly receiveBytes$: Observable<Uint8Array>;
+}
+```
+
+Design constraints for a future implementation PR:
+
+- **Additive / opt-in:** existing apps keep working without subscribing to bytes.
+- **Not breaking:** no removal or semantic change of `receive$` / `lines$` / `terminalText$`.
+- **Decode order:** bytes fan-out before `TextDecoder`.
+- **No protocol helpers** in core (Modbus / COBS / SLIP stay out of scope — parent [#555](https://github.com/gurezo/web-serial-rxjs/issues/555)).
+- **Separate PR** with tests; this design page alone is not an approval to merge API code.
+
+Optional later refinements (also deferred): session option to disable text decoding when only bytes are needed; explicit buffer limits. None of these are required until go criteria are met.
+
+## Compatibility with v1 `client.bytes$`
+
+v1 exposed `client.bytes$`. v2+ removed it; there is still no binary receive API. See [Migrating to v2](./migration-v2.md).
+
+| Approach | Verdict |
+| --- | --- |
+| Restore a drop-in `bytes$` name for compatibility | Not required; v2 migration already documents removal |
+| `TextEncoder.encode` on `receive$` chunks | **Rejected** — does not restore wire bytes |
+| New additive `receiveBytes$` if demand appears | Acceptable shape; not a silent revive of v1 semantics without design |
+
+If a byte API ships later, migration notes should point here and to `migration-v2.md`, and must not claim lossless round-trip from decoded strings.
+
+## Go / no-go checklist
+
+Use this table when reconsidering the feature.
+
+| Criterion | Current assessment |
+| --- | --- |
+| Confirmed real-world use cases that cannot use text APIs or app-owned Web Serial | **Not established** for shipping in-core |
+| Clear reason `receiveBytes$` belongs in this library vs app code | **Insufficient** today |
+| Responsibilities vs `receive$` / `lines$` / `terminalText$` documented | **Yes** (this page) |
+| Same-loop fan-out (bytes before decode) understood | **Yes** |
+| Slow-subscriber / buffer policy stated | **Yes** (no unbounded promise) |
+| Additive API possible without breaking change | **Yes** |
+| Value outweighs API and pump complexity | **No** for an immediate add |
+| Choosing **not** to implement remains valid | **Yes — current decision** |
+
+### Go (future)
+
+All of the following should be true before an implementation issue is opened:
+
+1. At least one concrete consumer need that cannot be met with `receive$` / Recipes / direct Web Serial.
+2. Agreement that additive `receiveBytes$` (or equivalent) is the public shape.
+3. Acceptance of multicast / no-replay semantics and framing-on-the-app rules.
+4. Capacity to change the read pump with tests, without regressing text streams.
+
+### No-go (now)
+
+- Speculative “someone might need Modbus.”
+- Implementing protocols inside the core package.
+- Shipping bytes without updating Supported data / stream-selection docs and migration notes.
+
+## Out of scope
+
+- Implementing `receiveBytes$` in this documentation change
+- Modbus RTU / COBS / SLIP / device-specific APIs
+- Polyfills for browsers without Web Serial
+- Claiming unverified hardware as supported
+
+## Related guides
+
+- [Supported data (concepts)](./concepts.md#supported-data-text--binary--charset) — current support table
+- [Choosing receive$ / lines$ / terminalText$](./stream-selection.md) — text stream selection
+- [Communication pattern Recipes](./recipes.md) — pattern index
+- [v1 → v2 Migration](./migration-v2.md) — `client.bytes$` removal
+- [Browser support and support policy](./browser-support.md) — API availability vs project support

--- a/packages/web-serial-rxjs/docs/guide/en/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/en/concepts.md
@@ -30,15 +30,16 @@ In docs and JSDoc, **raw** means **unframed decoded text chunks** (not line-spli
 
 ### Future binary receive (design notes only)
 
-A possible future API (for example `receiveBytes$`) is **not** implemented in this release. If revisited, design should address at least:
+A possible future API (for example `receiveBytes$`) is **not** implemented in this release. The design review recommends **deferring** addition until concrete demand justifies the complexity.
 
-- Chunk boundaries vs Web Serial `ReadableStream` read sizes
-- Backpressure / unread buffer growth when subscribers are slow
-- Relationship to existing `receive$` / `lines$` / `terminalText$` (parallel stream vs replacement)
-- Whether introducing bytes is a breaking change or an additive opt-in
-- Invalid UTF-8 / binary protocols that must not pass through `TextDecoder` first
+Summary:
 
-Track follow-up design work under [#545](https://github.com/gurezo/web-serial-rxjs/issues/545) (parent [#535](https://github.com/gurezo/web-serial-rxjs/issues/535)); documentation of current limits is [#540](https://github.com/gurezo/web-serial-rxjs/issues/540).
+- Prefer an **additive** `receiveBytes$: Observable<Uint8Array>` (parallel to text streams), not a replacement for `receive$`
+- Fan out wire bytes from the same read loop **before** `TextDecoder`
+- Chunk boundaries are not protocol frames; no unbounded backpressure promise for slow subscribers
+- Re-encoding decoded text does **not** restore original wire bytes
+
+Full go / no-go criteria and sketch: [Binary receive API — design decision](./binary-receive-design.md) ([#545](https://github.com/gurezo/web-serial-rxjs/issues/545), parent [#555](https://github.com/gurezo/web-serial-rxjs/issues/555)). Current limits were documented in [#540](https://github.com/gurezo/web-serial-rxjs/issues/540).
 
 ## Public exports
 

--- a/packages/web-serial-rxjs/docs/guide/en/stream-selection.md
+++ b/packages/web-serial-rxjs/docs/guide/en/stream-selection.md
@@ -13,7 +13,7 @@ Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [
 | Handle decoder chunks as they arrive | `receive$` |
 | Handle display control that uses `\r` | `receive$` or `terminalText$` |
 | Bind terminal-style text to a UI | `terminalText$` |
-| Receive raw `Uint8Array` (wire bytes) | **Not supported** — see [Supported data](./concepts.md#supported-data-text-binary--charset) and [#545](https://github.com/gurezo/web-serial-rxjs/issues/545) |
+| Receive raw `Uint8Array` (wire bytes) | **Not supported** — see [Supported data](./concepts.md#supported-data-text-binary--charset), [Binary receive design](./binary-receive-design.md), and [#545](https://github.com/gurezo/web-serial-rxjs/issues/545) |
 
 ## Responsibilities at a glance
 
@@ -75,7 +75,7 @@ There is **no** `receiveBytes$` or public `Uint8Array` receive stream. The read 
 - **Binary send** is supported via `send$(Uint8Array)`.
 - **Binary receive** is not — send/receive are asymmetric for binary payloads.
 
-Current limits and design notes: [Supported data](./concepts.md#supported-data-text-binary--charset). Future binary receive design: [#545](https://github.com/gurezo/web-serial-rxjs/issues/545).
+Current limits and design notes: [Supported data](./concepts.md#supported-data-text-binary--charset). Design decision (defer for now): [Binary receive API — design decision](./binary-receive-design.md) ([#545](https://github.com/gurezo/web-serial-rxjs/issues/545)).
 
 ## Related guides
 
@@ -86,3 +86,4 @@ Current limits and design notes: [Supported data](./concepts.md#supported-data-t
 - [Request / Response recipes](./request-response.md) — wait on `lines$` or `receive$`, then send
 - [Timeout / cancel / retry](./timeout-cancel-retry.md) — deadlines around waits
 - [API concepts – Supported data](./concepts.md#supported-data-text-binary--charset) — text / binary / charset scope
+- [Binary receive API — design decision](./binary-receive-design.md) — go / no-go for a future byte stream

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -15,8 +15,9 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 7. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
 8. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
 9. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
-10. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
-11. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
+10. **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** — 将来の `receiveBytes$` の go / no-go（未実装）
+11. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
+12. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
 
 既存コードから移行する場合:
 
@@ -37,6 +38,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | **[Request / Response](./request-response.md)** | コマンド送信後の応答待ち（コア `request$` なし） |
 | **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** | タイムアウト、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし） |
 | **[API の概念と設計メモ](./concepts.md)** | オプション・エラーコード・型の表形式補足、差し替え可能な `SerialSession` 契約、[対応範囲](./concepts.md#対応範囲テキスト--バイナリ--文字コード) |
+| **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** | 設計検討: `receiveBytes$` は当面追加しない。go / no-go 条件 |
 | **[実機なしテスト](./testing.md)** | 制御可能な Fake `SerialSession`、Vitest / Angular / React 例（npm 非同梱） |
 | **[トラブルシューティング](./troubleshooting.md)** | よくある問題の確認手順と報告時の情報 |
 | **[v3 → v4 マイグレーション](./migration-v4.md)** | Phase 1+2 公開 API 整理の統合ガイド |

--- a/packages/web-serial-rxjs/docs/guide/ja/binary-receive-design.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/binary-receive-design.md
@@ -1,0 +1,172 @@
+# バイナリ受信 API — 設計判断
+
+本ページは、将来のバイナリ受信 API（例: `receiveBytes$`）に関する**設計検討**の記録です。実装仕様ではなく、現行リリースで公開の `Uint8Array` 受信ストリームを追加するものでもありません。
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#545](https://github.com/gurezo/web-serial-rxjs/issues/545) · 関連: [対応範囲](./concepts.md#対応範囲テキスト--バイナリ--文字コード) · [receive$ / lines$ / terminalText$ の選び方](./stream-selection.md) · [v1 → v2 マイグレーション](./migration-v2.md)
+
+## 推奨判断（現状）
+
+**当面、`receiveBytes$`（および公開のワイヤバイト受信ストリーム）は追加しない。**
+
+既存のテキスト API や、利用側での Web Serial 直接利用では足りないという具体的な需要が確認され、複雑性の増加に見合う価値がある場合にのみ再検討する。
+
+| 判断 | 状態 |
+| --- | --- |
+| いま公開 API にバイナリ受信を追加する | **しない**（defer） |
+| 現行の対応範囲を明文化する | 済み（[対応範囲](./concepts.md#対応範囲テキスト--バイナリ--文字コード)、[#540](https://github.com/gurezo/web-serial-rxjs/issues/540)） |
+| 将来再検討時の preferred 形状 | 加算的 opt-in（[加算的スケッチ](#将来再検討時の加算的スケッチ)） |
+| 実装 | 本設計メモとは**別 Issue・別 PR** |
+
+親 Issue [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) の方針（コア API を安易に増やさない。ギャップが証明されるまで既存ストリームと Recipes を優先）と整合します。
+
+## 現状の挙動
+
+本ライブラリは **UTF-8 テキスト中心**です。
+
+- 内部の read pump は `port.readable`（`ReadableStream<Uint8Array>`）を読み、直後にストリーミング `TextDecoder`（UTF-8、`fatal: false`、`stream: true`）でデコードする
+- `receive$` / `lines$` / `terminalText$` はいずれも、そのデコード済みチャンク由来の `Observable<string>`
+- バイナリ**送信**（`send$(Uint8Array)`）は対応、バイナリ**受信**は非対応。バイナリについては送受信が非対称
+- ドキュメントや JSDoc で言う `receive$` の **「raw」は行未分割のデコード済みテキスト**であり、ワイヤ上の生バイトではない
+
+公開のエンコーディングオプションやバイトストリームは、現状ありません。
+
+## ユースケース判定
+
+生バイトが**必須**か、テキストストリームで足りるかを切り分けます。
+
+| 要件 | 現行 API との適合 |
+| --- | --- |
+| 改行／プロンプトのテキストプロトコル、シェル、ログ | `lines$` / `receive$` / `terminalText$` を使う |
+| デコード済みチャンク上のカスタム**テキスト**フレーミング | `receive$` 上で RxJS を合成（[高度な使用方法](./advanced-usage.md)） |
+| Modbus RTU、COBS、SLIP、独自**バイナリ**フレーム | **コアの対象外** — 利用側（または本ライブラリ外）で扱う |
+| UTF-8 以外の文字コード（例: Shift_JIS） | **非対応**。バイト先行でもアプリ側デコードが必要 |
+| 不正な UTF-8 / 任意オクテットを保持する必要がある | `TextDecoder` **より前**のワイヤバイトが必要 — 現行 pump では不可 |
+
+**ゲート:** 共有セッションのライフサイクルが複数の実利用者に必要で、かつ Web Serial を自前で開く／デコード済みテキストでは合理的に足りない場合にのみ、ライブラリのバイトストリーム追加を検討する。
+
+デコード済み文字列の再エンコード（`new TextEncoder().encode(chunk)`）は、元のワイヤバイトを**復元しない**。不正 UTF-8 やバイナリプロトコルでは損失がある。`receiveBytes$` の代替にしてはいけません。
+
+## 技術論点
+
+### チャンク境界と `ReadableStream` の read サイズ
+
+Web Serial が渡す `Uint8Array` のサイズはブラウザ／OS 側の都合であり、**アプリプロトコルのフレーム境界ではない**。
+
+- 1 論理フレームが多数の read にまたがることがある
+- 1 回の read に複数フレームや途中フレームが含まれることがある
+- 将来の `receiveBytes$` も **未フレーミングのバイトチャンク** を emit する。長さ前置・CRC・COBS などのフレーミングは利用側の責務 — `receive$` の「チャンク境界に依存しない」と同じ（[選び方](./stream-selection.md#チャンク境界に依存しない)）
+
+### 同一 read loop からの fan-out
+
+ポートの `readable` は**1 本**で、アクティブな reader も実質 1 つです。テキスト用とバイト用で別々に `getReader()` を持つことはできません。
+
+バイト API を将来追加する場合の preferred 内部形状:
+
+1. pump で `Uint8Array` を読む
+2. バイト購読者へ（コピー、または所有権を明記した）multicast
+3. **その後**に既存テキスト経路用の `TextDecoder` を実行（`receive$` → `lines$` / `terminalText$`）
+
+バイトはデコード**前**に取る必要があります。バイナリを先に `TextDecoder` へ通し、あとからオクテットを復元しようとするのは誤りです。
+
+### 遅い購読者とバッファ増大
+
+現行の受信経路はデコード済みテキストを multicast `Subject` で流します。pump は読み続け、Web Serial への Observable バックプレッシャーはありません。遅い `receive$` 購読者が `reader.read()` を止めません。
+
+バイトストリームも同じ緊張関係を継承します。
+
+- 遅い／遅い購読者に追いつかせるための無制限バッファはメモリ増大のリスクがある
+- 1 人の遅いバイト購読者のために read loop を止めると、テキスト UI を含む**全** consumer が停滞する
+
+**将来再検討時の preferred 方針:** pump 駆動の multicast を維持し、**無制限 replay は約束しない**。遅れて購読した consumer は過去チャンクを見逃す（`receive$` と同じ）。過負荷の実例が出てから明示的な上限／破棄／エラー方針を検討する。RxJS だけで TCP 風バックプレッシャーを約束しない。
+
+### `receive$` / `lines$` / `terminalText$` との関係
+
+| ストリーム | 役割 |
+| --- | --- |
+| `receive$` | 未フレーミングの UTF-8 **デコード済み**チャンク |
+| `lines$` | テキスト経路由来の改行区切り文字列 |
+| `terminalText$` | `receive$` の表示向け畳み込み |
+| `receiveBytes$`（仮） | 未フレーミングの**ワイヤ** `Uint8Array` — 並列の opt-in。**置換ではない** |
+
+`receive$` をバイトへ置き換えたり意味を変えたりしない。テキストストリームは安定に保ち、バイト API は加算的であること。
+
+## 将来再検討時の加算的スケッチ
+
+例示のみ — **未実装**:
+
+```typescript
+interface SerialSession {
+  readonly receive$: Observable<string>;
+  readonly lines$: Observable<string>;
+  readonly terminalText$: Observable<string>;
+  /** 仮 — 本リリースには存在しない */
+  readonly receiveBytes$: Observable<Uint8Array>;
+}
+```
+
+将来の実装 PR 向け制約:
+
+- **加算的 / opt-in:** 既存アプリはバイトを購読しなくても動作する
+- **非破壊:** `receive$` / `lines$` / `terminalText$` の削除や意味変更をしない
+- **デコード順:** bytes の fan-out のあとで `TextDecoder`
+- **コアにプロトコルヘルパを置かない**（Modbus / COBS / SLIP は対象外 — 親 [#555](https://github.com/gurezo/web-serial-rxjs/issues/555)）
+- **別 PR** とテスト。本設計ページだけでは API コードのマージ承認にはならない
+
+任意の後続案（これも defer）: バイトのみ利用時にテキストデコードを止めるオプション、明示的バッファ上限。go 条件を満たすまで不要です。
+
+## v1 `client.bytes$` との互換
+
+v1 は `client.bytes$` を公開していました。v2+ で削除され、いまもバイナリ受信 API はありません。[v2 への移行](./migration-v2.md) を参照してください。
+
+| 方針 | 判断 |
+| --- | --- |
+| 互換のため `bytes$` 名をそのまま復活 | 不要。v2 マイグレーションで削除済みと記載済み |
+| `receive$` チャンクへの `TextEncoder.encode` | **非推奨** — ワイヤバイトを復元しない |
+| 需要があれば加算的 `receiveBytes$` | 形状としては妥当。設計なしの v1 意味の暗黙復活はしない |
+
+将来バイト API を出す場合、マイグレーション注記は本ページと `migration-v2.md` を指し、デコード済み文字列からのロスレス往復を主張しないこと。
+
+## go / no-go チェックリスト
+
+機能を再検討するときに使う表です。
+
+| 観点 | 現状の評価 |
+| --- | --- |
+| テキスト API やアプリ所有の Web Serial では足りない実ユースケースが確認できるか | **コア投入には未確認** |
+| `receiveBytes$` を本ライブラリに置く明確な理由があるか | **今日は不十分** |
+| `receive$` / `lines$` / `terminalText$` との責務が整理されているか | **はい**（本ページ） |
+| 同一 loop の fan-out（デコード前の bytes）が理解されているか | **はい** |
+| 遅い購読者／バッファ方針が述べられているか | **はい**（無制限を約束しない） |
+| 破壊的変更なしの加算 API が可能か | **はい** |
+| API・pump 複雑性に見合う価値があるか | **即時追加には否** |
+| **実装しない**判断が妥当か | **はい — 現状の決定** |
+
+### Go（将来）
+
+実装 Issue を立てる前に、次がすべて真であること:
+
+1. `receive$` / Recipes / 直接 Web Serial では満たせない具体的な利用需要がある
+2. 公開形状として加算的 `receiveBytes$`（または同等）に合意できる
+3. multicast・無 replay・フレーミングはアプリ側、という規則を受け入れる
+4. テキストストリームを退行させずに read pump を変更し、テストできる余力がある
+
+### No-go（いま）
+
+- 「Modbus が必要かもしれない」程度の推測
+- コアパッケージ内でのプロトコル実装
+- 対応範囲／選び方／マイグレーションの更新なしでのバイト API 出荷
+
+## 対象外
+
+- 本ドキュメント変更での `receiveBytes$` 実装
+- Modbus RTU / COBS / SLIP / デバイス専用 API
+- Web Serial 非対応ブラウザ向け Polyfill
+- 未検証ハードウェアを対応済みと称すること
+
+## 関連ガイド
+
+- [対応範囲（concepts）](./concepts.md#対応範囲テキスト--バイナリ--文字コード) — 現行の対応表
+- [receive$ / lines$ / terminalText$ の選び方](./stream-selection.md) — テキストストリームの選択
+- [通信パターン別 Recipes](./recipes.md) — パターン索引
+- [v1 → v2 マイグレーション](./migration-v2.md) — `client.bytes$` 削除
+- [ブラウザサポートと公式サポート方針](./browser-support.md) — API 実装状況と公式サポート

--- a/packages/web-serial-rxjs/docs/guide/ja/concepts.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/concepts.md
@@ -30,15 +30,16 @@
 
 ### 将来のバイナリ受信（設計論点のみ）
 
-将来の API（例: `receiveBytes$`）は**本リリースでは実装しません**。再検討する場合は少なくとも次を整理する必要があります。
+将来の API（例: `receiveBytes$`）は**本リリースでは実装しません**。設計検討の推奨は、具体的な需要が複雑性に見合うまで**追加を見送る（defer）**ことです。
 
-- Web Serial `ReadableStream` の read サイズとチャンク境界
-- 購読が遅い場合のバックプレッシャー / 未読バッファ増大
-- 既存の `receive$` / `lines$` / `terminalText$` との関係（並列ストリームか置換か）
-- バイト列 API 追加が破壊的変更か、加算的な opt-in か
-- 不正な UTF-8 / バイナリプロトコルを先に `TextDecoder` へ通してはいけない点
+要約:
 
-後続の設計検討は [#545](https://github.com/gurezo/web-serial-rxjs/issues/545)（親 Issue [#535](https://github.com/gurezo/web-serial-rxjs/issues/535)）で追跡し、現行の対応範囲の明文化は [#540](https://github.com/gurezo/web-serial-rxjs/issues/540) です。
+- `receive$` の置換ではなく、テキストと並列の**加算的** `receiveBytes$: Observable<Uint8Array>` を preferred とする
+- 同一 read loop から、`TextDecoder` **より前**にワイヤバイトを fan-out する
+- チャンク境界はプロトコルフレームではない。遅い購読者への無制限バックプレッシャーは約束しない
+- デコード済みテキストの再エンコードでは元のワイヤバイトを復元できない
+
+go / no-go 条件とスケッチの全文: [バイナリ受信 API — 設計判断](./binary-receive-design.md)（[#545](https://github.com/gurezo/web-serial-rxjs/issues/545)、親 [#555](https://github.com/gurezo/web-serial-rxjs/issues/555)）。現行の対応範囲の明文化は [#540](https://github.com/gurezo/web-serial-rxjs/issues/540) です。
 
 ## 公開 export
 

--- a/packages/web-serial-rxjs/docs/guide/ja/stream-selection.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/stream-selection.md
@@ -13,7 +13,7 @@ Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [
 | 受信チャンクをそのまま扱う | `receive$` |
 | `\r` を含む表示制御を扱う | `receive$` または `terminalText$` |
 | ターミナル風テキストを画面へ表示する | `terminalText$` |
-| raw `Uint8Array`（ワイヤ生バイト）を受信する | **未対応** — [対応範囲](./concepts.md#対応範囲（テキスト-バイナリ--文字コード）) と [#545](https://github.com/gurezo/web-serial-rxjs/issues/545) を参照 |
+| raw `Uint8Array`（ワイヤ生バイト）を受信する | **未対応** — [対応範囲](./concepts.md#対応範囲（テキスト-バイナリ--文字コード）)、[バイナリ受信の設計判断](./binary-receive-design.md)、[#545](https://github.com/gurezo/web-serial-rxjs/issues/545) を参照 |
 
 ## 責務の要約
 
@@ -75,7 +75,7 @@ Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [
 - **バイナリ送信**は `send$(Uint8Array)` で対応
 - **バイナリ受信**は未対応 — バイナリについては送受信が非対称
 
-現行の制限と設計メモ: [対応範囲](./concepts.md#対応範囲（テキスト-バイナリ--文字コード）)。将来のバイナリ受信設計: [#545](https://github.com/gurezo/web-serial-rxjs/issues/545)。
+現行の制限と設計メモ: [対応範囲](./concepts.md#対応範囲（テキスト-バイナリ--文字コード）)。設計判断（当面は追加しない）: [バイナリ受信 API — 設計判断](./binary-receive-design.md)（[#545](https://github.com/gurezo/web-serial-rxjs/issues/545)）。
 
 ## 関連ガイド
 
@@ -86,3 +86,4 @@ Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [
 - [Request / Response レシピ](./request-response.md) — `lines$` / `receive$` で待ってから送信
 - [タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md) — 待ちの期限
 - [API の概念 — 対応範囲](./concepts.md#対応範囲（テキスト-バイナリ--文字コード）) — テキスト / バイナリ / 文字コードの範囲
+- [バイナリ受信 API — 設計判断](./binary-receive-design.md) — 将来のバイトストリームの go / no-go


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): document binary receive API design decision

## Summary
#545 の採否判断に必要な設計条件を Guide に整理し、現状は `receiveBytes$` を追加しない（defer）判断を文書化しました。実装は含みません。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #545
- Parent: #555

## What changed?
- 英語 / 日本語の設計ページ `binary-receive-design.md` を追加（現状・ユースケース判定・技術論点・加算的スケッチ・v1 `bytes$` 互換・go/no-go）
- `concepts.md` の将来バイナリ受信セクションを要約化し、設計ページと親 #555 へ誘導
- `stream-selection.md` と Guide README（日英）から設計ページへリンク

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/docs/guide/en/binary-receive-design.md` と `ja/binary-receive-design.md` の内容を確認する
2. `concepts.md` / `stream-selection.md` / Guide `README.md`（日英）から設計ページへのリンクが正しいことを確認する
3. 公開 API・ソースコードに差分がないことを確認する（本 PR はドキュメントのみ）

## Environment (if relevant)
- Browser: N/A（ドキュメントのみ）
- OS: N/A
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)