### PR TITLE
docs(web-serial-rxjs): document bundle size and tree-shaking verification

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -127,6 +127,7 @@ npm の [`@gurezo/web-serial-rxjs` README](packages/web-serial-rxjs/README.ja.md
 | **[トラブルシューティング](packages/web-serial-rxjs/docs/guide/ja/troubleshooting.md)** | Web Serial / セッションのよくある問題と自己解決手順。 |
 | **[バージョンサポートとリリース方針](packages/web-serial-rxjs/docs/guide/ja/version-support.md)** | SemVer、非推奨、サポート範囲（LTS なし）。 |
 | **[Bundler / framework 互換性の検証方針](packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md)** | CI と Example build の区別、ESM / RxJS / 型（全 matrix なし）。 |
+| **[Bundle size と tree-shaking](packages/web-serial-rxjs/docs/guide/ja/bundle-size.md)** | library-only サイズのスナップショットと再現可能な測定。 |
 | **[API の概念と設計メモ](packages/web-serial-rxjs/docs/guide/ja/concepts.md)** | オプション、`SerialSessionState`、`SerialError` の表形式補足。 |
 | **[v3 → v4 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v4.md)** | Phase 1+2 の削除（`receiveReplay$`、`isBrowserSupported()`、オプション整理）。 |
 | **[v2 → v3 マイグレーション](packages/web-serial-rxjs/docs/guide/ja/migration-v3.md)** | `state$` discriminated union、`SerialSessionStatus`、`context.cause`。 |
@@ -196,6 +197,7 @@ English: see the same sections in [CONTRIBUTING.md](CONTRIBUTING.md).
 - リリース手順: [RELEASING.ja.md](RELEASING.ja.md)
 - バージョンサポート / リリース方針（Guide）: [日本語](packages/web-serial-rxjs/docs/guide/ja/version-support.md) · [English](packages/web-serial-rxjs/docs/guide/en/version-support.md)
 - Bundler / framework 互換性の検証方針（Guide）: [日本語](packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md) · [English](packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md)
+- Bundle size / tree-shaking（Guide）: [日本語](packages/web-serial-rxjs/docs/guide/ja/bundle-size.md) · [English](packages/web-serial-rxjs/docs/guide/en/bundle-size.md)
 
 ## プロジェクトアイコンについて
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Documentation is split into **Guide** (how to use; Japanese and English hand-wri
 | **[Troubleshooting](packages/web-serial-rxjs/docs/guide/en/troubleshooting.md)** | Common Web Serial / session problems and self-help checks. |
 | **[Version support and release policy](packages/web-serial-rxjs/docs/guide/en/version-support.md)** | SemVer, deprecations, support window (no LTS). |
 | **[Bundler and framework compatibility](packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md)** | CI vs Example builds; ESM / RxJS / types (no full matrix). |
+| **[Bundle size and tree-shaking](packages/web-serial-rxjs/docs/guide/en/bundle-size.md)** | Library-only size snapshot and reproducible measurement. |
 | **[API concepts and design notes](packages/web-serial-rxjs/docs/guide/en/concepts.md)** | Options, `SerialSessionState`, and `SerialError` details. |
 | **[v3 → v4 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v4.md)** | Phase 1+2 removals (`receiveReplay$`, `isBrowserSupported()`, options cleanup). |
 | **[v2 → v3 Migration Guide](packages/web-serial-rxjs/docs/guide/en/migration-v3.md)** | `state$` discriminated union, `SerialSessionStatus`, and `context.cause`. |
@@ -196,6 +197,7 @@ This project follows **trunk-based development**: `main` stays release-ready; wo
 - Release instructions: [RELEASING.md](RELEASING.md)
 - Version support / release policy (Guide): [English](packages/web-serial-rxjs/docs/guide/en/version-support.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/version-support.md)
 - Bundler / framework compatibility (Guide): [English](packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md)
+- Bundle size / tree-shaking (Guide): [English](packages/web-serial-rxjs/docs/guide/en/bundle-size.md) · [日本語](packages/web-serial-rxjs/docs/guide/ja/bundle-size.md)
 
 ## Project Icon
 

--- a/packages/web-serial-rxjs/docs/guide/en/README.md
+++ b/packages/web-serial-rxjs/docs/guide/en/README.md
@@ -11,15 +11,16 @@ The canonical documentation layout is defined in [ARCHITECTURE.md](https://githu
 3. **[Browser support and support policy](./browser-support.md)** — Web Serial API availability vs official support
 4. **[Version support and release policy](./version-support.md)** — SemVer, deprecations, support window (no LTS)
 5. **[Bundler and framework compatibility](./bundler-compatibility.md)** — CI checks vs Example builds; ESM / RxJS / types baseline (no full matrix)
-6. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
-7. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
-8. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
-9. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
-10. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
-11. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
-12. **[Binary receive API — design decision](./binary-receive-design.md)** — go / no-go for a future `receiveBytes$` (not implemented)
-13. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
-14. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
+6. **[Bundle size and tree-shaking](./bundle-size.md)** — reproducible library-only size snapshot; measurement procedure
+7. **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** — pick the receive stream by use case
+8. **[Communication pattern Recipes](./recipes.md)** — find Guide pages by serial goal (line protocol, command/reply, timeout, …)
+9. **[Advanced Usage](./advanced-usage.md)** — line framing, derived streams, recovery
+10. **[Request / Response](./request-response.md)** — wait for replies on `lines$` / `receive$`, serialize commands
+11. **[Timeout / cancel / retry](./timeout-cancel-retry.md)** — deadlines, teardown cancel, bounded retry (no core auto-retry)
+12. **[API concepts and design notes](./concepts.md)** — options tables, `SerialError`, type supplements, swappable `SerialSession` contract, [supported data (text / binary / charset)](./concepts.md#supported-data-text--binary--charset) (not a TypeDoc substitute)
+13. **[Binary receive API — design decision](./binary-receive-design.md)** — go / no-go for a future `receiveBytes$` (not implemented)
+14. **[Hardware-free testing](./testing.md)** — Fake `SerialSession`, Vitest examples, DI injection (not published on npm)
+15. **[Troubleshooting](./troubleshooting.md)** — common Web Serial / session problems and self-help checks
 
 When migrating existing code:
 
@@ -36,6 +37,7 @@ When migrating existing code:
 | **[Browser support and support policy](./browser-support.md)** | API availability vs official support / untested |
 | **[Version support and release policy](./version-support.md)** | SemVer, deprecations, support window (no LTS) |
 | **[Bundler and framework compatibility](./bundler-compatibility.md)** | CI vs Examples; ESM / RxJS / types (no full bundler matrix) |
+| **[Bundle size and tree-shaking](./bundle-size.md)** | Library-only size snapshot and reproducible measurement |
 | **[Choosing receive$ / lines$ / terminalText$](./stream-selection.md)** | Decision guide for the three receive streams |
 | **[Communication pattern Recipes](./recipes.md)** | Pattern → Guide / Recipe index (not device compatibility) |
 | **[Advanced Usage](./advanced-usage.md)** | Application patterns and RxJS recipes |

--- a/packages/web-serial-rxjs/docs/guide/en/bundle-size.md
+++ b/packages/web-serial-rxjs/docs/guide/en/bundle-size.md
@@ -1,0 +1,111 @@
+# Bundle size and tree-shaking
+
+This page records **how** we measure `@gurezo/web-serial-rxjs` size and tree-shaking, and publishes a **library-only** snapshot. It is for **adoption decisions**. Numbers are reproducible snapshots — **not** a CI size budget or a guarantee that every app bundler will match these bytes.
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#563](https://github.com/gurezo/web-serial-rxjs/issues/563) · Related: [Bundler and framework compatibility](./bundler-compatibility.md) · [Version support](./version-support.md)
+
+## Terminology
+
+| Term | Meaning |
+| --- | --- |
+| **Library-only** | Size of this package’s code with **`rxjs` external**. The RxJS **peer dependency** is **not** included in primary numbers |
+| **npm pack tarball / unpacked** | Footprint of the published package (runtime, types, README, LICENSE, icon, …) |
+| **Published artifact** | `dist/index.mjs` as shipped (unminified ESM; `rxjs` already external at build time) |
+| **Consumer fixture** | A tiny app entry that imports named exports and is bundled with esbuild for measurement |
+| **Tree-shaking** | Unused named exports from this package are omitted from the consumer bundle |
+
+## What we measure
+
+| Metric | Why |
+| --- | --- |
+| npm pack tarball + unpacked | Adopt / cache cost of the published package |
+| `dist/index.mjs` raw / minified / gzip / brotli | Runtime artifact without app code |
+| Minimal import (`isWebSerialSupported` only) | Lower bound when most of the API is unused |
+| Session import (`createSerialSession` + `isWebSerialSupported`) | Typical “use the session” surface |
+| Tree-shake probe | Confirm unused exports (for example `createTerminalBuffer`) are absent from the minimal minified bundle |
+
+### What we do not promise
+
+- A **hard size budget** enforced in CI
+- That every bundler / minify / compression setting will match these bytes
+- That **RxJS** (or framework) size is “included” — install `rxjs` separately; see [Bundler and framework compatibility](./bundler-compatibility.md)
+- Per-device or per-Example size claims
+
+## Measurement procedure
+
+Script (canonical): [`tools/bundle-size/`](https://github.com/gurezo/web-serial-rxjs/tree/main/tools/bundle-size) ([README](https://github.com/gurezo/web-serial-rxjs/blob/main/tools/bundle-size/README.md)).
+
+From the repository root:
+
+```bash
+pnpm --filter @gurezo/web-serial-rxjs build
+node tools/bundle-size/measure.mjs
+```
+
+Conditions fixed by the script:
+
+| Condition | Value |
+| --- | --- |
+| Bundler | workspace **esbuild** (version printed in the report) |
+| Consumer resolve | symlink `tools/bundle-size/.out/node_modules/@gurezo/web-serial-rxjs` → package root (`exports` + `sideEffects` apply) |
+| Peer handling | `rxjs` is **always** `external` |
+| Minify | esbuild `minify: true` where labeled minified |
+| gzip | Node `zlib` level **9** |
+| brotli | Node brotli quality **11** |
+| Output | stdout summary + `tools/bundle-size/.out/report.json` |
+
+## Results snapshot
+
+Recorded from `node tools/bundle-size/measure.mjs` after build.
+
+| Field | Value |
+| --- | --- |
+| Package | `@gurezo/web-serial-rxjs@4.0.3` |
+| Measured at (UTC) | `2026-08-08T06:06:08.377Z` |
+| Node | `v24.16.0` |
+| esbuild | `0.28.1` |
+| `package.json` `sideEffects` | `false` |
+
+### npm pack (full published package)
+
+| Metric | Bytes |
+| --- | --- |
+| Tarball | 212,301 |
+| Unpacked | 442,307 |
+| Files | 65 |
+
+Includes types, READMEs, LICENSE, icon, and `dist/` — **not** a substitute for runtime-only size.
+
+### Published runtime artifact (`dist/index.mjs`, library-only)
+
+| Form | raw | gzip | brotli |
+| --- | ---: | ---: | ---: |
+| As published (unminified) | 45,138 | 10,200 | 8,862 |
+| Minified (esbuild, measurement only) | 16,497 | 5,527 | 5,005 |
+
+The npm artifact itself is **not** minified; the minified row is for adopters comparing compressed transfer sizes.
+
+### Consumer esbuild bundles (`rxjs` external)
+
+| Fixture | Form | raw | gzip | brotli |
+| --- | --- | ---: | ---: | ---: |
+| `isWebSerialSupported` only | raw | 13,416 | 3,836 | 3,180 |
+| `isWebSerialSupported` only | minified | 3,501 | 1,244 | 1,090 |
+| `createSerialSession` + `isWebSerialSupported` | raw | 43,688 | 9,876 | 8,579 |
+| `createSerialSession` + `isWebSerialSupported` | minified | 16,206 | 5,448 | 4,942 |
+
+### Tree-shaking and `sideEffects`
+
+- The package sets **`"sideEffects": false`** so bundlers that honor the field can treat the ESM entry as free of import-time side effects.
+- The measurement script’s **tree-shaking check** asserts that the **minimal minified** consumer bundle does **not** contain unused export names such as `createTerminalBuffer`, `DEFAULT_TERMINAL_BUFFER_OPTIONS`, and `SerialErrorCode`.
+- Snapshot result: **PASS** (those symbols absent).
+
+Re-run the script after API or build changes; update this page when publishing a new baseline.
+
+## Related
+
+- Measurement tool: [`tools/bundle-size/`](https://github.com/gurezo/web-serial-rxjs/tree/main/tools/bundle-size)
+- [Bundler and framework compatibility](./bundler-compatibility.md)
+- [Version support and release policy](./version-support.md)
+- [Browser support and support policy](./browser-support.md)
+- Package [`package.json`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/package.json) (`exports`, `sideEffects`, `peerDependencies`)

--- a/packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md
+++ b/packages/web-serial-rxjs/docs/guide/en/bundler-compatibility.md
@@ -2,7 +2,7 @@
 
 This page explains what `@gurezo/web-serial-rxjs` verifies in CI, what Framework Examples demonstrate, and the **minimum import requirements** adopters should rely on. It is for **build / tooling decisions**. It does **not** publish a maintained matrix of every bundler as “supported” or “unsupported.”
 
-Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#564](https://github.com/gurezo/web-serial-rxjs/issues/564) · Related: [Browser support](./browser-support.md) · [Version support](./version-support.md)
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#564](https://github.com/gurezo/web-serial-rxjs/issues/564) · Related: [Browser support](./browser-support.md) · [Version support](./version-support.md) · [Bundle size](./bundle-size.md)
 
 ## Terminology
 
@@ -70,5 +70,6 @@ If ESM resolution and the RxJS peer requirement are met, most modern bundlers th
 - [Quick Start – Installation and peer dependency](./quick-start.md#installation)
 - [Browser support and support policy](./browser-support.md)
 - [Version support and release policy](./version-support.md)
+- [Bundle size and tree-shaking](./bundle-size.md)
 - Repository [README – Examples](https://github.com/gurezo/web-serial-rxjs/blob/main/README.md#examples)
 - Package [`package.json` exports and peers](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/package.json)

--- a/packages/web-serial-rxjs/docs/guide/ja/README.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/README.md
@@ -11,15 +11,16 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 3. **[ブラウザサポートと公式サポート方針](./browser-support.md)** — Web Serial API 実装状況と公式サポートの分離
 4. **[バージョンサポートとリリース方針](./version-support.md)** — SemVer、非推奨、サポート範囲（LTS なし）
 5. **[Bundler / framework 互換性の検証方針](./bundler-compatibility.md)** — CI と Example build の区別、ESM / RxJS / 型の最低要件（全 matrix なし）
-6. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
-7. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
-8. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
-9. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
-10. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
-11. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
-12. **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** — 将来の `receiveBytes$` の go / no-go（未実装）
-13. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
-14. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
+6. **[Bundle size と tree-shaking](./bundle-size.md)** — 再現可能な library-only サイズのスナップショットと測定手順
+7. **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** — 用途から受信ストリームを選ぶ
+8. **[通信パターン別 Recipes](./recipes.md)** — 通信目的から Guide / Recipe を探す（行プロトコル、コマンド／応答、タイムアウトなど）
+9. **[高度な使用方法](./advanced-usage.md)** — 行フレーミング、派生ストリーム、リカバリ
+10. **[Request / Response](./request-response.md)** — `lines$` / `receive$` で応答待ち、コマンドの直列化
+11. **[タイムアウト・キャンセル・再試行](./timeout-cancel-retry.md)** — 期限、破棄時キャンセル、回数制限付き再試行（コア自動再試行なし）
+12. **[API の概念と設計メモ](./concepts.md)** — オプション表、`SerialError`、型の補足、差し替え可能な `SerialSession` 契約、[対応範囲（テキスト / バイナリ / 文字コード）](./concepts.md#対応範囲テキスト--バイナリ--文字コード)（TypeDoc の代替ではありません）
+13. **[バイナリ受信 API — 設計判断](./binary-receive-design.md)** — 将来の `receiveBytes$` の go / no-go（未実装）
+14. **[実機なしテスト](./testing.md)** — Fake `SerialSession`、Vitest 例、DI 注入（npm 非同梱）
+15. **[トラブルシューティング](./troubleshooting.md)** — Web Serial / セッションのよくある問題と自己解決手順
 
 既存コードから移行する場合:
 
@@ -36,6 +37,7 @@ canonical なドキュメント構成は [ARCHITECTURE.ja.md](https://github.com
 | **[ブラウザサポートと公式サポート方針](./browser-support.md)** | API 実装状況と公式サポート / 未検証の区別 |
 | **[バージョンサポートとリリース方針](./version-support.md)** | SemVer、非推奨、サポート範囲（LTS なし） |
 | **[Bundler / framework 互換性の検証方針](./bundler-compatibility.md)** | CI と Examples の区別、ESM / RxJS / 型（全 bundler matrix なし） |
+| **[Bundle size と tree-shaking](./bundle-size.md)** | library-only サイズのスナップショットと再現可能な測定 |
 | **[receive$ / lines$ / terminalText$ の選び方](./stream-selection.md)** | 3 系統の受信ストリームの判断ガイド |
 | **[通信パターン別 Recipes](./recipes.md)** | パターン → Guide / Recipe 索引（デバイス互換の保証ではない） |
 | **[高度な使用方法](./advanced-usage.md)** | 応用パターンと RxJS レシピ |

--- a/packages/web-serial-rxjs/docs/guide/ja/bundle-size.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/bundle-size.md
@@ -1,0 +1,111 @@
+# Bundle size と tree-shaking
+
+このページは、`@gurezo/web-serial-rxjs` のサイズと tree-shaking を**どう測るか**、および **library-only** のスナップショット結果をまとめます。**採用判断**のための文書です。数値は再現可能なスナップショットであり、CI のサイズ上限や、あらゆるアプリ bundler が同じバイト数になることの保証ではありません。
+
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#563](https://github.com/gurezo/web-serial-rxjs/issues/563) · Related: [Bundler / framework 互換性](./bundler-compatibility.md) · [バージョンサポート](./version-support.md)
+
+## 用語
+
+| 用語 | 意味 |
+| --- | --- |
+| **Library-only** | **`rxjs` を external** にした本パッケージ本体のサイズ。RxJS **peer dependency** は一次指標に**含めない** |
+| **npm pack tarball / unpacked** | 公開パッケージ全体のフットプリント（runtime、型、README、LICENSE、icon など） |
+| **公開成果物** | 配布される `dist/index.mjs`（minify されていない ESM。ビルド時点で `rxjs` は external） |
+| **Consumer fixture** | named export を import する小さなエントリを esbuild で束ねた測定用アプリ |
+| **Tree-shaking** | 未使用の named export が consumer bundle から除外されること |
+
+## 何を測るか
+
+| 指標 | 目的 |
+| --- | --- |
+| npm pack tarball + unpacked | 公開パッケージの取得・展開コスト |
+| `dist/index.mjs` の raw / minified / gzip / brotli | アプリコードを含まない runtime 成果物 |
+| 最小 import（`isWebSerialSupported` のみ） | API の大部分を使わない場合の下限 |
+| Session import（`createSerialSession` + `isWebSerialSupported`） | セッション利用時の代表的な面 |
+| Tree-shake プローブ | 未使用 export（例: `createTerminalBuffer`）が最小 minified bundle に含まれないこと |
+
+### 約束しないこと
+
+- CI で強制する **ハードなサイズ上限**
+- あらゆる bundler / minify / 圧縮設定でこのバイト数と一致すること
+- **RxJS**（や framework）のサイズを「込み」として扱うこと — `rxjs` は別途インストール。詳細は [Bundler / framework 互換性](./bundler-compatibility.md)
+- デバイス別・Example 別のサイズ主張
+
+## 測定手順
+
+正規のスクリプト: [`tools/bundle-size/`](https://github.com/gurezo/web-serial-rxjs/tree/main/tools/bundle-size)（[README](https://github.com/gurezo/web-serial-rxjs/blob/main/tools/bundle-size/README.md)）。
+
+リポジトリルートで:
+
+```bash
+pnpm --filter @gurezo/web-serial-rxjs build
+node tools/bundle-size/measure.mjs
+```
+
+スクリプトが固定する条件:
+
+| 条件 | 値 |
+| --- | --- |
+| Bundler | ワークスペースの **esbuild**（レポートに版を出力） |
+| Consumer 解決 | `tools/bundle-size/.out/node_modules/@gurezo/web-serial-rxjs` → パッケージルートの symlink（`exports` と `sideEffects` が適用される） |
+| Peer の扱い | `rxjs` は**常に** `external` |
+| Minify | minified と書いた行は esbuild `minify: true` |
+| gzip | Node `zlib` level **9** |
+| brotli | Node brotli quality **11** |
+| 出力 | stdout の要約 + `tools/bundle-size/.out/report.json` |
+
+## 結果スナップショット
+
+ビルド後に `node tools/bundle-size/measure.mjs` を実行して記録したものです。
+
+| 項目 | 値 |
+| --- | --- |
+| Package | `@gurezo/web-serial-rxjs@4.0.3` |
+| 測定時刻 (UTC) | `2026-08-08T06:06:08.377Z` |
+| Node | `v24.16.0` |
+| esbuild | `0.28.1` |
+| `package.json` の `sideEffects` | `false` |
+
+### npm pack（公開パッケージ全体）
+
+| 指標 | Bytes |
+| --- | --- |
+| Tarball | 212,301 |
+| Unpacked | 442,307 |
+| Files | 65 |
+
+型・README・LICENSE・icon・`dist/` を含みます。runtime のみのサイズの代替ではありません。
+
+### 公開 runtime 成果物（`dist/index.mjs`、library-only）
+
+| 形態 | raw | gzip | brotli |
+| --- | ---: | ---: | ---: |
+| 公開どおり（unminified） | 45,138 | 10,200 | 8,862 |
+| Minified（esbuild、測定用） | 16,497 | 5,527 | 5,005 |
+
+npm 成果物自体は **minify されていません**。minified 行は転送サイズ比較用です。
+
+### Consumer esbuild bundles（`rxjs` external）
+
+| Fixture | 形態 | raw | gzip | brotli |
+| --- | --- | ---: | ---: | ---: |
+| `isWebSerialSupported` のみ | raw | 13,416 | 3,836 | 3,180 |
+| `isWebSerialSupported` のみ | minified | 3,501 | 1,244 | 1,090 |
+| `createSerialSession` + `isWebSerialSupported` | raw | 43,688 | 9,876 | 8,579 |
+| `createSerialSession` + `isWebSerialSupported` | minified | 16,206 | 5,448 | 4,942 |
+
+### Tree-shaking と `sideEffects`
+
+- パッケージは **`"sideEffects": false`** を設定し、フィールドを尊重する bundler が import 時 side effect なしとして扱えるようにしています。
+- 測定スクリプトの **tree-shaking 検査**は、**最小 minified** consumer bundle に `createTerminalBuffer`、`DEFAULT_TERMINAL_BUFFER_OPTIONS`、`SerialErrorCode` などの未使用 export 名が含まれないことを確認します。
+- スナップショット結果: **PASS**（当該シンボルなし）。
+
+API やビルドが変わったらスクリプトを再実行し、ベースライン更新時に本ページを更新してください。
+
+## Related
+
+- 測定ツール: [`tools/bundle-size/`](https://github.com/gurezo/web-serial-rxjs/tree/main/tools/bundle-size)
+- [Bundler / framework 互換性の検証方針](./bundler-compatibility.md)
+- [バージョンサポートとリリース方針](./version-support.md)
+- [ブラウザサポートと公式サポート方針](./browser-support.md)
+- パッケージ [`package.json`](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/package.json)（`exports`、`sideEffects`、`peerDependencies`）

--- a/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md
+++ b/packages/web-serial-rxjs/docs/guide/ja/bundler-compatibility.md
@@ -2,7 +2,7 @@
 
 このページは、`@gurezo/web-serial-rxjs` が CI で何を検証しているか、Framework Examples が示す範囲、採用者が依拠すべき **最低限の import 条件**をまとめます。**ビルド／ツール選定**のための文書です。全 bundler を「対応」「非対応」として常時維持する matrix は**公開しません**。
 
-Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#564](https://github.com/gurezo/web-serial-rxjs/issues/564) · Related: [ブラウザサポート](./browser-support.md) · [バージョンサポート](./version-support.md)
+Parent: [#555](https://github.com/gurezo/web-serial-rxjs/issues/555) · Issue: [#564](https://github.com/gurezo/web-serial-rxjs/issues/564) · Related: [ブラウザサポート](./browser-support.md) · [バージョンサポート](./version-support.md) · [Bundle size](./bundle-size.md)
 
 ## 用語
 
@@ -70,5 +70,6 @@ ESM の解決と RxJS peer 要件を満たせば、`package.json` の `exports` 
 - [クイックスタート – インストールと peer dependency](./quick-start.md#インストール)
 - [ブラウザサポートと公式サポート方針](./browser-support.md)
 - [バージョンサポートとリリース方針](./version-support.md)
+- [Bundle size と tree-shaking](./bundle-size.md)
 - リポジトリ [README – サンプル](https://github.com/gurezo/web-serial-rxjs/blob/main/README.ja.md#サンプル)
 - パッケージ [`package.json` の exports と peers](https://github.com/gurezo/web-serial-rxjs/blob/main/packages/web-serial-rxjs/package.json)

--- a/packages/web-serial-rxjs/package.json
+++ b/packages/web-serial-rxjs/package.json
@@ -31,6 +31,7 @@
     "clean": "rm -rf dist",
     "prepublishOnly": "pnpm run build"
   },
+  "sideEffects": false,
   "dependencies": {},
   "peerDependencies": {
     "rxjs": "^7.8.0"

--- a/tools/bundle-size/.gitignore
+++ b/tools/bundle-size/.gitignore
@@ -1,0 +1,2 @@
+# Generated measurement artifacts — do not commit.
+.out/

--- a/tools/bundle-size/README.md
+++ b/tools/bundle-size/README.md
@@ -1,0 +1,46 @@
+# Bundle size measurement (`tools/bundle-size`)
+
+Reproducible snapshots for `@gurezo/web-serial-rxjs` library-only size and tree-shaking (Issue [#563](https://github.com/gurezo/web-serial-rxjs/issues/563)).
+
+This tool is **not** part of the pnpm workspace and does **not** fail CI on size budgets. Guide pages under `packages/web-serial-rxjs/docs/guide/` publish the narrative and latest recorded numbers.
+
+## Prerequisites
+
+From the repository root:
+
+```bash
+pnpm --filter @gurezo/web-serial-rxjs build
+```
+
+Requires Node.js (CI uses Node 22+; local measurement should note the version printed by the script) and the workspace `esbuild` dependency.
+
+## Run
+
+```bash
+node tools/bundle-size/measure.mjs
+```
+
+Output:
+
+- Human-readable summary on stdout
+- Machine-readable `tools/bundle-size/.out/report.json`
+- Intermediate consumer bundles under `tools/bundle-size/.out/` (gitignored)
+
+## What is measured
+
+| Metric | Meaning |
+| --- | --- |
+| npm pack tarball / unpacked | Published package footprint (types, README, LICENSE, icon, `dist/`, …) |
+| `dist/index.mjs` raw / minified / gzip / brotli | Published ESM runtime artifact only |
+| Consumer fixture A | `isWebSerialSupported` only (tree-shake probe) |
+| Consumer fixture B | `createSerialSession` + `isWebSerialSupported` |
+
+Fixtures import `@gurezo/web-serial-rxjs` through a symlink at `tools/bundle-size/.out/node_modules/@gurezo/web-serial-rxjs` so `package.json` `exports` and `sideEffects` are honored.
+
+**Library-only:** `rxjs` is always `external`. Peer dependency bytes are **not** included in primary numbers.
+
+**Compression:** gzip level 9; brotli quality 11.
+
+## Tree-shaking check
+
+The minified minimal fixture must not contain unused export names such as `createTerminalBuffer`. A non-zero exit code means the check failed.

--- a/tools/bundle-size/measure.mjs
+++ b/tools/bundle-size/measure.mjs
@@ -1,0 +1,358 @@
+/**
+ * Measure library-only bundle size and tree-shaking for @gurezo/web-serial-rxjs.
+ *
+ * Prerequisites:
+ *   pnpm --filter @gurezo/web-serial-rxjs build
+ *
+ * Usage (from repo root):
+ *   node tools/bundle-size/measure.mjs
+ *
+ * Notes:
+ * - Primary numbers are library-only (rxjs is external / not bundled).
+ * - Does not enforce size budgets; prints reproducible snapshots for docs.
+ */
+
+import {
+  brotliCompressSync,
+  constants as zlibConstants,
+  gzipSync,
+} from 'node:zlib';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = join(__dirname, '../..');
+const packageRoot = join(repoRoot, 'packages/web-serial-rxjs');
+const distEntry = join(packageRoot, 'dist/index.mjs');
+const packageJsonPath = join(packageRoot, 'package.json');
+const outDir = join(__dirname, '.out');
+
+// Resolve workspace esbuild (this tool is outside the pnpm workspace).
+const require = createRequire(join(repoRoot, 'package.json'));
+const { build } = require('esbuild');
+const esbuildPkg = require('esbuild/package.json');
+
+function formatBytes(bytes) {
+  return `${bytes.toLocaleString('en-US')} B`;
+}
+
+function compressedSizes(buffer) {
+  const gzip = gzipSync(buffer, { level: 9 });
+  const brotli = brotliCompressSync(buffer, {
+    params: {
+      [zlibConstants.BROTLI_PARAM_QUALITY]: 11,
+    },
+  });
+  return {
+    gzipBytes: gzip.byteLength,
+    brotliBytes: brotli.byteLength,
+  };
+}
+
+function directoryByteSize(dir) {
+  let total = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      total += directoryByteSize(full);
+    } else if (entry.isFile()) {
+      total += statSync(full).size;
+    }
+  }
+  return total;
+}
+
+function measureNpmPackUnpacked() {
+  const staging = mkdtempSync(join(tmpdir(), 'web-serial-rxjs-pack-'));
+  try {
+    const packJson = execFileSync('npm', ['pack', '--json', '--silent'], {
+      cwd: packageRoot,
+      encoding: 'utf8',
+    });
+    const parsed = JSON.parse(packJson);
+    const entry = Array.isArray(parsed) ? parsed[0] : parsed;
+    const tarballName = entry.filename;
+    const tarballPath = join(packageRoot, tarballName);
+    if (!existsSync(tarballPath)) {
+      throw new Error(`npm pack did not produce ${tarballPath}`);
+    }
+
+    const packedCopy = join(staging, tarballName);
+    copyFileSync(tarballPath, packedCopy);
+    rmSync(tarballPath, { force: true });
+
+    execFileSync('tar', ['-xzf', packedCopy, '-C', staging], {
+      stdio: 'pipe',
+    });
+    const unpackedRoot = join(staging, 'package');
+    if (!existsSync(unpackedRoot)) {
+      throw new Error('npm pack tarball missing package/ directory');
+    }
+
+    return {
+      tarballBytes: entry.size,
+      unpackedBytes: directoryByteSize(unpackedRoot),
+      fileCount: entry.entryCount ?? null,
+    };
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+async function buildConsumerFixture({
+  name,
+  source,
+  minify,
+  absWorkingDir,
+}) {
+  mkdirSync(outDir, { recursive: true });
+  const entryPath = join(outDir, `${name}.entry.mjs`);
+  const outfile = join(outDir, `${name}${minify ? '.min' : ''}.mjs`);
+  writeFileSync(entryPath, source, 'utf8');
+
+  await build({
+    absWorkingDir,
+    entryPoints: [entryPath],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: ['es2020'],
+    outfile,
+    minify,
+    // Keep library size separate from the RxJS peer dependency.
+    external: ['rxjs'],
+    write: true,
+    logLevel: 'silent',
+  });
+
+  const buffer = readFileSync(outfile);
+  const { gzipBytes, brotliBytes } = compressedSizes(buffer);
+  return {
+    name,
+    minify,
+    outfile: relative(repoRoot, outfile),
+    bytes: buffer.byteLength,
+    gzipBytes,
+    brotliBytes,
+    text: buffer.toString('utf8'),
+  };
+}
+
+function ensureConsumerNodeModules() {
+  const nmScoped = join(outDir, 'node_modules/@gurezo');
+  const linkPath = join(nmScoped, 'web-serial-rxjs');
+  mkdirSync(nmScoped, { recursive: true });
+  rmSync(linkPath, { recursive: true, force: true });
+  // Symlink the package root so package.json (sideEffects, exports) is honored.
+  execFileSync('ln', ['-s', packageRoot, linkPath]);
+  return outDir;
+}
+
+function assertTreeShaken(minifiedText) {
+  const forbidden = [
+    'createTerminalBuffer',
+    'DEFAULT_TERMINAL_BUFFER_OPTIONS',
+    'SerialErrorCode',
+  ];
+  const present = forbidden.filter((symbol) => minifiedText.includes(symbol));
+  return {
+    ok: present.length === 0,
+    present,
+    checked: forbidden,
+  };
+}
+
+function printRow(label, sizes) {
+  console.log(
+    `  ${label.padEnd(28)} raw=${formatBytes(sizes.bytes).padStart(12)}  gzip=${formatBytes(sizes.gzipBytes).padStart(12)}  brotli=${formatBytes(sizes.brotliBytes).padStart(12)}`,
+  );
+}
+
+async function main() {
+  if (!existsSync(distEntry)) {
+    throw new Error(
+      `Missing ${relative(repoRoot, distEntry)}. Run: pnpm --filter @gurezo/web-serial-rxjs build`,
+    );
+  }
+
+  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  const sideEffects =
+    Object.prototype.hasOwnProperty.call(pkg, 'sideEffects')
+      ? pkg.sideEffects
+      : '(unset)';
+
+  const consumerRoot = ensureConsumerNodeModules();
+
+  // Import via package name so package.json exports + sideEffects apply.
+  const fixtureMinimal = `
+import { isWebSerialSupported } from '@gurezo/web-serial-rxjs';
+export const supported = isWebSerialSupported();
+`;
+
+  const fixtureSession = `
+import { createSerialSession, isWebSerialSupported } from '@gurezo/web-serial-rxjs';
+export const supported = isWebSerialSupported();
+export const session = createSerialSession();
+`;
+
+  const distBuffer = readFileSync(distEntry);
+  const distSizes = {
+    bytes: distBuffer.byteLength,
+    ...compressedSizes(distBuffer),
+  };
+
+  const pack = measureNpmPackUnpacked();
+
+  const minimal = await buildConsumerFixture({
+    name: 'minimal-isWebSerialSupported',
+    source: fixtureMinimal,
+    minify: false,
+    absWorkingDir: consumerRoot,
+  });
+  const minimalMin = await buildConsumerFixture({
+    name: 'minimal-isWebSerialSupported',
+    source: fixtureMinimal,
+    minify: true,
+    absWorkingDir: consumerRoot,
+  });
+  const session = await buildConsumerFixture({
+    name: 'createSerialSession',
+    source: fixtureSession,
+    minify: false,
+    absWorkingDir: consumerRoot,
+  });
+  const sessionMin = await buildConsumerFixture({
+    name: 'createSerialSession',
+    source: fixtureSession,
+    minify: true,
+    absWorkingDir: consumerRoot,
+  });
+
+  const treeShake = assertTreeShaken(minimalMin.text);
+
+  // Also minify the published artifact alone (still library-only; no app code).
+  const publishedMinPath = join(outDir, 'published-index.min.mjs');
+  await build({
+    entryPoints: [distEntry],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: ['es2020'],
+    outfile: publishedMinPath,
+    minify: true,
+    external: ['rxjs'],
+    write: true,
+    logLevel: 'silent',
+  });
+  const publishedMinBuffer = readFileSync(publishedMinPath);
+  const publishedMinSizes = {
+    bytes: publishedMinBuffer.byteLength,
+    ...compressedSizes(publishedMinBuffer),
+  };
+
+  const report = {
+    measuredAt: new Date().toISOString(),
+    packageName: pkg.name,
+    packageVersion: pkg.version,
+    node: process.version,
+    esbuild: esbuildPkg.version,
+    sideEffects,
+    notes: [
+      'All sizes are library-only; rxjs peer dependency is external and not included.',
+      'Consumer fixtures import @gurezo/web-serial-rxjs via a symlink under tools/bundle-size/.out/node_modules so package.json exports and sideEffects apply.',
+      'gzip uses zlib level 9; brotli uses quality 11.',
+    ],
+    npmPack: {
+      tarballBytes: pack.tarballBytes,
+      unpackedBytes: pack.unpackedBytes,
+      fileCount: pack.fileCount,
+    },
+    publishedArtifact: {
+      path: relative(repoRoot, distEntry),
+      raw: distSizes,
+      minified: publishedMinSizes,
+    },
+    consumerBundles: {
+      minimalIsWebSerialSupported: {
+        raw: {
+          bytes: minimal.bytes,
+          gzipBytes: minimal.gzipBytes,
+          brotliBytes: minimal.brotliBytes,
+        },
+        minified: {
+          bytes: minimalMin.bytes,
+          gzipBytes: minimalMin.gzipBytes,
+          brotliBytes: minimalMin.brotliBytes,
+        },
+      },
+      createSerialSession: {
+        raw: {
+          bytes: session.bytes,
+          gzipBytes: session.gzipBytes,
+          brotliBytes: session.brotliBytes,
+        },
+        minified: {
+          bytes: sessionMin.bytes,
+          gzipBytes: sessionMin.gzipBytes,
+          brotliBytes: sessionMin.brotliBytes,
+        },
+      },
+    },
+    treeShaking: treeShake,
+  };
+
+  mkdirSync(outDir, { recursive: true });
+  const reportPath = join(outDir, 'report.json');
+  writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+
+  console.log(`Bundle size report for ${pkg.name}@${pkg.version}`);
+  console.log(`  measuredAt: ${report.measuredAt}`);
+  console.log(`  node: ${report.node}  esbuild: ${report.esbuild}`);
+  console.log(`  sideEffects: ${JSON.stringify(sideEffects)}`);
+  console.log('');
+  console.log('npm pack (includes types, README, LICENSE, icon, etc.):');
+  console.log(
+    `  tarball=${formatBytes(pack.tarballBytes)}  unpacked=${formatBytes(pack.unpackedBytes)}${pack.fileCount != null ? `  files=${pack.fileCount}` : ''}`,
+  );
+  console.log('');
+  console.log('Published runtime artifact (dist/index.mjs, library-only):');
+  printRow('raw', distSizes);
+  printRow('minified (esbuild)', publishedMinSizes);
+  console.log('');
+  console.log('Consumer esbuild bundles (rxjs external):');
+  printRow('minimal raw', minimal);
+  printRow('minimal minified', minimalMin);
+  printRow('createSerialSession raw', session);
+  printRow('createSerialSession min', sessionMin);
+  console.log('');
+  console.log('Tree-shaking check (minimal minified must omit unused exports):');
+  console.log(
+    `  ${treeShake.ok ? 'PASS' : 'FAIL'}  checked=[${treeShake.checked.join(', ')}]  present=[${treeShake.present.join(', ') || '(none)'}]`,
+  );
+  console.log('');
+  console.log(`Wrote ${relative(repoRoot, reportPath)}`);
+
+  if (!treeShake.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## PR Title (Conventional Commits)
docs(web-serial-rxjs): document bundle size and tree-shaking verification

## Summary
`@gurezo/web-serial-rxjs` の bundle size / tree-shaking を再現可能な手順で測定し、結果を Guide（EN/JA）へ公開しました。採用判断で本体サイズと RxJS peer を混同しないよう、library-only を一次指標にしています。あわせて `sideEffects: false` を設定しました。

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore (build/test/ci)
- [ ] Breaking change

## Related issues
- Fixes #563
- Parent: #555

## What changed?
- `tools/bundle-size/` に測定スクリプト（npm pack / raw / minified / gzip / brotli / tree-shake 検査）を追加
- `package.json` に `"sideEffects": false` を追加
- Guide EN/JA に `bundle-size.md` を追加（測定条件・結果スナップショット・tree-shaking 所見）
- Guide index / bundler-compatibility / ルート README から導線を追加

## API / Compatibility
- [x] Public API changes (export / function signature / behavior)
  - Details: 公開 API のシグネチャ変更なし。`package.json` に `"sideEffects": false` を追加（tree-shaking 向けのパッケージメタデータ。後方互換）
- [x] This change is backward compatible
- [ ] This change introduces a breaking change
  - Migration notes:

## How to test
1. `pnpm --filter @gurezo/web-serial-rxjs build`
2. `node tools/bundle-size/measure.mjs` を実行し、stdout / `tools/bundle-size/.out/report.json` で数値と tree-shaking PASS を確認する
3. Guide の [EN](packages/web-serial-rxjs/docs/guide/en/bundle-size.md) / [JA](packages/web-serial-rxjs/docs/guide/ja/bundle-size.md) と README の Documentation 表から辿れることを確認する

## Environment (if relevant)
- Browser: N/A（ドキュメント / パッケージメタデータ / 測定ツール）
- OS: macOS
- web-serial-rxjs version (for verification): 4.0.3
- RxJS version: peer `^7.8.0`（測定では external）

## Checklist
- [x] PR title follows Conventional Commits (`<type>(<scope>): <summary>`)
- [x] Commit messages follow Conventional Commits (commitlint passes)
- [x] I ran tests locally (if available)
- [ ] I verified behavior on a Chromium-based browser (Web Serial API)
- [x] I updated docs/README if needed
- [x] I added/updated types and kept exports consistent
- [x] I considered error handling (disconnect, permission denied, timeouts, etc.)


Made with [Cursor](https://cursor.com)