### PR TITLE
docs(web-serial-rxjs): document bundler and framework compatibility policy

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -126,6 +126,7 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 | **[高度な使用方法](packages/web-serial-rxjs/docs/guide/ja/advanced-usage.md)** | 行フレーミング、擬似リクエスト／レスポンス、リカバリ。 |
 | **[トラブルシューティング](packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md)** | Web Serial / セッションのよくある問題と自己解決手順。 |
 | **[バージョンサポートとリリース方針](packages/web-serial-rxjs/docs/guide/ja/version-support.md)** | SemVer、非推奨、サポート範囲（LTS なし）。 |
+| **[Bundler / framework 互換性の検証方針](packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md)** | CI と Example build の区別、ESM / RxJS / 型（全 matrix なし）。 |
 | **[API の概念と設計メモ](packages/web-serial-rxjs/docs/guide/ja/concepts.md)** | オプション、`SerialSessionState`、`SerialError` の表形式補足。 |
 | **[v3 → v4 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v4.md)** | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理）。 |
 | **[v2 → v3 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v3.md)** | `state$` discriminated union、`SerialSessionStatus`、`context.cause`。 |
@@ -133,7 +134,7 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 
 ## サンプル
 
-Framework Examples は各スタックでの **`SerialSession` の配線方法**を示すデモです。**対応デバイス一覧ではありません**。通信パターン（行プロトコル、コマンド／応答、タイムアウトなど）を探す場合は [Recipes 索引](packages/web-serial-rxjs/docs/guide/ja/recipes.md) を使ってください。
+Framework Examples は各スタックでの **`SerialSession` の配線方法**を示すデモです。**対応デバイス一覧ではありません**。Example が build できることは、**全 bundler / framework の互換性保証でもありません**。通信パターン（行プロトコル、コマンド／応答、タイムアウトなど）を探す場合は [Recipes 索引](packages/web-serial-rxjs/docs/guide/ja/recipes.md) を使ってください。CI で検証している範囲と ESM / RxJS の最低要件は [Bundler / framework 互換性の検証方針](packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md) を参照してください。
 
 **まずはこちら:** [Vanilla TypeScript](apps/example-vanilla-ts/)（Recommended / まずはこちら）— UI フレームワークなしで、TypeScript と RxJS からライブラリ API を試せます。
 
@@ -194,6 +195,7 @@ English: see the same sections in [CONTRIBUTING.md](CONTRIBUTING.md).
 - 貢献の詳細: [CONTRIBUTING.ja.md](CONTRIBUTING.ja.md)
 - リリース手順: [RELEASING.ja.md](RELEASING.ja.md)
 - バージョンサポート / リリース方針（Guide）: [日本語](packages/web-serial-rxjs/docs/guide/ja/version-support.md) · [English](packages/web-serial-rxjs/docs/guide/en/version-support.md)
+- Bundler / framework 互換性の検証方針（Guide）: [日本語](packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md) · [English](packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md)
 
 ## プロジェクトアイコンについて
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Documentation is split into **Guide** (how to use; Japanese and English hand-wri
 | **[Advanced Usage](packages/web-serial-rxjs/docs/guide/en/advanced-usage.md)** | Line framing, request/response-style flows, and recovery. |
 | **[Troubleshooting](packages/web-serial-rxjs/docs/guide/en/troubleshooting.md)** | Common Web Serial / session problems and self-help checks. |
 | **[Version support and release policy](packages/web-serial-rxjs/docs/guide/en/version-support.md)** | SemVer, deprecations, support window (no LTS). |
+| **[Bundler and framework compatibility](packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md)** | CI vs Example builds; ESM / RxJS / types (no full matrix). |
 | **[API concepts and design notes](packages/web-serial-rxjs/docs/guide/en/concepts.md)** | Options, `SerialSessionState`, and `SerialError` details. |
 | **[v3 → v4 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v4.md)** | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup). |
 | **[v2 → v3 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v3.md)** | `state$` discriminated union, `SerialSessionStatus`, and `context.cause`. |
