### PR TITLE
docs(web-serial-rxjs): document version support and release policy

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -125,6 +125,7 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 | **[クイックスタート](packages/web-serial-rxjs/docs/guide/ja/quick-start.md)** | 最短でポートを開いて購読するところまで。 |
 | **[高度な使用方法](packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
 | **[トラブルシューティング](packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md)** | Web Serial / セッションのよくある問題と自己解決手順。 |
+| **[バージョンサポートとリリース方針](packages/web-serial-rxjs/docs/guide/ja/version-support.md)** | SemVer、非推奨、サポート範囲（LTS なし）。 |
 | **[API の概念と設計メモ](packages/web-serial-rxjs/docs/guide/ja/concepts.md)** | オプション、`SerialSessionState`、`SerialError` の表形式補足。 |
 | **[v3 → v4 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v4.md)** | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理）。 |
 | **[v2 → v3 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v3.md)** | `state$` discriminated union、`SerialSessionStatus`、`context.cause`。 |
@@ -192,6 +193,7 @@ English: see the same sections in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 - 貢献の詳細: [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)
 - リリース手順: [RELEASING.ja.md](RELEASING.ja.md)
+- バージョンサポート / リリース方針（Guide）: [日本語](packages/web-serial-rxjs/docs/guide/ja/version-support.md) · [English](packages/web-serial-rxjs/docs/guide/en/version-support.md)
 
 ## プロジェクトアイコンについて
 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Documentation is split into **Guide** (how to use; Japanese and English hand-wri
 | **[Quick Start](packages/web-serial-rxjs/docs/guide/en/quick-start.md)** | Shortest path to a working open port and subscriptions. |
 | **[Advanced Usage](packages/web-serial-rxjs/docs/guide/en/advanced-usage.md)** | Line framing, request/response-style flows, and recovery. |
 | **[Troubleshooting](packages/web-serial-rxjs/docs/guide/en/troubleshooting.md)** | Common Web Serial / session problems and self-help checks. |
+| **[Version support and release policy](packages/web-serial-rxjs/docs/guide/en/version-support.md)** | SemVer, deprecations, support window (no LTS). |
 | **[API concepts and design notes](packages/web-serial-rxjs/docs/guide/en/concepts.md)** | Options, `SerialSessionState`, and `SerialError` details. |
 | **[v3 → v4 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v4.md)** | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup). |
 | **[v2 → v3 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v3.md)** | `state$` discriminated union, `SerialSessionStatus`, and `context.cause`. |
@@ -192,6 +193,7 @@ This project follows **trunk-based development**: `main` stays release-ready; wo
 
 - Contribution details: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Release instructions: [RELEASING.md](RELEASING.md)
+- Version support / release policy (Guide): [English](packages/web-serial-rxjs/docs/guide/en/version-support.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/version-support.md)
 
 ## Project Icon
 

--- a/RELEASING.ja.md
+++ b/RELEASING.ja.md
@@ -25,6 +25,7 @@
    - **MAJOR** (例: `1.0.0` → `2.0.0`): 破壊的変更
    - **MINOR** (例: `1.0.0` → `1.1.0`): 新機能（後方互換性あり）
    - **PATCH** (例: `1.0.0` → `1.0.1`): バグ修正（後方互換性あり）
+   - 利用者向けの要約（サポート範囲、非推奨、GitHub Release と CHANGELOG）: [バージョンサポートとリリース方針](packages/web-serial-rxjs/docs/guide/ja/version-support.md)
 6. **package.json のバージョン**: `packages/web-serial-rxjs/package.json` のバージョンをタグと一致させる
 7. **ドキュメント**: メンテナンスされている場合は `CHANGELOG.md` を更新（任意）
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,6 +25,7 @@ Before releasing, ensure the following:
    - **MAJOR** (e.g., `1.0.0` → `2.0.0`): Breaking changes
    - **MINOR** (e.g., `1.0.0` → `1.1.0`): New features (backward compatible)
    - **PATCH** (e.g., `1.0.0` → `1.0.1`): Bug fixes (backward compatible)
+   - Adopter-facing summary (support window, deprecations, GitHub Release vs CHANGELOG): [Version support and release policy](packages/web-serial-rxjs/docs/guide/en/version-support.md)
 6. **package.json version**: Update the version in `packages/web-serial-rxjs/package.json` to match the tag
 7. **Documentation**: Update `CHANGELOG.md` if maintained (optional)
 

--- a/SECURITY.ja.md
+++ b/SECURITY.ja.md
@@ -13,6 +13,8 @@ English: [SECURITY.md](SECURITY.md)
 
 古いメジャーバージョン（`3.x`、`2.x`、`1.x`）はセキュリティ更新の対象外です。可能な場合は最新の `4.x` へアップグレードしてください。
 
+SemVer の上げ方、非推奨方針、LTS なしのサポート範囲は Guide の [バージョンサポートとリリース方針](packages/web-serial-rxjs/docs/guide/ja/version-support.md)（[English](packages/web-serial-rxjs/docs/guide/en/version-support.md)）を参照してください。
+
 ## 脆弱性の報告
 
 脆弱性の詳細を **公開の GitHub Issue や Discussion に投稿しないでください**。

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,8 @@ Security fixes are considered only for the latest major release line.
 
 Older major versions (`3.x`, `2.x`, `1.x`) are not supported for security updates. Please upgrade to the latest `4.x` release when possible.
 
+For SemVer bumps, deprecation policy, and the non-LTS support window, see the Guide: [Version support and release policy](packages/web-serial-rxjs/docs/guide/en/version-support.md) ([日本語](packages/web-serial-rxjs/docs/guide/ja/version-support.md)).
+
 ## Reporting a Vulnerability
 
 **Do not** open a public GitHub Issue or Discussion with vulnerability details.

--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -9,15 +9,16 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 1. **[Overview](./overview.md)** — `SerialSession` public surface, role of `state$` / `errors$`, minimal sample
 2. **[Quick Start](./quick-start.md)** — installation, connect, receive/send, disconnect/dispose, error handling
 3. **[Browser support and support policy](./browser-support.md)** — Web Serial API availability vs official support
-4. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
-5. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
-6. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
-7. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
-8. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
-9. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
-10. **[Binary receive API — design decision](./binary-receive-design.md)** — go / no-go for a future `receiveBytes$` (not implemented)
-11. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
-12. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
+4. **[Version support and release policy](./version-support.md)** — SemVer, deprecations, support window (no LTS)
+5. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
+6. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
+7. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
+8. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
+9. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
+10. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
+11. **[Binary receive API — design decision](./binary-receive-design.md)** — go / no-go for a future `receiveBytes$` (not implemented)
+12. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
+13. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
 
 When migrating existing code:
 
@@ -32,6 +33,7 @@ When migrating existing code:
 | **[Overview](./overview.md)** | Public surface quick reference, feature summary, minimal sample |
 | **[Quick Start](./quick-start.md)** | Basic flow from installation through disconnect |
 | **[Browser support and support policy](./browser-support.md)** | API availability vs official support / untested |
+| **[Version support and release policy](./version-support.md)** | SemVer, deprecations, support window (no LTS) |
 | **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** | Decision guide for the three receive streams |
 | **[Communication pattern Recipes](./recipes.md)** | Pattern → Guide / Recipe index (not device compatibility) |
 | **[Advanced Usage](./advanced-usage.md)** | Application patterns and RxJS recipes |

--- a/packages/web-serial-rxjs/docs/guide/en/version-support.md
+++ b/packages/web-serial-rxjs/docs/guide/en/version-support.md
@@ -1,0 +1,57 @@
+# Version support and release policy
+
+This page summarizes how `@gurezo/web-serial-rxjs` versions releases, what support to expect for past majors, and where release notes live. It is for **upgrade and maintenance decisions**. It does **not** declare LTS or long-term support commitments.
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#565](https://github.com/gurezo/web-serial-rxjs/issues/565) · Related: [Browser support](./browser-support.md)
+
+## Semantic Versioning
+
+This project follows [Semantic Versioning](https://semver.org/). Package versions on npm and Git tags use `MAJOR.MINOR.PATCH` (tags are prefixed with `v`, for example `v4.1.0`).
+
+| Bump | Meaning |
+| --- | --- |
+| **MAJOR** | Breaking changes to the public API or documented behavior |
+| **MINOR** | New features that remain backward compatible |
+| **PATCH** | Bug fixes that remain backward compatible |
+
+Release mechanics (tag → CI → npm → GitHub Release) are described in the repository [RELEASING.md](https://github.com/gurezo/web-serial-rxjs/blob/main/RELEASING.md).
+
+## Breaking changes
+
+Breaking changes ship in a **major** release only.
+
+When a major release changes public APIs that adopters must migrate, this Guide adds or updates a **Migration Guide** (for example [v3 → v4](./migration-v4.md)). Prefer those pages over reading every commit.
+
+## Deprecated APIs
+
+- APIs marked `@deprecated` remain available within the **current major** so existing apps can migrate gradually.
+- Removal is deferred to a **future major** (today: **v5+**), not a minor or patch.
+- Concrete deprecated surfaces in v4 are listed in [API concepts – Deprecated exports](./concepts.md#deprecated-exports) and the relevant Migration Guides.
+
+## Support window (no LTS)
+
+This project does **not** promise LTS or multi-year support for older majors.
+
+| Concern | Policy |
+| --- | --- |
+| **Security fixes** | Considered only for the **latest major** line (currently **4.x**). See [SECURITY.md](https://github.com/gurezo/web-serial-rxjs/blob/main/SECURITY.md). |
+| **Bug fixes** | Land on `main` for the current major by default. Upgrade to the latest `4.x` when possible. |
+| **Backports to past majors** | **Not promised.** If a `release/v*` maintenance branch exists, hotfixes may be applied on a **best-effort** basis (see [CONTRIBUTING.md – Release from Maintenance Branches](https://github.com/gurezo/web-serial-rxjs/blob/main/CONTRIBUTING.md#release-from-maintenance-branches)). Absence of such a branch means older majors receive no further fixes. |
+
+Browser / environment support (what we test) is separate from version support — see [Browser support and support policy](./browser-support.md).
+
+## GitHub Release, npm, and CHANGELOG
+
+| Channel | Role |
+| --- | --- |
+| **GitHub Release** | Canonical user-facing release notes for each tagged version |
+| **npm** | Package distribution (`@gurezo/web-serial-rxjs`) |
+| **CHANGELOG.md** | Optional; may be updated when maintained. Prefer GitHub Releases when in doubt |
+
+## Related
+
+- Repository [SECURITY.md](https://github.com/gurezo/web-serial-rxjs/blob/main/SECURITY.md) · [日本語](https://github.com/gurezo/web-serial-rxjs/blob/main/SECURITY.ja.md)
+- Repository [RELEASING.md](https://github.com/gurezo/web-serial-rxjs/blob/main/RELEASING.md) · [日本語](https://github.com/gurezo/web-serial-rxjs/blob/main/RELEASING.ja.md)
+- [Browser support and support policy](./browser-support.md)
+- [v3 → v4 Migration](./migration-v4.md) · [v2 → v3](./migration-v3.md) · [v1 → v2](./migration-v2.md)
+- Repository [README – Development and Release Strategy](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md#development-and-release-strategy)

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -9,15 +9,16 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 1. **[概要](./overview.md)** — `SerialSession` の公開面、`state$` / `errors$` の位置付け、最小サンプル
 2. **[クイックスタート](./quick-start.md)** — インストール、接続、受信・送信、切断・破棄、エラーハンドリング
 3. **[ブラウザサポートと公式サポート方針](./browser-support.md)** — Web Serial API 実装状況と公式サポートの分離
-4. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
-5. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
-6. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
-7. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
-8. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
-9. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
-10. **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** — 将来の `receiveBytes$` の go / no-go（未実装）
-11. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
-12. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
+4. **[バージョンサポートとリリース方針](./version-support.md)** — SemVer、非推奨、サポート範囲（LTS なし）
+5. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
+6. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
+7. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
+8. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
+9. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
+10. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
+11. **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** — 将来の `receiveBytes$` の go / no-go（未実装）
+12. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
+13. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
 
 既存コードから移行する場合:
 
@@ -32,6 +33,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | **[概要](./overview.md)** | 公開面の早見表、機能概要、最小サンプル |
 | **[クイックスタート](./quick-start.md)** | インストールから切断までの基本フロー |
 | **[ブラウザサポートと公式サポート方針](./browser-support.md)** | API 実装状況と公式サポート / 未検証の区別 |
+| **[バージョンサポートとリリース方針](./version-support.md)** | SemVer、非推奨、サポート範囲（LTS なし） |
 | **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** | 3 系統の受信ストリームの判断ガイド |
 | **[通信パターン別 Recipes](./recipes.md)** | パターン → Guide / Recipe 索引（デバイス互換の保証ではない） |
 | **[高度な使用方法](./advanced-usage.md)** | 応用パターンと RxJS レシピ |

--- a/packages/web-serial-rxjs/docs/guide/ja/version-support.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/version-support.md
@@ -1,0 +1,57 @@
+# バージョンサポートとリリース方針
+
+このページは、`@gurezo/web-serial-rxjs` がどのようにバージョンを付けてリリースするか、過去 major へのサポート期待値、リリースノートの所在をまとめます。**アップグレード・保守判断**のための文書です。**LTS や長期サポートは約束しません**。
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#565](https://github.com/gurezo/web-serial-rxjs/issues/565) · Related: [ブラウザサポート](./browser-support.md)
+
+## Semantic Versioning
+
+本プロジェクトは [Semantic Versioning](https://semver.org/) に従います。npm のパッケージ版と Git タグは `MAJOR.MINOR.PATCH` です（タグは `v` 接頭辞付き。例: `v4.1.0`）。
+
+| 上げ方 | 意味 |
+| --- | --- |
+| **MAJOR** | 公開 API または文書化された挙動の破壊的変更 |
+| **MINOR** | 後方互換を保つ新機能 |
+| **PATCH** | 後方互換を保つバグ修正 |
+
+リリース手順（タグ → CI → npm → GitHub Release）はリポジトリの [RELEASING.ja.md](https://github.com/gurezo/web-serial-rxjs/blob/main/RELEASING.ja.md) を参照してください。
+
+## Breaking change
+
+破壊的変更は **major** リリースでのみ公開します。
+
+採用者が移行すべき公開 API の変更を含む major では、本 Guide に **Migration Guide** を追加または更新します（例: [v3 → v4](./migration-v4.md)）。個別コミットよりこれらのページを優先してください。
+
+## Deprecated API
+
+- `@deprecated` 付きの API は、既存アプリが段階的に移行できるよう **現行 major** 内では利用可能です。
+- 削除は **将来の major**（現時点では **v5+**）に延期し、minor / patch では削除しません。
+- v4 における具体的な deprecated 面は [API の概念 – Deprecated exports](./concepts.md#deprecated-exports) と各 Migration Guide を参照してください。
+
+## サポート範囲（LTS なし）
+
+本プロジェクトは、古い major に対する LTS や複数年サポートを**約束しません**。
+
+| 関心事 | 方針 |
+| --- | --- |
+| **セキュリティ修正** | **最新 major** 系列のみ対象（現在は **4.x**）。[SECURITY.ja.md](https://github.com/gurezo/web-serial-rxjs/blob/main/SECURITY.ja.md) を参照。 |
+| **バグ修正** | 既定では現行 major 向けに `main` へ取り込みます。可能な場合は最新の `4.x` へアップグレードしてください。 |
+| **過去 major への backport** | **約束しません**。`release/v*` 保守ブランチがある場合のみ、**best-effort** で hotfix する場合があります（[CONTRIBUTING.ja.md – 保守ブランチからのリリース](https://github.com/gurezo/web-serial-rxjs/blob/main/CONTRIBUTING.ja.md#保守ブランチからのリリース)）。そのようなブランチが無ければ、古い major への追加修正はありません。 |
+
+ブラウザ / 環境のサポート（動作確認の範囲）はバージョンサポートとは別です — [ブラウザサポートと公式サポート方針](./browser-support.md) を参照してください。
+
+## GitHub Release / npm / CHANGELOG
+
+| 経路 | 役割 |
+| --- | --- |
+| **GitHub Release** | タグ付き各バージョンの、利用者向けリリースノートの正本 |
+| **npm** | パッケージ配布（`@gurezo/web-serial-rxjs`） |
+| **CHANGELOG.md** | 任意。維持している場合に更新。迷ったら GitHub Releases を優先 |
+
+## 関連
+
+- リポジトリ [SECURITY.ja.md](https://github.com/gurezo/web-serial-rxjs/blob/main/SECURITY.ja.md) · [English](https://github.com/gurezo/web-serial-rxjs/blob/main/SECURITY.md)
+- リポジトリ [RELEASING.ja.md](https://github.com/gurezo/web-serial-rxjs/blob/main/RELEASING.ja.md) · [English](https://github.com/gurezo/web-serial-rxjs/blob/main/RELEASING.md)
+- [ブラウザサポートと公式サポート方針](./browser-support.md)
+- [v3 → v4 Migration](./migration-v4.md) · [v2 → v3](./migration-v3.md) · [v1 → v2](./migration-v2.md)
+- リポジトリ [README – 開発とリリース戦略](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md#開発とリリース戦略)


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): document version support and release policy

## Summary
利用者向けに Version support / release policy を Guide（EN/JA）で明文化し、SECURITY / RELEASING / README から矛盾なく辿れる導線を追加しました。LTS は約束しません。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #565
- Parent: #555

## What changed?
- Guide EN/JA に `version-support.md` を追加（SemVer、breaking / deprecate、サポート範囲、Release / npm / CHANGELOG の役割）
- Guide index（EN/JA）の Getting Started / 一覧に導線を追加
- ルート README（EN/JA）、SECURITY、RELEASING から Guide への短いリンクを追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/docs/guide/en/version-support.md` と `ja/version-support.md` で SemVer / major のみの breaking / LTS なし / security は 4.x のみを確認する
2. Guide EN/JA README の Getting Started・一覧から `version-support` へリンクできることを確認する
3. `README.md` / `README.ja.md` の Documentation 表と Development and Release Strategy、`SECURITY.md` / `SECURITY.ja.md`、`RELEASING.md` / `RELEASING.ja.md` から Guide へ辿れることを確認する
4. SECURITY の Supported Versions（4.x のみ）と Guide 本文が矛盾していないことを確認する

## Environment (if relevant)
- Browser: N/A（ドキュメントのみ）
- OS: N/A
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)