@@ -133,7 +134,7 @@ Documentation is split into **Guide** (how to use; Japanese and English hand-wri
 
 ## Examples
 
-Framework examples demonstrate **how to wire `SerialSession`** in each stack. They are **not** a supported-device catalog. For communication patterns (line protocol, command/reply, timeout, and so on), see the [Recipes index](packages/web-serial-rxjs/docs/guide/en/recipes.md) instead.
+Framework examples demonstrate **how to wire `SerialSession`** in each stack. They are **not** a supported-device catalog, and a successful Example build is **not** a full bundler / framework compatibility matrix. For communication patterns (line protocol, command/reply, timeout, and so on), see the [Recipes index](packages/web-serial-rxjs/docs/guide/en/recipes.md). For what CI verifies and the ESM / RxJS baseline, see [Bundler and framework compatibility](packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md).
 
 **Start here:** [Vanilla TypeScript](apps/example-vanilla-ts/) (Recommended / まずはこちら) — try the library API with TypeScript and RxJS, with no UI framework.
 
@@ -194,6 +195,7 @@ This project follows **trunk-based development**: `main` stays release-ready; wo
 - Contribution details: [CONTRIBUTING.md](CONTRIBUTING.md)
 - Release instructions: [RELEASING.md](RELEASING.md)
 - Version support / release policy (Guide): [English](packages/web-serial-rxjs/docs/guide/en/version-support.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/version-support.md)
+- Bundler / framework compatibility (Guide): [English](packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md)
 
 ## Project Icon
 

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -108,6 +108,8 @@ npm install rxjs
 pnpm add rxjs
 ```
 
+パッケージは **ESM のみ**です（`package.json` の `exports` 経由の `import`）。CI の検証範囲と Example build の意味、TypeScript の扱いは [Bundler / framework 互換性の検証方針](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md) を参照してください。
+
 ## 次に読むもの
 
 - **API の全体像**（機能一覧、`SerialSession` 早見表、`SerialSessionState`、最小サンプル）: [SerialSession の概要](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/overview.md)（[English](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/overview.md)）

--- a/packages/web-serial-rxjs/README.ja.md
+++ b/packages/web-serial-rxjs/README.ja.md
@@ -108,7 +108,7 @@ npm install rxjs
 pnpm add rxjs
 ```
 
-パッケージは **ESM のみ**です（`package.json` の `exports` 経由の `import`）。CI の検証範囲と Example build の意味、TypeScript の扱いは [Bundler / framework 互換性の検証方針](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md) を参照してください。
+パッケージは **ESM のみ**です（`package.json` の `exports` 経由の `import`）。
 
 ## 次に読むもの
 

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -108,7 +108,7 @@ npm install rxjs
 pnpm add rxjs
 ```
 
-The package is **ESM-only** (`import` via `package.json` `exports`). For CI coverage vs Example builds, and TypeScript typing notes, see [Bundler and framework compatibility](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md).
+The package is **ESM-only** (`import` via `package.json` `exports`).
 
 ## Where to go next
 

--- a/packages/web-serial-rxjs/README.md
+++ b/packages/web-serial-rxjs/README.md
@@ -108,6 +108,8 @@ npm install rxjs
 pnpm add rxjs
 ```
 
+The package is **ESM-only** (`import` via `package.json` `exports`). For CI coverage vs Example builds, and TypeScript typing notes, see [Bundler and framework compatibility](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md).
+
 ## Where to go next
 
 - Full **API map** (features, `SerialSession` table, `SerialSessionState`, minimal example): [SerialSession overview](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/en/overview.md) ([日本語](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/docs/guide/ja/overview.md))

--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -10,15 +10,16 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 2. **[Quick Start](./quick-start.md)** — installation, connect, receive/send, disconnect/dispose, error handling
 3. **[Browser support and support policy](./browser-support.md)** — Web Serial API availability vs official support
 4. **[Version support and release policy](./version-support.md)** — SemVer, deprecations, support window (no LTS)
-5. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
-6. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
-7. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
-8. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
-9. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
-10. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
-11. **[Binary receive API — design decision](./binary-receive-design.md)** — go / no-go for a future `receiveBytes$` (not implemented)
-12. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
-13. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
+5. **[Bundler and framework compatibility](./bundler-compatibility.md)** — CI checks vs Example builds; ESM / RxJS / types baseline (no full matrix)
+6. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
+7. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
+8. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
+9. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
+10. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
+11. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
+12. **[Binary receive API — design decision](./binary-receive-design.md)** — go / no-go for a future `receiveBytes$` (not implemented)
+13. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
+14. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
 
 When migrating existing code:
 
@@ -34,6 +35,7 @@ When migrating existing code:
 | **[Quick Start](./quick-start.md)** | Basic flow from installation through disconnect |
 | **[Browser support and support policy](./browser-support.md)** | API availability vs official support / untested |
 | **[Version support and release policy](./version-support.md)** | SemVer, deprecations, support window (no LTS) |
+| **[Bundler and framework compatibility](./bundler-compatibility.md)** | CI vs Examples; ESM / RxJS / types (no full bundler matrix) |
 | **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** | Decision guide for the three receive streams |
 | **[Communication pattern Recipes](./recipes.md)** | Pattern → Guide / Recipe index (not device compatibility) |
 | **[Advanced Usage](./advanced-usage.md)** | Application patterns and RxJS recipes |

--- a/packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md
+++ b/packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md
@@ -1,0 +1,74 @@
+# Bundler and framework compatibility
+
+This page explains what `@gurezo/web-serial-rxjs` verifies in CI, what Framework Examples demonstrate, and the **minimum import requirements** adopters should rely on. It is for **build / tooling decisions**. It does **not** publish a maintained matrix of every bundler as “supported” or “unsupported.”
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#564](https://github.com/gurezo/web-serial-rxjs/issues/564) · Related: [Browser support](./browser-support.md) · [Version support](./version-support.md)
+
+## Terminology
+
+| Term | Meaning |
+| --- | --- |
+| **Minimum package requirements** | Conditions we document for consuming the published npm package (ESM import, peer RxJS, published types) |
+| **CI verification** | What the repository’s CI workflow actually builds and checks on each PR |
+| **Example build** | An app under `apps/example-*` that builds successfully in this monorepo — a **reference wiring**, not a compatibility guarantee for every bundler or framework version |
+| **Untested tooling** | A bundler or build system we do not run in CI. **Untested is not the same as “unsupported” or “rejected by the library”** |
+
+## Minimum package requirements
+
+These are the conditions adopters should treat as the baseline:
+
+| Requirement | Policy |
+| --- | --- |
+| **Module format** | The package is **ESM-only**. `package.json` `exports` expose `import` → `dist/index.mjs` and `types` → `dist/index.d.ts`. There is no `require` / CommonJS export condition. |
+| **Import** | Use ESM `import` from `@gurezo/web-serial-rxjs` in an environment that resolves the package `exports` map. |
+| **RxJS** | **Peer dependency** `rxjs` **`^7.8.0`**. Install it in your app; it is not bundled into this package. |
+| **TypeScript** | TypeScript is **not** a peer dependency. The package ships `.d.ts` for TypeScript consumers. We do **not** pin a minimum TypeScript version as a product guarantee; use a TypeScript release that can consume the published declarations. JavaScript consumers can ignore the types. |
+
+Browser / Web Serial availability is separate — see [Browser support and support policy](./browser-support.md).
+
+## What CI verifies
+
+On pull requests to `main`, [CI](https://github.com/gurezo/web-serial-rxjs/blob/main/.github/workflows/ci.yml) typically:
+
+| Check | Meaning |
+| --- | --- |
+| **Node.js 22** + **pnpm** | Install with a frozen lockfile |
+| **`nx run-many --target=lint --all`** | Lint across workspace projects |
+| **`nx run-many --target=build --all`** | Build the library and all Example apps |
+| **`web-serial-rxjs:verify-dist`** | Post-build `dist/` artifacts and public API allowlist |
+| **`web-serial-rxjs:verify-pack`** | npm pack contents, package metadata, and consumer ESM / types smoke where configured |
+| **Tests** | Workspace test suite |
+
+CI proves that **this monorepo’s current toolchain** builds. It does **not** mean every bundler version in the ecosystem is certified.
+
+The library itself is built with **TypeScript (`tsc` for declarations) + esbuild (bundle)** inside the package scripts; that is how we produce npm artifacts, not a claim that every consumer must use esbuild.
+
+## Framework Examples and build systems
+
+Examples show **how to wire `SerialSession`** in each stack. Successful Example builds in CI are **smoke coverage for those apps**, not a promise that “Angular / React / Vue / Svelte / Vite / webpack are officially supported forever at every version.”
+
+| Example | Build system used in this repo |
+| --- | --- |
+| `example-angular` | Angular application builder (`@angular/build:application`) |
+| `example-react` | Vite via `@nx/vite:build` |
+| `example-vue` | Vite via `@nx/vite:build` |
+| `example-svelte` | Vite via `@nx/vite:build` |
+| `example-vanilla-ts` | Vite via `@nx/vite:build` |
+| `example-vanilla-js` | Vite via `@nx/vite:build` |
+
+Start with the Examples index in the repository [README – Examples](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md#examples).
+
+## What we do not maintain
+
+- A **full official compatibility matrix** for Angular build, Vite, webpack, esbuild, Rollup, and every major version thereof.
+- Statements that an untested bundler is **“not supported”** or **“incompatible.”** Absence from this page or from Examples only means **we do not claim continuous verification**.
+
+If ESM resolution and the RxJS peer requirement are met, most modern bundlers that understand `package.json` `exports` should consume the package. Report concrete import / build failures via [GitHub Issues](https://github.com/gurezo/web-serial-rxjs/issues) with bundler, versions, and a minimal reproduction.
+
+## Related
+
+- [Quick Start – Installation and peer dependency](./quick-start.md#installation)
+- [Browser support and support policy](./browser-support.md)
+- [Version support and release policy](./version-support.md)
+- Repository [README – Examples](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md#examples)
+- Package [`package.json` exports and peers](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/package.json)

--- a/packages/web-serial-rxjs/docs/guide/en/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/en/quick-start.md
@@ -33,6 +33,8 @@ npm install rxjs
 pnpm add rxjs
 ```
 
+The package is **ESM-only**. For what CI verifies, how Examples relate to compatibility, and TypeScript notes, see [Bundler and framework compatibility](./bundler-compatibility.md).
+
 For browser **API availability** vs this project's **official support** (and untested mobile), see [Browser support and support policy](./browser-support.md). The monorepo [README.md](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md) also summarizes browser support and lists example apps.
 
 ## Connect, receive, and send

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -10,15 +10,16 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 2. **[クイックスタート](./quick-start.md)** — インストール、接続、受信・送信、切断・破棄、エラーハンドリング
 3. **[ブラウザサポートと公式サポート方針](./browser-support.md)** — Web Serial API 実装状況と公式サポートの分離
 4. **[バージョンサポートとリリース方針](./version-support.md)** — SemVer、非推奨、サポート範囲（LTS なし）
-5. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
-6. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
-7. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
-8. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
-9. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
-10. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
-11. **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** — 将来の `receiveBytes$` の go / no-go（未実装）
-12. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
-13. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
+5. **[Bundler / framework 互換性の検証方針](./bundler-compatibility.md)** — CI と Example build の区別、ESM / RxJS / 型の最低要件（全 matrix なし）
+6. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
+7. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
+8. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
+9. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
+10. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
+11. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
+12. **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** — 将来の `receiveBytes$` の go / no-go（未実装）
+13. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
+14. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
 
 既存コードから移行する場合:
 
@@ -34,6 +35,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | **[クイックスタート](./quick-start.md)** | インストールから切断までの基本フロー |
 | **[ブラウザサポートと公式サポート方針](./browser-support.md)** | API 実装状況と公式サポート / 未検証の区別 |
 | **[バージョンサポートとリリース方針](./version-support.md)** | SemVer、非推奨、サポート範囲（LTS なし） |
+| **[Bundler / framework 互換性の検証方針](./bundler-compatibility.md)** | CI と Examples の区別、ESM / RxJS / 型（全 bundler matrix なし） |
 | **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** | 3 系統の受信ストリームの判断ガイド |
 | **[通信パターン別 Recipes](./recipes.md)** | パターン → Guide / Recipe 索引（デバイス互換の保証ではない） |
 | **[高度な使用方法](./advanced-usage.md)** | 応用パターンと RxJS レシピ |

--- a/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md
@@ -1,0 +1,74 @@
+# Bundler / framework 互換性の検証方針
+
+このページは、`@gurezo/web-serial-rxjs` が CI で何を検証しているか、Framework Examples が示す範囲、採用者が依拠すべき **最低限の import 条件**をまとめます。**ビルド／ツール選定**のための文書です。全 bundler を「対応」「非対応」として常時維持する matrix は**公開しません**。
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#564](https://github.com/gurezo/web-serial-rxjs/issues/564) · Related: [ブラウザサポート](./browser-support.md) · [バージョンサポート](./version-support.md)
+
+## 用語
+
+| 用語 | 意味 |
+| --- | --- |
+| **パッケージの最低要件** | 公開 npm パッケージを消費するときの文書化された条件（ESM import、peer の RxJS、公開型定義） |
+| **CI 検証** | リポジトリの CI が PR ごとに実際に build / 検査している範囲 |
+| **Example build** | `apps/example-*` 配下のアプリがこのモノレポで build できること — **配線の参考実装**であり、あらゆる bundler / framework 版への互換性保証ではない |
+| **未検証のツールチェーン** | CI で実行していない bundler / build system。**未検証は「非対応」や「ライブラリが拒否する」こととは異なる** |
+
+## パッケージの最低要件
+
+採用者が基準とすべき条件は次のとおりです。
+
+| 要件 | 方針 |
+| --- | --- |
+| **モジュール形式** | パッケージは **ESM のみ**。`package.json` の `exports` は `import` → `dist/index.mjs` と `types` → `dist/index.d.ts` を公開します。`require` / CommonJS の export 条件はありません。 |
+| **Import** | パッケージの `exports` マップを解決できる環境で、`@gurezo/web-serial-rxjs` を ESM `import` してください。 |
+| **RxJS** | **peer dependency** として `rxjs` **`^7.8.0`** が必要です。アプリ側でインストールしてください（本パッケージには同梱しません）。 |
+| **TypeScript** | TypeScript は **peer dependency ではありません**。TypeScript 利用者向けに `.d.ts` を同梱します。製品として TypeScript の最低バージョンを保証はしません。公開宣言を消費できる TypeScript を使ってください。JavaScript 利用者は型を無視できます。 |
+
+ブラウザ / Web Serial の可否は別です — [ブラウザサポートと公式サポート方針](./browser-support.md) を参照してください。
+
+## CI で検証していること
+
+`main` 向けの PR では、[CI](https://github.com/gurezo/web-serial-rxjs/blob/main/.github/workflows/ci.yml) がおおよそ次を実行します。
+
+| 検査 | 意味 |
+| --- | --- |
+| **Node.js 22** + **pnpm** | frozen lockfile でのインストール |
+| **`nx run-many --target=lint --all`** | ワークスペース全体の lint |
+| **`nx run-many --target=build --all`** | ライブラリとすべての Example アプリの build |
+| **`web-serial-rxjs:verify-dist`** | ビルド後の `dist/` と公開 API allowlist |
+| **`web-serial-rxjs:verify-pack`** | npm pack 内容、package metadata、設定済みの場合は消費者向け ESM / 型 smoke |
+| **Tests** | ワークスペースのテスト |
+
+CI が示すのは、**このモノレポの現行ツールチェーンで build できること**です。エコシステム上のすべての bundler 版を認証したという意味ではありません。
+
+ライブラリ自体の npm 成果物は、パッケージ scripts 内の **TypeScript（`tsc` で宣言）+ esbuild（bundle）** で生成します。これは配布物の作り方であり、消費者が必ず esbuild を使うという意味ではありません。
+
+## Framework Examples と build system
+
+Examples は各スタックでの **`SerialSession` の配線方法**を示します。CI で Example が build されることは、**それらのアプリに対する smoke カバレッジ**であり、「Angular / React / Vue / Svelte / Vite / webpack をあらゆる版で公式サポートし続ける」約束ではありません。
+
+| Example | このリポジトリで使っている build system |
+| --- | --- |
+| `example-angular` | Angular application builder（`@angular/build:application`） |
+| `example-react` | Vite（`@nx/vite:build`） |
+| `example-vue` | Vite（`@nx/vite:build`） |
+| `example-svelte` | Vite（`@nx/vite:build`） |
+| `example-vanilla-ts` | Vite（`@nx/vite:build`） |
+| `example-vanilla-js` | Vite（`@nx/vite:build`） |
+
+開始地点はリポジトリ [README – サンプル](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md#サンプル) を参照してください。
+
+## 公式に維持しないもの
+
+- Angular build、Vite、webpack、esbuild、Rollup およびその主要バージョンすべてに対する **常時更新の公式 compatibility matrix**
+- 未検証の bundler を **「非対応」「非互換」** と断定する表現。本ページや Examples に無いことは、**継続検証を主張しない**という意味に留めます
+
+ESM の解決と RxJS peer 要件を満たせば、`package.json` の `exports` を理解する現代的な bundler の多くで消費できる想定です。具体的な import / build 失敗は、bundler・バージョン・最小再現付きで [GitHub Issues](https://github.com/gurezo/web-serial-rxjs/issues) へ報告してください。
+
+## 関連
+
+- [クイックスタート – インストールと peer dependency](./quick-start.md#installation)
+- [ブラウザサポートと公式サポート方針](./browser-support.md)
+- [バージョンサポートとリリース方針](./version-support.md)
+- リポジトリ [README – サンプル](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md#サンプル)
+- パッケージ [`package.json` の exports と peers](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/package.json)

--- a/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md
@@ -67,7 +67,7 @@ ESM の解決と RxJS peer 要件を満たせば、`package.json` の `exports` 
 
 ## 関連
 
-- [クイックスタート – インストールと peer dependency](./quick-start.md#installation)
+- [クイックスタート – インストールと peer dependency](./quick-start.md#インストール)
 - [ブラウザサポートと公式サポート方針](./browser-support.md)
 - [バージョンサポートとリリース方針](./version-support.md)
 - リポジトリ [README – サンプル](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md#サンプル)

--- a/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/quick-start.md
@@ -33,6 +33,8 @@ npm install rxjs
 pnpm add rxjs
 ```
 
+パッケージは **ESM のみ**です。CI で検証していること、Examples と互換性の関係、TypeScript の扱いは [Bundler / framework 互換性の検証方針](./bundler-compatibility.md) を参照してください。
+
 ブラウザの **API 実装状況**と本プロジェクトの **公式サポート**（および未検証のモバイル）の区別は [ブラウザサポートと公式サポート方針](./browser-support.md) を参照してください。モノレポ [README.ja.md](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md) にもブラウザサポートの要約とサンプルアプリ索引があります。
 
 ## 接続・受信・送信


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): document bundler and framework compatibility policy

## Summary
Framework Examples の存在を互換性保証と混同しないよう、CI で検証している範囲と ESM / RxJS / 型の最低要件を Guide（EN/JA）で明文化しました。全 bundler の公式 matrix は維持しません。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #564
- Parent: #555

## What changed?
- Guide EN/JA に `bundler-compatibility.md` を追加（用語、最低要件、CI、Examples の build system、維持しない matrix）
- Guide index（EN/JA）の Getting Started / 一覧に導線を追加
- ルート README（EN/JA）、パッケージ README、quick-start から Guide への短いリンクを追加

## API / Compatibility
- [ ] Public API changes (export / function signature / behavior)
  - Details:
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md` と `ja/bundler-compatibility.md` で、ESM のみ / `rxjs ^7.8.0` / TS は peer ではない / Example ≠ 公式 matrix / 未検証 ≠ 非対応 を確認する
2. Guide EN/JA README の Getting Started・一覧から `bundler-compatibility` へリンクできることを確認する
3. `README.md` / `README.ja.md` の Documentation 表と Examples 節、パッケージ README・quick-start から Guide へ辿れることを確認する
4. CI の説明が `.github/workflows/ci.yml`（Node 22、lint/build all、verify-dist、verify-pack）と矛盾していないことを確認する

## Environment (if relevant)
- Browser: N/A（ドキュメントのみ）
- OS: N/A
- web-serial-rxjs version (for verification): N/A
- RxJS version: N/A

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [ ] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [ ] I added/updated types and kept exports consistent
- [ ] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)